### PR TITLE
cluster_staypoints: add support for big data

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,8 +54,8 @@ autodoc_mock_imports = [
 # -- Project information -----------------------------------------------------
 
 project = 'trackintel'
-copyright = '2019, Dominik Bucher, Henry Martin'
-author = 'Dominik Bucher, Henry Martin'
+copyright = '2019, Dominik Bucher, Henry Martin, Ye Hong'
+author = 'Dominik Bucher, Henry Martin, Ye Hong'
 
 # This always leads to errors. Simply update the version by hand here.
 
@@ -192,7 +192,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'trackintel.tex', 'trackintel Documentation',
-     'Dominik Bucher, Henry Martin', 'manual'),
+     'Dominik Bucher, Henry Martin, Ye Hong', 'manual'),
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ NAME = 'trackintel'
 DESCRIPTION = 'Human mobility and movement analysis framework.'
 URL = 'https://github.com/mie-lab/trackintel'
 EMAIL = 'dobucher@ethz.ch, martinhe@ethz.ch'
-AUTHOR = 'Dominik Bucher, Henry Martin'
+AUTHOR = 'Dominik Bucher, Henry Martin, Ye Hong'
 REQUIRES_PYTHON = '>=3.6.0'
 VERSION = None
 LICENSE = 'MIT'

--- a/tests/preprocessing/test_preprocessing.py
+++ b/tests/preprocessing/test_preprocessing.py
@@ -109,4 +109,23 @@ class TestPreprocessing():
         labels = db.fit_predict(sp_distance_matrix)
         
         assert len(set(locs['location_id'])) == len(set(labels)) , "The #location should be the same"
+    
+    def test_cluster_staypoints_dbscan_hav_euc(self):
+        spts = ti.read_staypoints_csv(os.path.join('tests', 'data', 'geolife', 'geolife_staypoints.csv'))
         
+        # haversine calculation 
+        _, loc_har = spts.as_staypoints.extract_locations(method='dbscan', epsilon=100, 
+                                                          num_samples=0, distance_matrix_metric='haversine',
+                                                          agg_level='dataset')
+        # WGS_1984
+        spts.crs = 'epsg:4326'
+        # WGS_1984_UTM_Zone_49N 
+        spts = spts.to_crs("epsg:32649")
+        
+        # euclidean calculation 
+        _, loc_eu = spts.as_staypoints.extract_locations(method='dbscan', epsilon=100, 
+                                                         num_samples=0, distance_matrix_metric='euclidean',
+                                                         agg_level='dataset')
+        
+        assert len(loc_har) == len(loc_eu) , "The #location should be the same for haversine" + \
+            "and euclidean distances"

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -59,6 +59,9 @@ def cluster_staypoints(staypoints,
     if method=='dbscan':
 
         if distance_matrix_metric == 'haversine':
+            # The input and output of sklearn's harvarsine metrix are both in radians,
+            # see https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.haversine_distances.html
+            # here the 'epsilon' is directly applied to the metric's output.
             epsilon = epsilon / 6371000 # convert to radius
         db = DBSCAN(eps=epsilon, min_samples=num_samples, algorithm='ball_tree', metric=distance_matrix_metric)
             
@@ -84,6 +87,7 @@ def cluster_staypoints(staypoints,
                 ret_sp.loc[user_staypoints.index, 'location_id'] = labels
         else:
             if distance_matrix_metric == 'haversine':
+                # the input is converted to list of (lat, lon) tuples in radians unit
                 p = np.array([[radians(g.y), radians(g.x)] for g in ret_sp.geometry])
             else:
                 p = np.array([[g.x, g.y] for g in ret_sp.geometry])

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -72,6 +72,7 @@ def cluster_staypoints(staypoints,
                 user_staypoints = ret_sp[ret_sp["user_id"] == user_id_this]  
                 
                 if distance_matrix_metric == 'haversine':
+                    # the input is converted to list of (lat, lon) tuples in radians unit
                     p = np.array([[radians(g.y), radians(g.x)] for g in user_staypoints.geometry])
                 else:
                     p = np.array([[g.x, g.y] for g in user_staypoints.geometry])

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 from shapely.geometry import Point, MultiPoint
 from sklearn.cluster import DBSCAN
+from math import radians
 
 from trackintel.geogr.distances import calculate_distance_matrix, meters_to_decimal_degrees
 
@@ -12,7 +13,7 @@ def cluster_staypoints(staypoints,
                        method='dbscan',
                        epsilon=100, 
                        num_samples=1, 
-                       distance_matrix_metric=None,
+                       distance_matrix_metric='euclidean',
                        agg_level='user'):
     """Clusters staypoints to get locations.
 
@@ -31,12 +32,10 @@ def cluster_staypoints(staypoints,
     num_samples : int, default 1
         The minimal number of samples in a cluster. 
 
-    distance_matrix_metric: str (optional)
-        When given, dbscan will work on a precomputed a distance matrix that is
-        created using the staypoints based on the given metric. Possible metrics
+    distance_matrix_metric: str, default 'euclidean'
+        The distance matrix used by the applied method. Possible metrics
         are: {'haversine', 'euclidean'} or any mentioned in: 
-        https://scikit-learn.org/stable/modules/generated/
-        sklearn.metrics.pairwise_distances.html
+        https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html
         
     agg_level: str, {'user' or 'dataset'}, default 'user'
         The level of aggregation when generating locations:
@@ -59,10 +58,9 @@ def cluster_staypoints(staypoints,
     ret_sp = staypoints.copy()
     if method=='dbscan':
 
-        if distance_matrix_metric is not None:
-            db = DBSCAN(eps=epsilon, min_samples=num_samples, metric='precomputed')
-        else:    
-            db = DBSCAN(eps=epsilon, min_samples=num_samples)
+        if distance_matrix_metric == 'haversine':
+            epsilon = epsilon / 6371000 # convert to radius
+        db = DBSCAN(eps=epsilon, min_samples=num_samples, algorithm='ball_tree', metric=distance_matrix_metric)
             
         if agg_level == 'user':
             location_id_counter = 0
@@ -70,13 +68,11 @@ def cluster_staypoints(staypoints,
                 # Slice staypoints array by user. This is not a copy!
                 user_staypoints = ret_sp[ret_sp["user_id"] == user_id_this]  
                 
-                if distance_matrix_metric is not None:
-                    sp_distance_matrix = calculate_distance_matrix(user_staypoints, 
-                                                                   dist_metric=distance_matrix_metric)
-                    labels = db.fit_predict(sp_distance_matrix)
+                if distance_matrix_metric == 'haversine':
+                    p = np.array([[radians(g.y), radians(g.x)] for g in user_staypoints.geometry])
                 else:
-                    coordinates = np.array([[g.x, g.y] for g in user_staypoints.geometry])
-                    labels = db.fit_predict(coordinates)
+                    p = np.array([[g.x, g.y] for g in user_staypoints.geometry])
+                labels = db.fit_predict(p)
                     
                 # enforce unique lables across all users without changing noise labels
                 max_label = np.max(labels)
@@ -87,13 +83,11 @@ def cluster_staypoints(staypoints,
                 # add staypoint - location matching to original staypoints
                 ret_sp.loc[user_staypoints.index, 'location_id'] = labels
         else:
-            if distance_matrix_metric is not None:
-                sp_distance_matrix = calculate_distance_matrix(ret_sp, 
-                                                               dist_metric=distance_matrix_metric)
-                labels = db.fit_predict(sp_distance_matrix)
+            if distance_matrix_metric == 'haversine':
+                p = np.array([[radians(g.y), radians(g.x)] for g in ret_sp.geometry])
             else:
-                coordinates = np.array([[g.x, g.y] for g in ret_sp.geometry])
-                labels = db.fit_predict(coordinates)
+                p = np.array([[g.x, g.y] for g in ret_sp.geometry])
+            labels = db.fit_predict(p)
             
             # add 1 to match the 'user' level result
             ret_sp['location_id'] = labels + 1


### PR DESCRIPTION
- change the `cluster_staypoints `function: the DBSCAN now directly accepts the distance metric and does not use a pre-calculated pairwise distance matrix.
- add test for haversine distance DBSCAN
- update author information