### PR TITLE
fix bugs in cluster_staypoints function

### DIFF
--- a/tests/preprocessing/test_preprocessing.py
+++ b/tests/preprocessing/test_preprocessing.py
@@ -101,8 +101,19 @@ class TestPreprocessing():
         other_locs = gpd.GeoDataFrame(other_locs, geometry='center', crs=spts.crs)
         
         assert all(other_locs['center'] == locs['center']), "The location geometry should be the same"
-        assert all(other_locs['location_id'] == locs['location_id']), "The location id should be the same" + \
-            "and start from one"
+        assert all(other_locs['location_id'] == locs['location_id']), "The location id should be the same"
+        
+    def test_cluster_staypoints_functions(self):
+        spts = ti.read_staypoints_csv(os.path.join('tests', 'data', 'geolife', 'geolife_staypoints.csv'))
+        _, locs_1 = spts.as_staypoints.extract_locations(method='dbscan', epsilon=10, 
+                                                          num_samples=0, distance_matrix_metric='haversine',
+                                                          agg_level='dataset')
+        _, locs_2 = spts.as_staypoints.cluster_staypoints(method='dbscan', epsilon=10, 
+                                                          num_samples=0, distance_matrix_metric='haversine',
+                                                          agg_level='dataset')
+        
+        assert all(locs_1['center'] == locs_2['center']), "The location geometry should be the same"
+        assert all(locs_1['location_id'] == locs_2['location_id']), "The location id should be the same"
     
     def test_cluster_staypoints_dbscan_haversine(self):
         spts = ti.read_staypoints_csv(os.path.join('tests', 'data', 'geolife', 'geolife_staypoints.csv'))
@@ -138,3 +149,5 @@ class TestPreprocessing():
         
         assert len(loc_har) == len(loc_eu) , "The #location should be the same for haversine" + \
             "and euclidean distances"
+            
+    

--- a/tests/preprocessing/test_preprocessing.py
+++ b/tests/preprocessing/test_preprocessing.py
@@ -38,14 +38,23 @@ class TestPreprocessing():
     def test_cluster_staypoints_dbscan_min(self):
         pfs = ti.read_positionfixes_csv(os.path.join('tests','data','positionfixes.csv'), sep=';')
         spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
-        _, clusters = spts.as_staypoints.extract_locations(method='dbscan', epsilon=1e-18, num_samples=0)
-        assert len(clusters) == len(spts), "With small hyperparameters, clustering should not reduce the number"
+        _, locs_user = spts.as_staypoints.extract_locations(method='dbscan', epsilon=1e-18, 
+                                                            num_samples=0, agg_level='user')
+        _, locs_data = spts.as_staypoints.extract_locations(method='dbscan', epsilon=1e-18, 
+                                                            num_samples=0, agg_level='dataset')
+        assert len(locs_user) == len(spts), "With small hyperparameters, clustering should not reduce the number"
+        assert len(locs_data) == len(spts), "With small hyperparameters, clustering should not reduce the number"
 
     def test_cluster_staypoints_dbscan_max(self):
         pfs = ti.read_positionfixes_csv(os.path.join('tests','data','positionfixes.csv'), sep=';')
         spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
-        _, clusters = spts.as_staypoints.extract_locations(method='dbscan', epsilon=1e18, num_samples=1000)
-        assert len(clusters) == 0, "With large hyperparameters, everything is an outlier"
+        _, locs_user = spts.as_staypoints.extract_locations(method='dbscan', epsilon=1e18, 
+                                                            num_samples=1000, agg_level='user')
+        _, locs_data = spts.as_staypoints.extract_locations(method='dbscan', epsilon=1e18, 
+                                                            num_samples=1000, agg_level='dataset')
+        assert len(locs_user) == 0, "With large hyperparameters, every user location is an outlier"
+        assert len(locs_data) == 0, "With large hyperparameters, every dataset location is an outlier"
+        
         
     def test_cluster_staypoints_dbscan_user_dataset(self):
         spts = ti.read_staypoints_csv(os.path.join('tests', 'data', 'geolife', 'geolife_staypoints.csv'))

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -64,7 +64,7 @@ class StaypointsAccessor(object):
         return ti.preprocessing.staypoints.cluster_staypoints(self._obj, *args, **kwargs)
     
     def cluster_staypoints(self, *args, **kwargs):
-        """Extracts locations from this collection of staypoints.
+        """Function alias for extract_locations to ensure consistency for function naming.
         See :func:`trackintel.preprocessing.staypoints.cluster_staypoints`."""
         return self.extract_locations(*args, **kwargs)
 

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -62,6 +62,11 @@ class StaypointsAccessor(object):
         """Extracts locations from this collection of staypoints.
         See :func:`trackintel.preprocessing.staypoints.cluster_staypoints`."""
         return ti.preprocessing.staypoints.cluster_staypoints(self._obj, *args, **kwargs)
+    
+    def cluster_staypoints(self, *args, **kwargs):
+        """Extracts locations from this collection of staypoints.
+        See :func:`trackintel.preprocessing.staypoints.cluster_staypoints`."""
+        return self.extract_locations(*args, **kwargs)
 
     def create_activity_flag(self, *args, **kwargs):
         """Sets a flag if a staypoint is also an activity.

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -97,8 +97,7 @@ def cluster_staypoints(staypoints,
                 p = np.array([[g.x, g.y] for g in ret_sp.geometry])
             labels = db.fit_predict(p)
             
-            # add 1 to match the 'user' level result
-            ret_sp['location_id'] = labels + 1
+            ret_sp['location_id'] = labels
             
         # create locations as grouped staypoints
         temp_sp = ret_sp[['user_id', 'location_id', ret_sp.geometry.name]]
@@ -115,7 +114,7 @@ def cluster_staypoints(staypoints,
             ret_loc = ret_loc.merge(geom_df, on='location_id', how='left')
             
         # filter outlier
-        ret_loc = ret_loc.loc[ret_loc['location_id'] != 0]
+        ret_loc = ret_loc.loc[ret_loc['location_id'] != -1]
         
         # locations with only one staypoints is of type "Point"
         point_idx = ret_loc.geom_type == 'Point'

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -27,7 +27,8 @@ def cluster_staypoints(staypoints,
         'dbscan' : Uses the DBSCAN algorithm to cluster staypoints.
 
     epsilon : float, default 100
-        The epsilon for the 'dbscan' method.
+        The epsilon for the 'dbscan' method. if 'distance_matrix_metric' is 'haversine' 
+        or 'euclidean', the unit is meters.
 
     num_samples : int, default 1
         The minimal number of samples in a cluster. 
@@ -62,8 +63,10 @@ def cluster_staypoints(staypoints,
             # The input and output of sklearn's harvarsine metrix are both in radians,
             # see https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.haversine_distances.html
             # here the 'epsilon' is directly applied to the metric's output.
-            epsilon = epsilon / 6371000 # convert to radius
-        db = DBSCAN(eps=epsilon, min_samples=num_samples, algorithm='ball_tree', metric=distance_matrix_metric)
+            # convert to radius
+            db = DBSCAN(eps=epsilon / 6371000 , min_samples=num_samples, algorithm='ball_tree', metric=distance_matrix_metric)
+        else:
+            db = DBSCAN(eps=epsilon, min_samples=num_samples, algorithm='ball_tree', metric=distance_matrix_metric)
             
         if agg_level == 'user':
             location_id_counter = 0
@@ -99,9 +102,20 @@ def cluster_staypoints(staypoints,
             
         # create locations as grouped staypoints
         temp_sp = ret_sp[['user_id', 'location_id', ret_sp.geometry.name]]
-        ret_loc = temp_sp.dissolve(by=['user_id', 'location_id'],as_index=False)
+        if agg_level == 'user':
+            # directly dissolve by 'user_id' and 'location_id'
+            ret_loc = temp_sp.dissolve(by=['user_id', 'location_id'],as_index=False)
+        else:
+            ## generate user-location pairs with same geometries across users
+            # get user-location pairs
+            ret_loc = temp_sp.dissolve(by=['user_id', 'location_id'], as_index=False).drop(columns={'geom'})
+            # get location geometries
+            geom_df = temp_sp.dissolve(by=['location_id'], as_index=False).drop(columns={'user_id'})
+            # merge pairs with location geometries
+            ret_loc = ret_loc.merge(geom_df, on='location_id', how='left')
+            
         # filter outlier
-        ret_loc = ret_loc.loc[ret_loc['location_id'] != -1]
+        ret_loc = ret_loc.loc[ret_loc['location_id'] != 0]
         
         # locations with only one staypoints is of type "Point"
         point_idx = ret_loc.geom_type == 'Point'


### PR DESCRIPTION
- `epsilon` value is retained for `buffer` function for linestring and point geometry.
- fix geometry generation for dataset locations: same geometry across users
- ensure location_id start from 0
- add `cluster_staypoints` function in `StaypointsAccessor` to ensure consistency