### PR TITLE
Ci postgis

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,4 +60,4 @@ jobs:
         source activate test
         conda install postgis -c conda-forge
         source ci/envs/setup_postgres.sh
-        pytest -v -r s --color=yes --cov=./ | tee /dev/stderr | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi
+        pytest -v -r s --color=yes --cov=./ | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi

--- a/tests/io/test_postgis_gpd.py
+++ b/tests/io/test_postgis_gpd.py
@@ -86,5 +86,5 @@ class TestIO:
         # by user; should not be set to 0, as from get_srid failure
         assert df.crs is None
 
-    def test_postgis_test_that_fails():
-        pytest.skip("This skip should cause a fail for the postgis test run")
+    # def test_postgis_test_that_fails():
+    #     pytest.skip("This skip should cause a fail for the postgis test run")

--- a/tests/io/test_postgis_gpd.py
+++ b/tests/io/test_postgis_gpd.py
@@ -85,3 +85,6 @@ class TestIO:
         # no crs defined on the created geodatabase, and none specified
         # by user; should not be set to 0, as from get_srid failure
         assert df.crs is None
+
+    def test_postgis_test_that_fails():
+        pytest.skip("This skip should cause a fail for the postgis test run")


### PR DESCRIPTION
a hot fix for the failing postgresql/postgis test. In the long run we should see how it is fixed in geopandas but for now this works. I have tested that it can still successfully identify skipped postgis tests as failing in the postgis run.