### PR TITLE
Fix output format for generate functions

### DIFF
--- a/tests/preprocessing/test_extract_triplegs.py
+++ b/tests/preprocessing/test_extract_triplegs.py
@@ -12,7 +12,7 @@ class TestExtractTriplegs:
     def test_extract_triplegs_global(self):
         # generate triplegs from raw-data
         pfs = read_geolife(os.path.join('tests', 'data', 'geolife'))
-        spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25, time_threshold=5 * 60)
+        _, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25, time_threshold=5 * 60)
         tpls = pfs.as_positionfixes.extract_triplegs(spts)
 
         # load pregenerated test-triplegs
@@ -37,7 +37,7 @@ class TestExtractTriplegs:
         the next one started.
         """
         pfs = read_geolife(os.path.join('tests', 'data', 'geolife_long'))
-        spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25, time_threshold=5 * 60)
+        _, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25, time_threshold=5 * 60)
         tpls = pfs.as_positionfixes.extract_triplegs(spts)
 
         spts_tpls = spts[['started_at', 'finished_at', 'user_id']].append(

--- a/tests/preprocessing/test_extract_triplegs.py
+++ b/tests/preprocessing/test_extract_triplegs.py
@@ -12,8 +12,8 @@ class TestExtractTriplegs:
     def test_extract_triplegs_global(self):
         # generate triplegs from raw-data
         pfs = read_geolife(os.path.join('tests', 'data', 'geolife'))
-        _, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25, time_threshold=5 * 60)
-        tpls = pfs.as_positionfixes.extract_triplegs(spts)
+        pfs, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25, time_threshold=5 * 60)
+        pfs, tpls = pfs.as_positionfixes.extract_triplegs(spts)
 
         # load pregenerated test-triplegs
         tpls_test = ti.read_triplegs_csv(os.path.join('tests', 'data', 'geolife', 'geolife_triplegs_short.csv'))
@@ -37,8 +37,8 @@ class TestExtractTriplegs:
         the next one started.
         """
         pfs = read_geolife(os.path.join('tests', 'data', 'geolife_long'))
-        _, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25, time_threshold=5 * 60)
-        tpls = pfs.as_positionfixes.extract_triplegs(spts)
+        pfs, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25, time_threshold=5 * 60)
+        pfs, tpls = pfs.as_positionfixes.extract_triplegs(spts)
 
         spts_tpls = spts[['started_at', 'finished_at', 'user_id']].append(
             tpls[['started_at', 'finished_at', 'user_id']])

--- a/tests/preprocessing/test_preprocessing.py
+++ b/tests/preprocessing/test_preprocessing.py
@@ -16,18 +16,18 @@ from trackintel.geogr.distances import calculate_distance_matrix
 class TestPreprocessing():
     def test_extract_staypoints_sliding_min(self):
         pfs = ti.read_positionfixes_csv(os.path.join('tests','data','positionfixes.csv'), sep=';')
-        spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
+        _, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
         assert len(spts) == len(pfs), "With small thresholds, staypoint extraction should yield each positionfix"
         
     def test_extract_staypoints_sliding_max(self):
         pfs = ti.read_positionfixes_csv(os.path.join('tests','data','positionfixes.csv'), sep=';')
-        spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=sys.maxsize, 
+        _, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=sys.maxsize, 
                                                        time_threshold=sys.maxsize)
         assert len(spts) == 0, "With large thresholds, staypoint extraction should not yield positionfixes"
         
     def test_extract_triplegs_staypoint(self):
         pfs = ti.read_positionfixes_csv(os.path.join('tests','data','positionfixes.csv'), sep=';')
-        spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
+        pfs, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
         tpls1 = pfs.as_positionfixes.extract_triplegs()
         tpls2 = pfs.as_positionfixes.extract_triplegs(spts)
         assert len(tpls1) > 0, "There should be more than zero triplegs"
@@ -37,7 +37,7 @@ class TestPreprocessing():
 
     def test_cluster_staypoints_dbscan_min(self):
         pfs = ti.read_positionfixes_csv(os.path.join('tests','data','positionfixes.csv'), sep=';')
-        spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
+        _, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
         _, locs_user = spts.as_staypoints.extract_locations(method='dbscan', epsilon=1e-18, 
                                                             num_samples=0, agg_level='user')
         _, locs_data = spts.as_staypoints.extract_locations(method='dbscan', epsilon=1e-18, 
@@ -47,7 +47,7 @@ class TestPreprocessing():
 
     def test_cluster_staypoints_dbscan_max(self):
         pfs = ti.read_positionfixes_csv(os.path.join('tests','data','positionfixes.csv'), sep=';')
-        spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
+        _, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
         _, locs_user = spts.as_staypoints.extract_locations(method='dbscan', epsilon=1e18, 
                                                             num_samples=1000, agg_level='user')
         _, locs_data = spts.as_staypoints.extract_locations(method='dbscan', epsilon=1e18, 

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -49,7 +49,7 @@ class TestGenerate_trips():
         pfs, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25,
                                                        time_threshold=5 * 60)
         spts = spts.as_staypoints.create_activity_flag()
-        tpls = pfs.as_positionfixes.extract_triplegs(spts)
+        pfs, tpls = pfs.as_positionfixes.extract_triplegs(spts)
 
         # temporary fix ID bug (issue  #56) so that we work with valid staypoint/tripleg files
         spts = spts.set_index('id')
@@ -77,7 +77,7 @@ class TestGenerate_trips():
                                                             dist_threshold=25,
                                                             time_threshold=5 * 60)
         spts = spts.as_staypoints.create_activity_flag()
-        tpls = pfs.as_positionfixes.extract_triplegs(spts)
+        pfs, tpls = pfs.as_positionfixes.extract_triplegs(spts)
 
         # temporary fix ID bug (issue  #56) so that we work with valid staypoint/tripleg files
         spts = spts.set_index('id')

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -46,7 +46,7 @@ class TestGenerate_trips():
 
         # create trips from geolife (based on positionfixes)
         pfs = read_geolife(os.path.join('tests', 'data', 'geolife_long'))
-        spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25,
+        pfs, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25,
                                                        time_threshold=5 * 60)
         spts = spts.as_staypoints.create_activity_flag()
         tpls = pfs.as_positionfixes.extract_triplegs(spts)
@@ -73,8 +73,9 @@ class TestGenerate_trips():
 
         # create trips from geolife (based on positionfixes)
         pfs = read_geolife(os.path.join('tests', 'data', 'geolife_long'))
-        spts = pfs.as_positionfixes.extract_staypoints(method='sliding', dist_threshold=25,
-                                                       time_threshold=5 * 60)
+        pfs, spts = pfs.as_positionfixes.extract_staypoints(method='sliding', 
+                                                            dist_threshold=25,
+                                                            time_threshold=5 * 60)
         spts = spts.as_staypoints.create_activity_flag()
         tpls = pfs.as_positionfixes.extract_triplegs(spts)
 

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -43,8 +43,8 @@ def extract_staypoints(positionfixes, method='sliding',
     Returns
     -------
     (GeoDataFrame, GeoDataFrame)
-        The tuple contains (positionfixes, staypoints). Positionfixes contains a new column 
-        'staypoint_ids', and staypoints is the generated staypoints where a person spent some 
+        The tuple contains (positionfixes, staypoints). 'Positionfixes' contains a new column 
+        'staypoint_ids', and 'staypoints' is the generated staypoints where a person spent some 
         time.
 
     Examples
@@ -204,8 +204,6 @@ def extract_triplegs(positionfixes, staypoints=None, *args, **kwargs):
     positionfixes or passing some staypoints that correspond to the positionfixes! 
     This means you usually should call ``extract_staypoints()`` first.
 
-    This function modifies the positionfixes and adds a ``tripleg_id``.
-
     Parameters
     ----------
     positionfixes : GeoDataFrame
@@ -217,8 +215,9 @@ def extract_triplegs(positionfixes, staypoints=None, *args, **kwargs):
 
     Returns
     -------
-    GeoDataFrame
-        A new GeoDataFrame containing triplegs.
+    (GeoDataFrame, GeoDataFrame)
+        The tuple contains (positionfixes, triplegs). 'Positionfixes' contains a new column 
+        'tripleg_id', and 'triplegs' is the generated triplegs.
 
     Examples
     --------


### PR DESCRIPTION
'extract_staypoints' and 'extract_triplegs' functions now return the modified 'pfs'. All of our 'generate' functions now returns the modified dataframe as output and do not change is implicitly. The tests and comments are modified accordingly
