### PR TITLE
ENH/BUG/PERF: tracking quality module

### DIFF
--- a/tests/analysis/test_tracking_quality.py
+++ b/tests/analysis/test_tracking_quality.py
@@ -64,7 +64,6 @@ class TestTemporal_tracking_quality:
         start_date = splitted["started_at"].min().date()
         splitted["week"] = splitted["started_at"].apply(lambda x: (x.date() - start_date).days // 7)
 
-        print(splitted)
         # calculate tracking quality of the first week for the first user
         user_0 = splitted.loc[splitted["user_id"] == 0]
         extent = 60 * 60 * 24 * 7
@@ -123,13 +122,23 @@ class TestTemporal_tracking_quality:
         assert quality_manual == quality.loc[(quality["user_id"] == 0) & (quality["hour"] == 2), "quality"].values[0]
 
     def test_tracking_quality_error(self, testdata_stps_tpls_geolife_long):
-        """Test if the an error is raised when passing unknown 'granularity'."""
+        """Test if the an error is raised when passing unknown 'granularity' to temporal_tracking_quality()."""
         stps_tpls = testdata_stps_tpls_geolife_long
 
         with pytest.raises(AttributeError):
             ti.analysis.tracking_quality.temporal_tracking_quality(stps_tpls, granularity=12345)
         with pytest.raises(AttributeError):
             ti.analysis.tracking_quality.temporal_tracking_quality(stps_tpls, granularity="random")
+            
+    def test_tracking_quality_user_error(self, testdata_stps_tpls_geolife_long):
+        """Test if the an error is raised when passing unknown 'granularity' to _get_tracking_quality_user()."""
+        stps_tpls = testdata_stps_tpls_geolife_long
+        user_0 = stps_tpls.loc[stps_tpls['user_id'] == 0] 
+
+        with pytest.raises(AttributeError):
+            ti.analysis.tracking_quality._get_tracking_quality_user(user_0, granularity=12345)
+        with pytest.raises(AttributeError):
+            ti.analysis.tracking_quality._get_tracking_quality_user(user_0, granularity="random")
 
     def test_split_overlaps_days(self, testdata_stps_tpls_geolife_long):
         """Test if _split_overlaps() function can split records that span several days."""

--- a/tests/analysis/test_tracking_quality.py
+++ b/tests/analysis/test_tracking_quality.py
@@ -88,10 +88,9 @@ class TestTemporal_tracking_quality:
 
         splitted["weekday"] = splitted["started_at"].dt.weekday
 
-        print(splitted)
         # calculate tracking quality of the first week for the first user
         user_0 = splitted.loc[(splitted["user_id"] == 0) & (splitted["weekday"] == 3)]
-        extent = (60 * 60 * 24) * len(user_0["week"].unique())
+        extent = (60 * 60 * 24) * (user_0["week"].max() - user_0["week"].min() + 1)
         tracked = (user_0["finished_at"] - user_0["started_at"]).dt.total_seconds().sum()
         quality_manual = tracked / extent
 
@@ -114,7 +113,7 @@ class TestTemporal_tracking_quality:
 
         # calculate tracking quality of an hour for the first user
         user_0 = splitted.loc[(splitted["user_id"] == 0) & (splitted["hour"] == 2)]
-        extent = (60 * 60) * len(user_0["day"].unique())
+        extent = (60 * 60) * (user_0["day"].max() - user_0["day"].min() + 1)
         tracked = (user_0["finished_at"] - user_0["started_at"]).dt.total_seconds().sum()
         quality_manual = tracked / extent
 

--- a/trackintel/analysis/tracking_quality.py
+++ b/trackintel/analysis/tracking_quality.py
@@ -13,11 +13,11 @@ def temporal_tracking_quality(source, granularity="all"):
     df : GeoDataFrame (as trackintel datamodels)
         The source dataframe to calculate temporal tracking quality.
 
-    granularity : {"all", "day", "week", "weekday", "hour"}, default "all"
+    granularity : {"all", "day", "week", "weekday", "hour"}
         The level of which the tracking quality is calculated. The default "all" returns
         the overall tracking quality; "day" the tracking quality by days; "week" the quality
-        by weeks; "weekday" the quality by day of the week (e.g, Mondays, Tuesdays, etc.) and "hour" the
-        quality by hours.
+        by weeks; "weekday" the quality by day of the week (e.g, Mondays, Tuesdays, etc.) and 
+        "hour" the quality by hours.
 
     Returns
     -------
@@ -27,16 +27,16 @@ def temporal_tracking_quality(source, granularity="all"):
     Note
     ----
     The temporal tracking quality is the ratio of tracking time and the total time extent. It is
-    calculated and returned per-user in the defined granularity. The possible time extents of the
-    different granularities are different:
+    calculated and returned per-user in the defined ``granularity``. The possible time extents of 
+    the different granularities are different:
 
-    - "all" considers the time between the latest "finished_at" and the earliest "started_at";
-    - "week" considers the whole week (604800 sec)
-    - "day" and "weekday" consider the whole day (86400 sec)
-    - "hour" considers the whole hour (3600 sec).
+    - ``all`` considers the time between the latest "finished_at" and the earliest "started_at";
+    - ``week`` considers the whole week (604800 sec)
+    - ``day`` and ``weekday`` consider the whole day (86400 sec)
+    - ``hour`` considers the whole hour (3600 sec).
 
     The tracking quality of each user is calculated based on his or her own tracking extent.
-    For granularity = "day" or "week", the quality["day"] or quality["week"] column displays the
+    For granularity = ``day`` or ``week``, the quality["day"] or quality["week"] column displays the
     time relative to the first record in the entire dataset.
 
     Examples
@@ -183,6 +183,10 @@ def _get_tracking_quality_user(df, granularity="all"):
         # total seconds in an hour * number of tracked days
         # (entries from multiple days may be grouped together)
         extent = (60 * 60) * (df["day"].max() - df["day"].min() + 1)
+    else:
+        raise AttributeError(
+            f"granularity unknown. We only support ['all', 'day', 'week', 'weekday', 'hour']. You passed {granularity}"
+        )
     return pd.Series([tracked_duration / extent], index=["quality"])
 
 

--- a/trackintel/analysis/tracking_quality.py
+++ b/trackintel/analysis/tracking_quality.py
@@ -6,7 +6,7 @@ import numpy as np
 
 def temporal_tracking_quality(source, granularity="all"):
     """
-    Calculate per-user temporal tracking quality.
+    Calculate per-user temporal tracking quality defined as the temporal coverage.
 
     Parameters
     ----------
@@ -16,7 +16,8 @@ def temporal_tracking_quality(source, granularity="all"):
     granularity : {"all", "day", "week", "weekday", "hour"}, default "all"
         The level of which the tracking quality is calculated. The default "all" returns
         the overall tracking quality; "day" the tracking quality by days; "week" the quality
-        by weeks; "weekday" the quality by weekdays and "hour" the quality by hours.
+        by weeks; "weekday" the quality by day of the week (e.g, Mondays, Tuesdays, etc.) and "hour" the
+        quality by hours.
 
     Returns
     -------
@@ -25,14 +26,17 @@ def temporal_tracking_quality(source, granularity="all"):
 
     Note
     ----
-    The temporal tracking quality is the time proportion of tracked period with the possible
-    time extent. The possible time extents of the different granularities are different: "all"
-    considers the time between the latest "finished_at" and the earliest "started_at", whereas
-    "week" considers the whole week (604800 sec), "day" and "weekday" considers the whole day
-    (86400 sec) and "hour" considers the whole hour (3600 sec).
+    The temporal tracking quality is the ratio of tracking time and the total time extent. It is
+    calculated and returned per-user in the defined granularity. The possible time extents of the
+    different granularities are different:
 
-    The tracking quality of each user is calculated based on his or her own tracking extent. But
-    for granularity = "day" or "week", the quality["day"] or quality["week"] column displays the
+    - "all" considers the time between the latest "finished_at" and the earliest "started_at";
+    - "week" considers the whole week (604800 sec)
+    - "day" and "weekday" consider the whole day (86400 sec)
+    - "hour" considers the whole hour (3600 sec).
+
+    The tracking quality of each user is calculated based on his or her own tracking extent.
+    For granularity = "day" or "week", the quality["day"] or quality["week"] column displays the
     time relative to the first record in the entire dataset.
 
     Examples
@@ -112,15 +116,14 @@ def temporal_tracking_quality(source, granularity="all"):
 
 def _get_all_quality(df, raw_quality, granularity):
     """
-    Construct the full tracking quality based on the calculated raw_quality.
+    Add tracking quality values for empty bins.
 
-    As raw_quality is calcuated using groupby, the units that has entirely no tracking info
-    is not included in raw_quality (quality = 0). They are added using this function.
+    raw_quality is calculated using `groupby` and does not report bins (=granularties) with
+    quality = 0. This function adds these values.
 
     Parameters
     ----------
     df : GeoDataFrame (as trackintel datamodels)
-        The source dataframe
 
     raw_quality: DataFrame
         The calculated raw tracking quality directly from the groupby operations.
@@ -193,13 +196,13 @@ def _split_overlaps(source, granularity="day"):
         The source to perform the split
 
     granularity : {'day', 'hour'}, default 'day'
-        The criteria of spliting. "day" splits records that have duration of several
+        The criteria of splitting. "day" splits records that have duration of several
         days and "hour" splits records that have duration of several hours.
 
     Returns
     -------
     GeoDataFrame (as trackintel datamodels)
-        The GeoDataFrame object after the spliting
+        The GeoDataFrame object after the splitting
     """
     df = source.copy()
     change_flag = __get_split_index(df, granularity=granularity)


### PR DESCRIPTION
closes #162 

ENH: 
- The relative to the dataset start and user start time is a bit confusing, I added a description in the docstring. Line 34-36.
- granularity = weekday and week is added. Now we have all options. The tests are added, but as even geolife_long does not include records for several weeks, the tests for weekday and week might not be useful. I have tested the code using MOBIS and SBB to make sure they produce correct results.

BUG: 
- previously using groupby we did not include timesteps that have no tracking (e.g., a user is tracked in week 4 and 6 but not 5, week 5 will then not be included in the final quality df). This is solved using `_get_all_quality(df, raw_quality, granularity)` to fill in the untracked periods with quality=0. This facilitates subsequent dataset level calculations. 
- Previously only tracked periods are considered in the calculation (Line 182 `len(df["day"].unique()`), which would lead to higher quality. This is now replaced to  `(df["day"].max() - df["day"].min() + 1)`.

PERF:
`granularity = "hour"` is more efficient if we call `_split_overlaps(df, granularity="day")` beforehand, Line 91