### PR TITLE
PERF: datatime loading

### DIFF
--- a/tests/io/test_dataset_reader.py
+++ b/tests/io/test_dataset_reader.py
@@ -82,7 +82,6 @@ class TestReadGeolife:
         pfs, _ = read_geolife(os.path.join('tests', 'data', 'geolife'))
         tmp_file = os.path.join('tests', 'data', 'positionfixes_test.csv')
         pfs.as_positionfixes.to_csv(tmp_file)
-        print(pfs)
         pfs2 = ti.read_positionfixes_csv(tmp_file, index_col='id')[pfs.columns]
         os.remove(tmp_file)
         assert np.isclose(0, (pfs.lat - pfs2.lat).abs().sum())

--- a/tests/io/test_dataset_reader.py
+++ b/tests/io/test_dataset_reader.py
@@ -78,11 +78,11 @@ def impossible_matching_data():
 
 class TestReadGeolife:
     def test_loop_read(self):
-        """use read_geolife reader, store posfix as .csv, load them again"""
-
+        """Use read_geolife reader, store posfix as .csv, load them again."""
         pfs, _ = read_geolife(os.path.join('tests', 'data', 'geolife'))
         tmp_file = os.path.join('tests', 'data', 'positionfixes_test.csv')
         pfs.as_positionfixes.to_csv(tmp_file)
+        print(pfs)
         pfs2 = ti.read_positionfixes_csv(tmp_file, index_col='id')[pfs.columns]
         os.remove(tmp_file)
         assert np.isclose(0, (pfs.lat - pfs2.lat).abs().sum())

--- a/tests/io/test_file.py
+++ b/tests/io/test_file.py
@@ -5,8 +5,8 @@ import pytest
 import trackintel as ti
 
 
-class TestFile:
-    def test_positionfixes_from_to_csv(self):
+class TestPositionfixes:
+    def test_from_to_csv(self):
         orig_file = os.path.join('tests', 'data', 'positionfixes.csv')
         mod_file = os.path.join('tests', 'data', 'positionfixes_mod_columns.csv')
         tmp_file = os.path.join('tests', 'data', 'positionfixes_test.csv')
@@ -23,21 +23,22 @@ class TestFile:
         assert filecmp.cmp(orig_file, tmp_file, shallow=False)
         os.remove(tmp_file)
 
-    def test_read_positionfixes_csv_crs_parameter(self):
+    def test_set_crs(self):
         file = os.path.join('tests', 'data', 'positionfixes.csv')
         pfs = ti.read_positionfixes_csv(file, sep=';', index_col="id")
-        crs = "EPSG:2056"
         assert pfs.crs is None
+        
+        crs = "EPSG:2056"
         pfs = ti.read_positionfixes_csv(file, sep=';', index_col="id", crs=crs)
         assert pfs.crs == crs
 
-    def test_positionfixes_csv_index_warning(self):
+    def test_index_warning(self):
         """Test if a warning is raised when not parsing the index_col argument."""
         file = os.path.join('tests', 'data', 'positionfixes.csv')
         with pytest.warns(UserWarning):
             ti.read_positionfixes_csv(file, sep=';')
 
-    def test_positionfixes_csv_index_col(self):
+    def test_index_col(self):
         """Test if `index_col` can be set."""
         file = os.path.join('tests', 'data', 'positionfixes.csv')
         ind_name = 'id'
@@ -46,9 +47,11 @@ class TestFile:
         pfs = ti.read_positionfixes_csv(file, sep=";", index_col=None)
         assert pfs.index.name is None
 
-    def test_positionfixes_from_to_postgis(self):
+    def test_from_to_postgis(self):
         # TODO Implement some tests for PostGIS.
         pass
+
+class TestFile:
 
     def test_triplegs_from_to_csv(self):
         orig_file = os.path.join('tests', 'data', 'triplegs.csv')

--- a/trackintel/io/dataset_reader.py
+++ b/trackintel/io/dataset_reader.py
@@ -121,7 +121,7 @@ def read_geolife(geolife_path):
         # read every day of every user and concatenate input files
         for input_file_this in input_files:
             data_this = pd.read_csv(input_file_this, skiprows=6, header=None,
-                                    names=['lat', 'lon', 'zeros', 'elevation',
+                                    names=['latitude', 'longitude', 'zeros', 'elevation',
                                            'date days', 'date', 'time'])
 
             data_this['tracked_at'] = pd.to_datetime(data_this['date']
@@ -132,7 +132,7 @@ def read_geolife(geolife_path):
             data_this['user_id'] = user_id
             data_this['elevation'] = data_this['elevation'] * FEET2METER
 
-            data_this['geom'] = list(zip(data_this.lon, data_this.lat))
+            data_this['geom'] = list(zip(data_this['longitude'], data_this['latitude']))
             data_this['geom'] = data_this['geom'].apply(Point)
 
             df_list_days.append(data_this)

--- a/trackintel/io/dataset_reader.py
+++ b/trackintel/io/dataset_reader.py
@@ -121,7 +121,7 @@ def read_geolife(geolife_path):
         # read every day of every user and concatenate input files
         for input_file_this in input_files:
             data_this = pd.read_csv(input_file_this, skiprows=6, header=None,
-                                    names=['latitude', 'longitude', 'zeros', 'elevation',
+                                    names=['lat', 'lon', 'zeros', 'elevation',
                                            'date days', 'date', 'time'])
 
             data_this['tracked_at'] = pd.to_datetime(data_this['date']
@@ -132,7 +132,7 @@ def read_geolife(geolife_path):
             data_this['user_id'] = user_id
             data_this['elevation'] = data_this['elevation'] * FEET2METER
 
-            data_this['geom'] = list(zip(data_this['longitude'], data_this['latitude']))
+            data_this['geom'] = list(zip(data_this['lon'], data_this['lat']))
             data_this['geom'] = data_this['geom'].apply(Point)
 
             df_list_days.append(data_this)

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -93,14 +93,10 @@ def read_positionfixes_csv(*args, columns=None, tz=None, index_col=object(), crs
     # transform to datatime
     df["tracked_at"] = pd.to_datetime(df["tracked_at"])
 
-    # check and/or set timezone
+    # set timezone if none is recognized
     for col in ['tracked_at']:
         if not pd.api.types.is_datetime64tz_dtype(df[col]):
             df[col] = localize_timestamp(dt_series=df[col], pytz_tzinfo=tz, col_name=col)
-        else:
-            # dateutil parser timezones are sometimes not compatible with pandas (e.g., in asserts)
-            tz = df[col].iloc[0].tzinfo.tzname(df[col].iloc[0])
-            df[col] = df[col].dt.tz_convert(tz)
 
     df = df.drop(['longitude', 'latitude'], axis=1)
     gdf = gpd.GeoDataFrame(df, geometry='geom')

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -85,9 +85,13 @@ def read_positionfixes_csv(*args, columns=None, tz=None, index_col=object(), crs
 
     df = pd.read_csv(*args, **kwargs)
     df = df.rename(columns=columns)
-    df['geom'] = list(zip(df.longitude, df.latitude))
+    
+    # construct geom column from lon and lat
+    df['geom'] = list(zip(df['longitude'], df['latitude']))
     df['geom'] = df['geom'].apply(Point)
-    df['tracked_at'] = df['tracked_at'].apply(dateutil.parser.parse)
+    
+    # transform to datatime
+    df["tracked_at"] = pd.to_datetime(df["tracked_at"])
 
     # check and/or set timezone
     for col in ['tracked_at']:
@@ -121,8 +125,9 @@ def write_positionfixes_csv(positionfixes, filename, *args, **kwargs):
     gdf = positionfixes.copy()
     gdf['longitude'] = positionfixes.geometry.apply(lambda p: p.coords[0][0])
     gdf['latitude'] = positionfixes.geometry.apply(lambda p: p.coords[0][1])
-    gdf = gdf.drop(gdf.geometry.name, axis=1)
-    gdf.to_csv(filename, index=True, *args, **kwargs)
+    df = gdf.drop(gdf.geometry.name, axis=1)
+    
+    df.to_csv(filename, index=True, *args, **kwargs)
 
 
 def read_triplegs_csv(*args, columns=None, tz=None, index_col=object(), crs=None, **kwargs):


### PR DESCRIPTION
When loading pfs from csv, the bottleneck is in `df['tracked_at'] = df['tracked_at'].apply(dateutil.parser.parse)`. This per-row operation is expensive and can be changed to `df["tracked_at"] = pd.to_datetime(df["tracked_at"])`, which is much faster for common datatime formats and will call `dateutil.parser.parse` if receiving non-common ones. Since we work directly with pd, line 96-99 is no longer needed.

Additional tests for setting tz is added.
The test stricture of test_file.py is incorrect, but I only changed the `TestPositionfixes` class.

