### PR TITLE
BUG: a proposed fix for stps generation

### DIFF
--- a/tests/analysis/test_modal_split.py
+++ b/tests/analysis/test_modal_split.py
@@ -17,7 +17,7 @@ def read_geolife_with_modes():
 
     pfs, spts = pfs.as_positionfixes.generate_staypoints(method='sliding',
                                                          dist_threshold=25,
-                                                         time_threshold=5 * 60)
+                                                         time_threshold=5.0)
     _, tpls = pfs.as_positionfixes.generate_triplegs(spts, method='between_staypoints')
 
     tpls_with_modes = geolife_add_modes_to_triplegs(tpls, labels)

--- a/tests/analysis/test_tracking_quality.py
+++ b/tests/analysis/test_tracking_quality.py
@@ -24,9 +24,6 @@ class TestTemporal_tracking_quality:
     def test_tracking_quality_all(self, testdata_stps_tpls_geolife_long):
         """Test if the calculated total tracking quality is correct."""
         stps_tpls = testdata_stps_tpls_geolife_long
-        
-        print(stps_tpls[["started_at", "finished_at"]])
-
         # calculate tracking quality for a sample user
         user_0 = stps_tpls.loc[stps_tpls["user_id"] == 0]
         extent = (user_0["finished_at"].max() - user_0["started_at"].min()).total_seconds()
@@ -36,7 +33,7 @@ class TestTemporal_tracking_quality:
         # test if the result of the user agrees
         quality = ti.analysis.tracking_quality.temporal_tracking_quality(stps_tpls, granularity="all")
 
-        assert quality_manual == quality.loc[quality["user_id"] == 0, "quality"].values[0]
+        assert quality_manual != quality.loc[quality["user_id"] == 0, "quality"].values[0]
 
     def test_tracking_quality_day(self, testdata_stps_tpls_geolife_long):
         """Test if the calculated tracking quality per day is correct."""

--- a/tests/analysis/test_tracking_quality.py
+++ b/tests/analysis/test_tracking_quality.py
@@ -9,7 +9,7 @@ import trackintel as ti
 def testdata_stps_tpls_geolife_long():
     """Generate stps and tpls sequences of the original pfs for subsequent testing."""
     pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join("tests", "data", "geolife_long"))
-    pfs, stps = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=25, time_threshold=5 * 60)
+    pfs, stps = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=25, time_threshold=5.0)
     pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps, method="between_staypoints")
 
     tpls["type"] = "tripleg"
@@ -24,6 +24,8 @@ class TestTemporal_tracking_quality:
     def test_tracking_quality_all(self, testdata_stps_tpls_geolife_long):
         """Test if the calculated total tracking quality is correct."""
         stps_tpls = testdata_stps_tpls_geolife_long
+        
+        print(stps_tpls[["started_at", "finished_at"]])
 
         # calculate tracking quality for a sample user
         user_0 = stps_tpls.loc[stps_tpls["user_id"] == 0]

--- a/tests/analysis/test_tracking_quality.py
+++ b/tests/analysis/test_tracking_quality.py
@@ -33,7 +33,7 @@ class TestTemporal_tracking_quality:
         # test if the result of the user agrees
         quality = ti.analysis.tracking_quality.temporal_tracking_quality(stps_tpls, granularity="all")
 
-        assert quality_manual != quality.loc[quality["user_id"] == 0, "quality"].values[0]
+        assert quality_manual == quality.loc[quality["user_id"] == 0, "quality"].values[0]
 
     def test_tracking_quality_day(self, testdata_stps_tpls_geolife_long):
         """Test if the calculated tracking quality per day is correct."""

--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -66,8 +66,8 @@ class TestGenerate_staypoints():
     def test_generate_staypoints_sliding_min(self):
         pfs_file = os.path.join('tests', 'data', 'positionfixes.csv')
         pfs = ti.read_positionfixes_csv(pfs_file, sep=';', tz='utc', index_col='id')
-        pfs, stps = pfs.as_positionfixes.generate_staypoints(method='sliding', dist_threshold=0, time_threshold=0)
-        assert len(stps) == len(pfs), "With small thresholds, staypoint extraction should yield each positionfix"
+        pfs, stps = pfs.as_positionfixes.generate_staypoints(method='sliding', dist_threshold=0, time_threshold=0, include_last=True)
+        assert len(stps) == len(pfs) - 1, "With small thresholds, staypoint extraction should yield each positionfix"
 
     def test_generate_staypoints_sliding_max(self):
         pfs_file = os.path.join('tests', 'data', 'positionfixes.csv')
@@ -110,37 +110,6 @@ class TestGenerate_staypoints():
 
         assert (stps_sliding.index == np.arange(len(stps_sliding))).any()
         # assert (stps_dbscan.index == np.arange(len(stps_dbscan))).any()
-
-    def test_generate_staypoints_groupby_sliding(self):
-        """Test the 'sliding' result obtained using user_id for loop (previous) with groupby.apply (current)."""
-        pfs_file = os.path.join('tests', 'data', 'positionfixes.csv')
-        pfs_ori = ti.read_positionfixes_csv(pfs_file, sep=';', tz='utc', index_col='id')
-
-        # stps detection using groupby
-        pfs_groupby, stps_groupby = pfs_ori.as_positionfixes.generate_staypoints(method='sliding',
-                                                                                 dist_threshold=25,
-                                                                                 time_threshold=5.0)
-        # stps detection using for loop
-        pfs_for, stps_for = _generate_staypoints_original(pfs_ori,
-                                                          method='sliding',
-                                                          dist_threshold=25,
-                                                          time_threshold=5.0)
-
-        pd.testing.assert_frame_equal(stps_groupby, stps_for, check_dtype=False)
-        pd.testing.assert_frame_equal(pfs_groupby, pfs_for, check_dtype=False)
-
-    # def test_generate_staypoints_groupby_dbscan(self):
-    #     """Test the 'dbscan' result obtained using user_id for loop (previous) with groupby.apply (current)."""
-    #     pfs_file = os.path.join('tests', 'data', 'positionfixes.csv')
-    #     pfs_ori = ti.read_positionfixes_csv(pfs_file, sep=';', tz='utc', index_col='id')
-
-    #     # stps detection using groupby
-    #     pfs_groupby, stps_groupby = pfs_ori.as_positionfixes.generate_staypoints(method='dbscan')
-    #     # stps detection using for loop
-    #     pfs_for, stps_for = _generate_staypoints_original(pfs_ori, method='dbscan')
-
-    #     pd.testing.assert_frame_equal(stps_groupby, stps_for, check_dtype=False)
-    #     pd.testing.assert_frame_equal(pfs_groupby, pfs_for, check_dtype=False)
 
 
 class TestGenerate_triplegs():
@@ -292,147 +261,3 @@ class TestGenerate_triplegs():
 
             # all values have to greater or equal to zero. Otherwise there is an overlap
             assert all(diff >= np.timedelta64(datetime.timedelta()))
-
-
-def _generate_staypoints_original(positionfixes, method='sliding',
-                                  dist_threshold=50, time_threshold=300, epsilon=100,
-                                  dist_func=haversine_dist, num_samples=1):
-    """
-    Original function using 'user_id' for-loop to generate staypoints based on pfs.
-    
-    Used for comparing with the current groupby.apply() method.
-    """
-    # copy the original pfs for adding 'staypoint_id' column
-    ret_pfs = positionfixes.copy()
-    ret_pfs.sort_values(by='user_id', inplace=True)
-
-    elevation_flag = 'elevation' in ret_pfs.columns  # if there is elevation data
-
-    name_geocol = ret_pfs.geometry.name
-    ret_stps = pd.DataFrame(columns=['id', 'user_id', 'started_at', 'finished_at', 'geom'])
-
-    if method == 'sliding':
-        # Algorithm from Li et al. (2008). For details, please refer to the paper.
-        staypoint_id_counter = 0
-        ret_pfs['staypoint_id'] = np.nan  # this marks all that are not part of a SP
-
-        for user_id_this in ret_pfs['user_id'].unique():
-
-            positionfixes_user_this = ret_pfs.loc[ret_pfs['user_id'] == user_id_this]  # this is no copy
-
-            positionfixes_user_this = positionfixes_user_this.sort_values('tracked_at')
-            pfs = positionfixes_user_this.to_dict('records')
-            idx = positionfixes_user_this.index.to_list()
-            num_pfs = len(pfs)
-
-            posfix_staypoint_matching = {}
-
-            i = 0
-            j = 0  # is zero because it gets incremented in the beginning
-            while i < num_pfs:
-                if j == num_pfs:
-                    # We're at the end, this can happen if in the last "bin", 
-                    # the dist_threshold is never crossed anymore.
-                    break
-                else:
-                    j = i + 1
-                while j < num_pfs:
-                    # TODO: Can we make distance function independent of projection?
-                    dist = dist_func(pfs[i][name_geocol].x, pfs[i][name_geocol].y,
-                                     pfs[j][name_geocol].x, pfs[j][name_geocol].y)
-
-                    if dist > dist_threshold:
-                        delta_t = pfs[j]['tracked_at'] - pfs[i]['tracked_at']
-                        if delta_t.total_seconds() > time_threshold:
-                            staypoint = {}
-                            staypoint['user_id'] = pfs[i]['user_id']
-                            staypoint[name_geocol] = Point(np.mean([pfs[k][name_geocol].x for k in range(i, j)]),
-                                                           np.mean([pfs[k][name_geocol].y for k in range(i, j)]))
-                            if elevation_flag:
-                                staypoint['elevation'] = np.mean([pfs[k]['elevation'] for k in range(i, j)])
-                            staypoint['started_at'] = pfs[i]['tracked_at']
-                            staypoint['finished_at'] = pfs[j - 1]['tracked_at']
-                            staypoint['id'] = staypoint_id_counter
-
-                            # store matching 
-                            posfix_staypoint_matching[staypoint_id_counter] = [idx[k] for k in range(i, j)]
-                            staypoint_id_counter += 1
-
-                            # add staypoint
-                            ret_stps = ret_stps.append(staypoint, ignore_index=True)
-
-                            # TODO Discussion: Is this last point really a staypoint? As we don't know if the
-                            #      person "moves on" afterwards...
-                            if j == num_pfs - 1:
-                                staypoint = {}
-                                staypoint['user_id'] = pfs[j]['user_id']
-                                staypoint[name_geocol] = Point(pfs[j][name_geocol].x, pfs[j][name_geocol].y)
-                                if elevation_flag:
-                                    staypoint['elevation'] = pfs[j]['elevation']
-                                staypoint['started_at'] = pfs[j]['tracked_at']
-                                staypoint['finished_at'] = pfs[j]['tracked_at']
-                                staypoint['id'] = staypoint_id_counter
-
-                                # store matching
-                                posfix_staypoint_matching[staypoint_id_counter] = [idx[j]]
-                                staypoint_id_counter += 1
-                                ret_stps = ret_stps.append(staypoint, ignore_index=True)
-                        i = j
-                        break
-                    j = j + 1
-
-            # add matching to original positionfixes (for every user)
-
-            for staypoints_id, posfix_idlist in posfix_staypoint_matching.items():
-                # note that we use .loc because above we have saved the id 
-                # of the positionfixes not thier absolut position
-                ret_pfs.loc[posfix_idlist, 'staypoint_id'] = staypoints_id
-
-
-    elif method == 'dbscan':
-
-        db = DBSCAN(eps=epsilon / 6371000, min_samples=num_samples, algorithm='ball_tree', metric='haversine')
-
-        for user_id_this in ret_pfs['user_id'].unique():
-
-            user_positionfixes = ret_pfs[ret_pfs['user_id'] == user_id_this]  # this is not a copy!
-
-            # TODO: enable transformations to temporary (metric) system
-            transform_crs = None
-            if transform_crs is not None:
-                pass
-
-            # get staypoint matching
-            coordinates = np.array([[radians(g.y), radians(g.x)] for g in user_positionfixes[name_geocol]])
-            labels = db.fit_predict(coordinates)
-
-            # add positionfixes - staypoint matching to original positionfixes
-            ret_pfs.loc[user_positionfixes.index, 'staypoint_id'] = labels
-
-        # create staypoints as the center of the grouped positionfixes
-        grouped_df = ret_pfs.groupby(['user_id', 'staypoint_id'])
-        for combined_id, group in grouped_df:
-            user_id, staypoint_id = combined_id
-
-            if int(staypoint_id) != -1:
-                staypoint = {}
-                staypoint['user_id'] = user_id
-                staypoint['id'] = staypoint_id
-
-                # point geometry of staypoint
-                staypoint[name_geocol] = Point(group[name_geocol].x.mean(),
-                                               group[name_geocol].y.mean())
-
-                ret_stps = ret_stps.append(staypoint, ignore_index=True)
-
-    ret_stps = gpd.GeoDataFrame(ret_stps, geometry=name_geocol, crs=ret_pfs.crs)
-    ret_pfs = gpd.GeoDataFrame(ret_pfs, geometry=name_geocol, crs=ret_pfs.crs)
-
-    ## ensure dtype consistency 
-    ret_stps['id'] = ret_stps['id'].astype('int64')
-    ret_stps.set_index('id', inplace=True)
-    ret_pfs['staypoint_id'] = ret_pfs['staypoint_id'].astype('float')
-
-    ret_stps['user_id'] = ret_stps['user_id'].astype(ret_pfs['user_id'].dtype)
-
-    return ret_pfs, ret_stps

--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -32,7 +32,7 @@ def pfs_geolife_long():
 def geolife_pfs_stps_short(pfs_geolife):
     pfs, stps = pfs_geolife.as_positionfixes.generate_staypoints(method='sliding',
                                                                  dist_threshold=25,
-                                                                 time_threshold=5 * 60)
+                                                                 time_threshold=5.0)
     return pfs, stps
 
 
@@ -40,7 +40,7 @@ def geolife_pfs_stps_short(pfs_geolife):
 def geolife_pfs_stps_long(pfs_geolife_long):
     pfs, stps = pfs_geolife_long.as_positionfixes.generate_staypoints(method='sliding',
                                                                       dist_threshold=25,
-                                                                      time_threshold=5 * 60)
+                                                                      time_threshold=5.0)
     return pfs, stps
 
 
@@ -77,7 +77,7 @@ class TestGenerate_staypoints():
                                                            time_threshold=sys.maxsize)
         assert len(stps) == 0, "With large thresholds, staypoint extraction should not yield positionfixes"
 
-    def test_generate_staypoints_missing_link(self, geolife_pfs_stps_long):
+    def test_generate_staypoints_missing_link(self):
         """Test nan is assigned for missing link between pfs and stps."""
         pfs_file = os.path.join('tests', 'data', 'positionfixes.csv')
         pfs = ti.read_positionfixes_csv(pfs_file, sep=';', tz='utc', index_col='id')
@@ -93,7 +93,7 @@ class TestGenerate_staypoints():
         pfs = ti.read_positionfixes_csv(pfs_file, sep=';', tz='utc', index_col='id')
         pfs, stps = pfs.as_positionfixes.generate_staypoints(method='sliding',
                                                              dist_threshold=25,
-                                                             time_threshold=5 * 60)
+                                                             time_threshold=5)
         assert pfs['user_id'].dtype == stps['user_id'].dtype
         assert pfs['staypoint_id'].dtype == "Int64"
         assert stps.index.dtype == "int64"
@@ -105,11 +105,11 @@ class TestGenerate_staypoints():
 
         _, stps_sliding = pfs_ori.as_positionfixes.generate_staypoints(method='sliding',
                                                                        dist_threshold=25,
-                                                                       time_threshold=300)
-        _, stps_dbscan = pfs_ori.as_positionfixes.generate_staypoints(method='dbscan')
+                                                                       time_threshold=5.0)
+        # _, stps_dbscan = pfs_ori.as_positionfixes.generate_staypoints(method='dbscan')
 
         assert (stps_sliding.index == np.arange(len(stps_sliding))).any()
-        assert (stps_dbscan.index == np.arange(len(stps_dbscan))).any()
+        # assert (stps_dbscan.index == np.arange(len(stps_dbscan))).any()
 
     def test_generate_staypoints_groupby_sliding(self):
         """Test the 'sliding' result obtained using user_id for loop (previous) with groupby.apply (current)."""
@@ -119,28 +119,28 @@ class TestGenerate_staypoints():
         # stps detection using groupby
         pfs_groupby, stps_groupby = pfs_ori.as_positionfixes.generate_staypoints(method='sliding',
                                                                                  dist_threshold=25,
-                                                                                 time_threshold=300)
+                                                                                 time_threshold=5.0)
         # stps detection using for loop
         pfs_for, stps_for = _generate_staypoints_original(pfs_ori,
                                                           method='sliding',
                                                           dist_threshold=25,
-                                                          time_threshold=300)
+                                                          time_threshold=5.0)
 
         pd.testing.assert_frame_equal(stps_groupby, stps_for, check_dtype=False)
         pd.testing.assert_frame_equal(pfs_groupby, pfs_for, check_dtype=False)
 
-    def test_generate_staypoints_groupby_dbscan(self):
-        """Test the 'dbscan' result obtained using user_id for loop (previous) with groupby.apply (current)."""
-        pfs_file = os.path.join('tests', 'data', 'positionfixes.csv')
-        pfs_ori = ti.read_positionfixes_csv(pfs_file, sep=';', tz='utc', index_col='id')
+    # def test_generate_staypoints_groupby_dbscan(self):
+    #     """Test the 'dbscan' result obtained using user_id for loop (previous) with groupby.apply (current)."""
+    #     pfs_file = os.path.join('tests', 'data', 'positionfixes.csv')
+    #     pfs_ori = ti.read_positionfixes_csv(pfs_file, sep=';', tz='utc', index_col='id')
 
-        # stps detection using groupby
-        pfs_groupby, stps_groupby = pfs_ori.as_positionfixes.generate_staypoints(method='dbscan')
-        # stps detection using for loop
-        pfs_for, stps_for = _generate_staypoints_original(pfs_ori, method='dbscan')
+    #     # stps detection using groupby
+    #     pfs_groupby, stps_groupby = pfs_ori.as_positionfixes.generate_staypoints(method='dbscan')
+    #     # stps detection using for loop
+    #     pfs_for, stps_for = _generate_staypoints_original(pfs_ori, method='dbscan')
 
-        pd.testing.assert_frame_equal(stps_groupby, stps_for, check_dtype=False)
-        pd.testing.assert_frame_equal(pfs_groupby, pfs_for, check_dtype=False)
+    #     pd.testing.assert_frame_equal(stps_groupby, stps_for, check_dtype=False)
+    #     pd.testing.assert_frame_equal(pfs_groupby, pfs_for, check_dtype=False)
 
 
 class TestGenerate_triplegs():

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -35,7 +35,7 @@ class TestGenerate_trips():
         # create trips from geolife (based on positionfixes)
         pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join('tests', 'data', 'geolife_long'))
         pfs, stps = pfs.as_positionfixes.generate_staypoints(method='sliding', dist_threshold=25,
-                                                             time_threshold=5 * 60)
+                                                             time_threshold=5.0)
         stps = stps.as_staypoints.create_activity_flag()
         pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps)
 
@@ -50,7 +50,7 @@ class TestGenerate_trips():
         pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join('tests', 'data', 'geolife_long'))
         pfs, stps = pfs.as_positionfixes.generate_staypoints(method='sliding',
                                                              dist_threshold=25,
-                                                             time_threshold=5 * 60)
+                                                             time_threshold=5.0)
         stps = stps.as_staypoints.create_activity_flag()
         pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps)
 
@@ -68,7 +68,7 @@ class TestGenerate_trips():
         pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join('tests', 'data', 'geolife_long'))
         pfs, stps = pfs.as_positionfixes.generate_staypoints(method='sliding',
                                                              dist_threshold=25,
-                                                             time_threshold=5 * 60)
+                                                             time_threshold=5.0)
         stps = stps.as_staypoints.create_activity_flag()
         pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps)
 
@@ -90,7 +90,7 @@ class TestGenerate_trips():
         pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join('tests', 'data', 'geolife_long'))
         pfs, stps = pfs.as_positionfixes.generate_staypoints(method='sliding',
                                                              dist_threshold=25,
-                                                             time_threshold=5 * 60)
+                                                             time_threshold=5.0)
         stps = stps.as_staypoints.create_activity_flag()
         pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps)
         
@@ -170,7 +170,7 @@ class TestGenerate_trips():
 
         # create trips from geolife (based on positionfixes)
         pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join('tests', 'data', 'geolife_long'))
-        pfs, stps = pfs.as_positionfixes.generate_staypoints(method='sliding', dist_threshold=25, time_threshold=5 * 60)
+        pfs, stps = pfs.as_positionfixes.generate_staypoints(method='sliding', dist_threshold=25, time_threshold=5.0)
         stps = stps.as_staypoints.create_activity_flag()
         pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps)
 

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -124,17 +124,13 @@ def generate_staypoints(positionfixes,
             # pfs with no stps receives nan in 'staypoint_id'
             ret_pfs = ret_pfs.join(temp, how='left')
             ret_spts.drop(columns={'pfs_id'}, inplace=True)
-        # if no staypoint is identified
+            
+        # if no staypoint at all is identified
         else:
             ret_pfs['staypoint_id'] = np.nan
     
-    ret_pfs = gpd.GeoDataFrame(ret_pfs, crs=ret_pfs.crs).set_geometry(geo_col)
-    ret_spts = gpd.GeoDataFrame(ret_spts, crs=ret_pfs.crs).set_geometry(geo_col)
-    
-    # sanity check for tripleg generation
-    assert len(spts_column) == len(ret_spts.columns), "Unexpected or missing column in staypoint generation"
-    for col in spts_column:
-        assert col in ret_spts.columns, "Unexpected columns in staypoint generation."
+    ret_pfs = gpd.GeoDataFrame(ret_pfs, geometry=geo_col, crs=ret_pfs.crs)
+    ret_spts = gpd.GeoDataFrame(ret_spts, columns=spts_column, geometry=geo_col, crs=ret_pfs.crs)
     # rearange column order
     ret_spts = ret_spts[spts_column]
                 


### PR DESCRIPTION

I checked [their](https://github.com/scikit-mobility/scikit-mobility/blob/master/skmob/preprocessing/detection.py) implementation, essentially they are also using the 2008 method, but considering [i, j] in time and [i, j) in space (median is used instead of mean for coordinates). I also went for this and maybe we add some description in the docs.
They added two minor improvements:
-  a gap threshold between consecutive pfs to determine whether to add a stp here. (Line 300-304).
- a speed threshold to delete the pfs with too high speed at the end of a stp. (not implemented here).

I slightly modified the structure (now using only one _for_) and tested using geolife. For one user it takes approx. 15s, which is quite fast I guess.

Known problems:
- the method only detects stps after the user steps out, so the last stp is always discarded. for `test_generate_staypoints_sliding_min` test this means it always generate `n-1` stp for `n` pfs. Proposed fix would be to add the last stp using a flag.
- we still have the matching problem between pfs and stp (they don't). Now the [i, j-1] pfs is considered as stp, although stp receives the [i, j] time. This means if we include the last pfs in stp in the tripleg generation (`generate_triplegs`), we will create overlapping time. See below (green stp ending time, red tpl starting time). The proposed fix would be not including the last pfs.
![image](https://user-images.githubusercontent.com/17105123/111979683-a8eaf580-8b05-11eb-8b70-7ad5374a059c.png)


other minor changes:
- time_threshold parameter now accepts minutes instead of seconds, some tests are changed.
- print_progress parameter is added to show a progress bar for user-level generation.
- DBSCAN method is deleted for now.

some tests still fails and I will wait until we discussed a solution for the above problems.