### PR TITLE
CLN: fix black error

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -5,6 +5,6 @@ import os
 
 class Test_examples:
     def test_example_preprocess_trajectories(self):
-        """checks if the example 'preprocess_trajectories' runs without errors """
+        """checks if the example 'preprocess_trajectories' runs without errors"""
 
         exec(open(os.path.join("examples", "preprocess_trajectories.py")).read())


### PR DESCRIPTION
Should fix the Lint Action error. The action we took will always pip install the newest version of black (current 21.4b2), which sometimes is not in line with our local version (my local version was 20.8b1). 

The current solution is to `pip uninstall black` then `pip install black` to force update the black version. 