### PR TITLE
ENH: Cleaner and faster trip generation

### DIFF
--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -530,13 +530,7 @@ def _generate_trips_user(df, gap_threshold):
     # if user ends generate last trip with unknown destination
     if (len(temp_trip_stack) > 0) and (_check_trip_stack_has_tripleg(temp_trip_stack)):
         destination_activity = unknown_activity
-        trip_ls.append(
-            _create_trip_from_stack(
-                temp_trip_stack,
-                origin_activity,
-                destination_activity,
-            )
-        )
+        trip_ls.append(_create_trip_from_stack(temp_trip_stack, origin_activity, destination_activity,))
 
     # print(trip_ls)
     trips = pd.DataFrame(trip_ls)

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -530,7 +530,13 @@ def _generate_trips_user(df, gap_threshold):
     # if user ends generate last trip with unknown destination
     if (len(temp_trip_stack) > 0) and (_check_trip_stack_has_tripleg(temp_trip_stack)):
         destination_activity = unknown_activity
-        trip_ls.append(_create_trip_from_stack(temp_trip_stack, origin_activity, destination_activity,))
+        trip_ls.append(
+            _create_trip_from_stack(
+                temp_trip_stack,
+                origin_activity,
+                destination_activity,
+            )
+        )
 
     # print(trip_ls)
     trips = pd.DataFrame(trip_ls)

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -5,8 +5,8 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
 from geopandas.testing import assert_geodataframe_equal
+from pandas.testing import assert_frame_equal
 from shapely.geometry import LineString, Point
 
 import trackintel as ti
@@ -95,22 +95,22 @@ class TestGenerate_trips:
 
         # prepare data
         pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join("tests", "data", "geolife_long"))
-        pfs, stps = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=25, time_threshold=5)
-        stps = stps.as_staypoints.create_activity_flag(time_threshold=15)
-        pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps)
+        pfs, spts = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=25, time_threshold=5)
+        spts = spts.as_staypoints.create_activity_flag(time_threshold=15)
+        pfs, tpls = pfs.as_positionfixes.generate_triplegs(spts)
 
         # accessor with only arguments (not allowed)
         with pytest.raises(AssertionError):
-            _, _, _ = tpls.as_triplegs.generate_trips(stps, 15)
+            _, _, _ = tpls.as_triplegs.generate_trips(spts, 15)
 
         # accessor with only keywords
-        stps_1, tpls_1, trips_1 = tpls.as_triplegs.generate_trips(stps_input=stps, gap_threshold=15)
+        spts_1, tpls_1, trips_1 = tpls.as_triplegs.generate_trips(spts=spts, gap_threshold=15)
 
         # accessor with mixed arguments/keywords
-        stps_2, tpls_2, trips_2 = tpls.as_triplegs.generate_trips(stps, gap_threshold=15)
+        spts_2, tpls_2, trips_2 = tpls.as_triplegs.generate_trips(spts, gap_threshold=15)
 
         # test if generated trips are equal (1,2)
-        assert_geodataframe_equal(stps_1, stps_2)
+        assert_geodataframe_equal(spts_1, spts_2)
         assert_geodataframe_equal(tpls_1, tpls_2)
         pd.testing.assert_frame_equal(trips_1, trips_2)
 

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -278,7 +278,7 @@ class TestGenerate_trips:
         ]
         for n, d in enumerate(spts_tpls):
             d["user_id"] = 0
-            d["started_at"] = start + n*h
+            d["started_at"] = start + n * h
             d["finished_at"] = d["started_at"] + h
         spts_tpls = pd.DataFrame(spts_tpls)
         spts = spts_tpls[spts_tpls["type"] == "staypoint"]

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -31,6 +31,7 @@ class TestSmoothen_triplegs:
 
 class TestGenerate_trips:
     """Tests for generate_trips() method."""
+
     def test_duplicate_columns(self):
         """Test if running the function twice, the generated column does not yield exception in join statement"""
         # create trips from geolife (based on positionfixes)
@@ -277,7 +278,7 @@ def _generate_trips_old(stps_input, tpls_input, gap_threshold=15, print_progress
     --------
     >>> staypoints, triplegs, trips = generate_trips(staypoints, triplegs)
     """
-    assert ("activity" in stps_input.columns), "staypoints need the column 'activities' to be able to generate trips"
+    assert "activity" in stps_input.columns, "staypoints need the column 'activities' to be able to generate trips"
 
     # we copy the input because we need to add a temporary column
     tpls = tpls_input.copy()
@@ -296,10 +297,12 @@ def _generate_trips_old(stps_input, tpls_input, gap_threshold=15, print_progress
     stps["type"] = "staypoint"
 
     # create table with relevant information from triplegs and staypoints.
-    stps_tpls = pd.concat([
-        stps[["started_at", "finished_at", "user_id", "type", "activity"]],
-        tpls[["started_at", "finished_at", "user_id", "type"]]
-    ])
+    stps_tpls = pd.concat(
+        [
+            stps[["started_at", "finished_at", "user_id", "type", "activity"]],
+            tpls[["started_at", "finished_at", "user_id", "type"]],
+        ]
+    )
 
     # create ID field from index
     stps_tpls["id"] = stps_tpls.index
@@ -315,14 +318,14 @@ def _generate_trips_old(stps_input, tpls_input, gap_threshold=15, print_progress
         tqdm.pandas(desc="User trip generation")
         trips = (
             stps_tpls.groupby(["user_id"], group_keys=False, as_index=False)
-                     .progress_apply(_generate_trips_user, gap_threshold=gap_threshold)
-                     .reset_index(drop=True)
+            .progress_apply(_generate_trips_user, gap_threshold=gap_threshold)
+            .reset_index(drop=True)
         )
     else:
         trips = (
             stps_tpls.groupby(["user_id"], group_keys=False, as_index=False)
-                     .apply(_generate_trips_user, gap_threshold=gap_threshold)
-                     .reset_index(drop=True)
+            .apply(_generate_trips_user, gap_threshold=gap_threshold)
+            .reset_index(drop=True)
         )
 
     # index management
@@ -476,13 +479,7 @@ def _generate_trips_user(df, gap_threshold):
     # if user ends generate last trip with unknown destination
     if (len(temp_trip_stack) > 0) and (_check_trip_stack_has_tripleg(temp_trip_stack)):
         destination_activity = unknown_activity
-        trip_ls.append(
-            _create_trip_from_stack(
-                temp_trip_stack,
-                origin_activity,
-                destination_activity,
-            )
-        )
+        trip_ls.append(_create_trip_from_stack(temp_trip_stack, origin_activity, destination_activity,))
 
     # print(trip_ls)
     trips = pd.DataFrame(trip_ls)

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -4,6 +4,7 @@ import os
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 from shapely.geometry import LineString, Point
 
@@ -42,7 +43,8 @@ class TestGenerate_trips:
 
         # generate trips and a joint staypoint/triplegs dataframe
         stps_run_1, tpls_run_1, _ = generate_trips(stps, tpls, gap_threshold=15)
-        stps_run_2, tpls_run_2, _ = generate_trips(stps_run_1, tpls_run_1, gap_threshold=15)
+        with pytest.warns(UserWarning):
+            stps_run_2, tpls_run_2, _ = generate_trips(stps_run_1, tpls_run_1, gap_threshold=15)
 
         assert set(tpls_run_1.columns) == set(tpls_run_2.columns)
         assert set(stps_run_1.columns) == set(stps_run_2.columns)

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 
 import geopandas as gpd
@@ -25,10 +26,8 @@ class TestSmoothen_triplegs:
         assert len(line1_smoothed.coords) == 4
         assert len(line2_smoothed.coords) == 3
 
-
 class TestGenerate_trips:
     """Tests for generate_trips() method."""
-
     def test_duplicate_columns(self):
         """Test if running the function twice, the generated column does not yield exception in join statement"""
         # load pregenerated trips
@@ -95,6 +94,25 @@ class TestGenerate_trips:
         assert stps["prev_trip_id"].dtype == "Int64"
         assert stps["next_trip_id"].dtype == "Int64"
         assert tpls["trip_id"].dtype == "Int64"
+
+    def test_compare_to_old_trip_function(self):
+        """Test if we can generate the example trips based on example data."""
+        # load pregenerated trips
+
+        # create trips from geolife (based on positionfixes)
+        pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join("tests", "data", "geolife_long"))
+        pfs, stps = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=25, time_threshold=5)
+        stps = stps.as_staypoints.create_activity_flag(time_threshold=15)
+        pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps)
+
+        # generate trips and a joint staypoint/triplegs dataframe
+        stps, tpls, trips = ti.preprocessing.triplegs.generate_trips(stps, tpls, gap_threshold=15)
+        stps_, tpls_, trips_ = _generate_trips_old(stps, tpls, gap_threshold=15)
+
+        # test if generated trips are equal
+        pd.testing.assert_frame_equal(trips, trips_)
+        pd.testing.assert_frame_equal(stps, stps_)
+        pd.testing.assert_frame_equal(tpls, tpls_)
 
     def test_generate_trips_index_start(self):
         """Test the generated index start from 0 for different methods."""
@@ -212,3 +230,329 @@ def _create_debug_stps_tpls_data(stps, tpls, gap_threshold):
     stps_tpls["gap"] = (stps_tpls["started_at_next"] - stps_tpls["finished_at"]).dt.seconds / 60 > gap_threshold
 
     return stps_tpls
+
+
+def _generate_trips_old(stps_input, tpls_input, gap_threshold=15, print_progress=False):
+    """Generate trips based on staypoints and triplegs.
+
+    Parameters
+    ----------
+    stps_input : GeoDataFrame (as trackintel staypoints)
+        The staypoints have to follow the standard definition for staypoints DataFrames.
+
+    tpls_input : GeoDataFrame (as trackintel triplegs)
+        The triplegs have to follow the standard definition for triplegs DataFrames.
+
+    gap_threshold : float, default 15 (minutes)
+        Maximum allowed temporal gap size in minutes. If tracking data is missing for more than
+        `gap_threshold` minutes, then a new trip begins after the gap.
+
+    Returns
+    -------
+    staypoints: GeoDataFrame (as trackintel staypoints)
+        the original staypoints with new columns ``[`trip_id`, `prev_trip_id`, `next_trip_id`]``.
+
+    triplegs: GeoDataFrame (as trackintel triplegs)
+        The original triplegs with a new column ``[`trip_id`]``.
+
+    trips: GeoDataFrame (as trackintel trips)
+        The generated trips.
+
+    Notes
+    -----
+    Trips are an aggregation level in transport planning that summarize all movement and all non-essential actions
+    (e.g., waiting) between two relevant activities.
+    The function returns altered versions of the input staypoints and triplegs. Staypoints receive the fields
+    [`trip_id` `prev_trip_id` and `next_trip_id`], triplegs receive the field [`trip_id`].
+    The following assumptions are implemented
+
+        - All movement before the first and after the last activity is omitted
+        - If we do not record a person for more than `gap_threshold` minutes, \
+            we assume that the person performed an activity in the recording gap and split the trip at the gap.
+        - Trips that start/end in a recording gap can have an unknown origin/destination
+        - There are no trips without a (recored) tripleg
+
+    Examples
+    --------
+    >>> staypoints, triplegs, trips = generate_trips(staypoints, triplegs)
+    """
+    assert (
+            "activity" in stps_input.columns
+    ), "staypoints need the column 'activities' \
+                                         to be able to generate trips"
+
+    # we copy the input because we need to add a temporary column
+    tpls = tpls_input.copy()
+    stps = stps_input.copy()
+
+    # if the triplegs already have a column "trip_id", we drop it
+    if "trip_id" in tpls:
+        tpls.drop(columns="trip_id", inplace=True)
+
+    # if the staypoints already have any of the columns  "trip_id", "prev_trip_id", "next_trip_id", we drop them
+    for col in ["trip_id", "prev_trip_id", "next_trip_id"]:
+        if col in stps:
+            stps.drop(columns=col, inplace=True)
+
+    tpls["type"] = "tripleg"
+    stps["type"] = "staypoint"
+
+    # create table with relevant information from triplegs and staypoints.
+    stps_tpls = stps[["started_at", "finished_at", "user_id", "type", "activity"]].append(
+        tpls[["started_at", "finished_at", "user_id", "type"]]
+    )
+
+    # create ID field from index
+    stps_tpls["id"] = stps_tpls.index
+
+    # transform nan to bool
+    stps_tpls["activity"] = stps_tpls["activity"] == True
+
+    stps_tpls.sort_values(by=["user_id", "started_at"], inplace=True)
+    stps_tpls["started_at_next"] = stps_tpls["started_at"].shift(-1)
+    stps_tpls["activity_next"] = stps_tpls["activity"].shift(-1)
+
+    if print_progress:
+        tqdm.pandas(desc="User trip generation")
+        trips = (
+            stps_tpls.groupby(["user_id"], group_keys=False, as_index=False)
+                .progress_apply(_generate_trips_user, gap_threshold=gap_threshold)
+                .reset_index(drop=True)
+        )
+    else:
+        trips = (
+            stps_tpls.groupby(["user_id"], group_keys=False, as_index=False)
+                .apply(_generate_trips_user, gap_threshold=gap_threshold)
+                .reset_index(drop=True)
+        )
+
+    # index management
+    trips["id"] = np.arange(len(trips))
+    trips.set_index("id", inplace=True)
+
+    # assign trip_id to tpls
+    trip2tpl_map = trips[["tpls"]].to_dict()["tpls"]
+    ls = []
+    for key, values in trip2tpl_map.items():
+        for value in values:
+            ls.append([value, key])
+    temp = pd.DataFrame(ls, columns=[tpls.index.name, "trip_id"]).set_index(tpls.index.name)
+    tpls = tpls.join(temp, how="left")
+
+    # assign trip_id to stps, for non-activity stps
+    trip2spt_map = trips[["stps"]].to_dict()["stps"]
+    ls = []
+    for key, values in trip2spt_map.items():
+        for value in values:
+            ls.append([value, key])
+    temp = pd.DataFrame(ls, columns=[stps.index.name, "trip_id"]).set_index(stps.index.name)
+    stps = stps.join(temp, how="left")
+
+    # assign prev_trip_id to stps
+    temp = trips[["destination_staypoint_id"]].copy()
+    temp.rename(columns={"destination_staypoint_id": stps.index.name}, inplace=True)
+    temp.index.name = "prev_trip_id"
+    temp = temp.reset_index().set_index(stps.index.name)
+    stps = stps.join(temp, how="left")
+
+    # assign next_trip_id to stps
+    temp = trips[["origin_staypoint_id"]].copy()
+    temp.rename(columns={"origin_staypoint_id": stps.index.name}, inplace=True)
+    temp.index.name = "next_trip_id"
+    temp = temp.reset_index().set_index(stps.index.name)
+    stps = stps.join(temp, how="left")
+
+    # final cleaning
+    tpls.drop(columns=["type"], inplace=True)
+    stps.drop(columns=["type"], inplace=True)
+    trips.drop(columns=["tpls", "stps"], inplace=True)
+
+    ## dtype consistency
+    # trips id (generated by this function) should be int64
+    trips.index = trips.index.astype("int64")
+    # trip id of stps and tpls can only be in Int64 (missing values)
+    stps["trip_id"] = stps["trip_id"].astype("Int64")
+    stps["prev_trip_id"] = stps["prev_trip_id"].astype("Int64")
+    stps["next_trip_id"] = stps["next_trip_id"].astype("Int64")
+    tpls["trip_id"] = tpls["trip_id"].astype("Int64")
+
+    # user_id of trips should be the same as tpls
+    trips["user_id"] = trips["user_id"].astype(tpls["user_id"].dtype)
+
+    return stps, tpls, trips
+
+
+def _generate_trips_user(df, gap_threshold):
+    # function called after groupby: should only contain records of one user
+    user_id = df["user_id"].unique()
+    assert len(user_id) == 1
+    user_id = user_id[0]
+
+    unknown_activity = {"user_id": user_id, "activity": True, "id": np.nan}
+    origin_activity = unknown_activity
+    temp_trip_stack = []
+    in_trip = False
+    trip_ls = []
+
+    for _, row in df.iterrows():
+
+        # check if we can start a new trip
+        # (we make sure that we start the trip with the most recent activity)
+        if in_trip is False:
+            # If there are several activities in a row, we skip until the last one
+            if row["activity"] and row["activity_next"]:
+                continue
+
+            # if this is the last activity before the trip starts, reset the origin
+            elif row["activity"]:
+                origin_activity = row
+                in_trip = True
+                continue
+
+            # if for non-activities we simply start the trip
+            else:
+                in_trip = True
+
+        if in_trip is True:
+            # during trip generation/recording
+
+            # check if trip ends regularly
+            if row["activity"] is True:
+
+                # if there are no triplegs in the trip, set the current activity as origin and start over
+                if not _check_trip_stack_has_tripleg(temp_trip_stack):
+                    origin_activity = row
+                    temp_trip_stack = list()
+                    in_trip = True
+
+                else:
+                    # record trip
+                    destination_activity = row
+                    trip_ls.append(_create_trip_from_stack(temp_trip_stack, origin_activity, destination_activity))
+
+                    # set values for next trip
+                    if row["started_at_next"] - row["finished_at"] > datetime.timedelta(minutes=gap_threshold):
+                        # if there is a gap after this trip the origin of the next trip is unknown
+                        origin_activity = unknown_activity
+                        destination_activity = None
+                        temp_trip_stack = list()
+                        in_trip = False
+
+                    else:
+                        # if there is no gap after this trip the origin of the next trip is the destination of the
+                        # current trip
+                        origin_activity = destination_activity
+                        destination_activity = None
+                        temp_trip_stack = list()
+                        in_trip = False
+
+            # check if gap during the trip
+            elif row["started_at_next"] - row["finished_at"] > datetime.timedelta(minutes=gap_threshold):
+                # in case of a gap, the destination of the current trip and the origin of the next trip
+                # are unknown.
+
+                # add current item to trip
+                temp_trip_stack.append(row)
+
+                # if the trip has no recored triplegs, we do not generate the current trip.
+                if not _check_trip_stack_has_tripleg(temp_trip_stack):
+                    origin_activity = unknown_activity
+                    in_trip = True
+                    temp_trip_stack = list()
+
+                else:
+                    # add tripleg to trip, generate trip, start new trip with unknown origin
+                    destination_activity = unknown_activity
+
+                    trip_ls.append(_create_trip_from_stack(temp_trip_stack, origin_activity, destination_activity))
+                    origin_activity = unknown_activity
+                    destination_activity = None
+                    temp_trip_stack = list()
+                    in_trip = True
+
+            else:
+                temp_trip_stack.append(row)
+
+    # if user ends generate last trip with unknown destination
+    if (len(temp_trip_stack) > 0) and (_check_trip_stack_has_tripleg(temp_trip_stack)):
+        destination_activity = unknown_activity
+        trip_ls.append(
+            _create_trip_from_stack(
+                temp_trip_stack,
+                origin_activity,
+                destination_activity,
+            )
+        )
+
+    # print(trip_ls)
+    trips = pd.DataFrame(trip_ls)
+    return trips
+
+
+def _check_trip_stack_has_tripleg(temp_trip_stack):
+    """
+    Check if a trip has at least 1 tripleg.
+
+    Parameters
+    ----------
+    temp_trip_stack : list
+        list of dictionary like elements (either pandas series or python dictionary).
+        Contains all elements that will be aggregated into a trip
+
+    Returns
+    -------
+    has_tripleg: Bool
+    """
+    has_tripleg = False
+    for row in temp_trip_stack:
+        if row["type"] == "tripleg":
+            has_tripleg = True
+            break
+
+    return has_tripleg
+
+
+def _create_trip_from_stack(temp_trip_stack, origin_activity, destination_activity):
+    """
+    Aggregate information of trip elements in a structured dictionary.
+
+    Parameters
+    ----------
+    temp_trip_stack : list
+        list of dictionary like elements (either pandas series or python dictionary).
+        Contains all elements that will be aggregated into a trip
+
+    origin_activity : dictionary like
+        Either dictionary or pandas series
+
+    destination_activity : dictionary like
+        Either dictionary or pandas series
+
+    Returns
+    -------
+    trip_dict_entry: dictionary
+
+    """
+    # this function return and empty dict if no tripleg is in the stack
+    first_trip_element = temp_trip_stack[0]
+    last_trip_element = temp_trip_stack[-1]
+
+    # all data has to be from the same user
+    assert origin_activity["user_id"] == last_trip_element["user_id"]
+
+    # double check if trip requirements are fulfilled
+    assert origin_activity["activity"] == True
+    assert destination_activity["activity"] == True
+    assert first_trip_element["activity"] == False
+
+    trip_dict_entry = {
+        "user_id": origin_activity["user_id"],
+        "started_at": first_trip_element["started_at"],
+        "finished_at": last_trip_element["finished_at"],
+        "origin_staypoint_id": origin_activity["id"],
+        "destination_staypoint_id": destination_activity["id"],
+        "tpls": [tripleg["id"] for tripleg in temp_trip_stack if tripleg["type"] == "tripleg"],
+        "stps": [tripleg["id"] for tripleg in temp_trip_stack if tripleg["type"] == "staypoint"],
+    }
+
+    return trip_dict_entry

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -1,7 +1,6 @@
 import pandas as pd
 
 import trackintel as ti
-import trackintel.preprocessing.filter
 import trackintel.visualization.triplegs
 
 
@@ -110,15 +109,15 @@ class TriplegsAccessor(object):
         See :func:`trackintel.preprocessing.triplegs.generate_trips`.
         """
         # if spts in kwargs: 'spts' can not be in args as it would be the first argument
-        if "stps_input" in kwargs:
-            return ti.preprocessing.triplegs.generate_trips(tpls_input=self._obj, **kwargs)
+        if "spts" in kwargs:
+            return ti.preprocessing.triplegs.generate_trips(tpls=self._obj, **kwargs)
         # if 'spts' no in kwargs it has to be the first argument in 'args'
         else:
             assert len(args) <= 1, (
                 "All arguments except 'stps_input' have to be given as keyword arguments. You gave"
                 f" {args[1:]} as positional arguments."
             )
-            return ti.preprocessing.triplegs.generate_trips(stps_input=args[0], tpls_input=self._obj, **kwargs)
+            return ti.preprocessing.triplegs.generate_trips(spts=args[0], tpls=self._obj, **kwargs)
 
     def predict_transport_mode(self, *args, **kwargs):
         """

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -202,7 +202,16 @@ def generate_trips(spts, tpls, gap_threshold=15):
     trips = trips_with_act[~trips_with_act["activity"]].copy()
 
     trips.drop(
-        ["type", "spts_tpls_id", "activity", "temp_trip_id", "prev_trip_id", "next_trip_id",], inplace=True, axis=1,
+        [
+            "type",
+            "spts_tpls_id",
+            "activity",
+            "temp_trip_id",
+            "prev_trip_id",
+            "next_trip_id",
+        ],
+        inplace=True,
+        axis=1,
     )
 
     # now handle the data that is aggregated in the trips

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -170,19 +170,18 @@ def generate_trips(spts, tpls, gap_threshold=15):
     # add gaps as activities, to simplify id assignment.
     gaps = pd.DataFrame(spts_tpls.loc[gap, "user_id"])
     gaps["started_at"] = spts_tpls.loc[gap, "finished_at"] + gap_threshold / 2
-    gaps[["type", "activity"]] = ["gap", True]
+    gaps[["type", "activity"]] = ["gap", True]  # nicer for debugging
 
     # same for user changes
     user_change = pd.DataFrame(spts_tpls.loc[condition_new_user, "user_id"])
     user_change["started_at"] = spts_tpls.loc[condition_new_user, "started_at"] - gap_threshold / 2
-    user_change[["type", "activity"]] = ["user_change", True]
+    user_change[["type", "activity"]] = ["user_change", True]  # nicer for debugging
 
     # merge trips with (filler) activities
     trips.drop(columns=["type", "spts_tpls_id"], inplace=True)  # make space so no overlap with activity "spts_tpls_id"
-
-    trips_with_act = pd.concat((trips, spts_tpls_only_act, gaps, user_change), axis=0, ignore_index=True)
     # Inserting `gaps` and `user_change` into the dataframe creates buffers that catch shifted
     # "staypoint_id" and "trip_id" from corrupting staypoints/trips.
+    trips_with_act = pd.concat((trips, spts_tpls_only_act, gaps, user_change), axis=0, ignore_index=True)
     trips_with_act.sort_values(["user_id", "started_at"], inplace=True)
 
     # ID assignment #
@@ -203,16 +202,7 @@ def generate_trips(spts, tpls, gap_threshold=15):
     trips = trips_with_act[~trips_with_act["activity"]].copy()
 
     trips.drop(
-        [
-            "type",
-            "spts_tpls_id",
-            "activity",
-            "temp_trip_id",
-            "prev_trip_id",
-            "next_trip_id",
-        ],
-        inplace=True,
-        axis=1,
+        ["type", "spts_tpls_id", "activity", "temp_trip_id", "prev_trip_id", "next_trip_id",], inplace=True, axis=1,
     )
 
     # now handle the data that is aggregated in the trips

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -1,5 +1,5 @@
-import warnings
 import copy
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -97,7 +97,7 @@ def generate_trips(spts, tpls, gap_threshold=15):
     # If the triplegs already have a column "trip_id", we drop it
     if "trip_id" in tpls:
         tpls.drop(columns="trip_id", inplace=True)
-        warnings.warn("Deleted column 'trip_id' from tpls.")
+        warnings.warn("Deleted existing column 'trip_id' from tpls.")
 
     # if the staypoints already have any of the columns "trip_id", "prev_trip_id", "next_trip_id", we drop them
     for col in ["trip_id", "prev_trip_id", "next_trip_id"]:

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -177,6 +177,8 @@ def generate_trips(spts, tpls, gap_threshold=15):
     trips.drop(columns=["type", "id"], inplace=True)  # make space so no overlap with activity "id"
     spts_tpls_only_act.drop(columns=["trip_id"])  # no overlap of activity trip_ids to real trip_ids in trips
     trips = pd.concat((trips, spts_tpls_only_act, gaps, user_change), axis=0, ignore_index=True)
+    # Inserting `gaps` and `user_change` into the dataframe we create buffers that catch shifted
+    # "staypoint_id" and "trip_id", finally they get deleted together with the other activities.
     trips = trips.sort_values(["user_id", "started_at"])
 
     # add origin/destination ids by shifting

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -177,8 +177,8 @@ def generate_trips(spts, tpls, gap_threshold=15):
     trips.drop(columns=["type", "id"], inplace=True)  # make space so no overlap with activity "id"
     spts_tpls_only_act.drop(columns=["trip_id"])  # no overlap of activity trip_ids to real trip_ids in trips
     trips = pd.concat((trips, spts_tpls_only_act, gaps, user_change), axis=0, ignore_index=True)
-    # Inserting `gaps` and `user_change` into the dataframe we create buffers that catch shifted
-    # "staypoint_id" and "trip_id", finally they get deleted together with the other activities.
+    # Inserting `gaps` and `user_change` into the dataframe creates buffers that catch shifted
+    # "staypoint_id" and "trip_id" from corrupting staypoints/trips.
     trips = trips.sort_values(["user_id", "started_at"])
 
     # add origin/destination ids by shifting

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -1,4 +1,3 @@
-import copy
 import warnings
 
 import numpy as np
@@ -159,9 +158,14 @@ def generate_trips(spts, tpls, gap_threshold=15):
         t = row_type == "tripleg"
         tpls_ids = row_id[t]
         spts_ids = row_id[~t]
+        # for dropping trips that don't have triplegs
+        tpls_ids = tpls_ids if len(tpls_ids) > 0 else None
         return [spts_ids, tpls_ids]
 
     trips[["spts", "tpls"]] = trips.apply(_seperate_ids, axis=1, result_type="expand")
+
+    # drop all trips that don't contain any triplegs
+    trips.dropna(subset=["tpls"], inplace=True)
 
     # recount trips ignoring empty trips and save trip_id as for id assignment.
     trips.reset_index(inplace=True, drop=True)


### PR DESCRIPTION
fixes #219

Main idea of the new implementation is that we assign a trip_ids to a combined dataframe of triplegs and staypoints so that we are able to create trips using a groupby statement that is based on the assigned trip id.

The implementation itself has several main steps:

0. Merge triplegs and staypoints into a single dataframe and sort them by [user_id, started_at]
1. identify start of new trips (activities, user change, temporal gaps) 
2. assign trip ids to all triplegs/staypoints that belong to a trip
3. delete activities as they are not part of trips
4. group by trip_id to create trips
5. add activities again to trip dataframe to assign origin_staypoint_id and destination_staypoint_id
6. delete activities again
7. Do some id stuff

Some tests are already passing but I have added the remaining todos in the code