### PR TITLE
ENH: gap_threshold for generate_stps

### DIFF
--- a/tests/preprocessing/test_staypoints.py
+++ b/tests/preprocessing/test_staypoints.py
@@ -108,7 +108,9 @@ class TestGenerate_locations:
         """Test with small epsilon parameter."""
         pfs_file = os.path.join("tests", "data", "positionfixes.csv")
         pfs = ti.read_positionfixes_csv(pfs_file, sep=";", tz="utc", index_col="id")
-        _, stps = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=0, time_threshold=0)
+        _, stps = pfs.as_positionfixes.generate_staypoints(
+            method="sliding", gap_threshold=1e6, dist_threshold=0, time_threshold=0
+        )
         _, locs_user = stps.as_staypoints.generate_locations(
             method="dbscan", epsilon=1e-18, num_samples=0, agg_level="user"
         )
@@ -123,7 +125,9 @@ class TestGenerate_locations:
         """Test with large epsilon parameter."""
         pfs_file = os.path.join("tests", "data", "positionfixes.csv")
         pfs = ti.read_positionfixes_csv(pfs_file, sep=";", tz="utc", index_col="id")
-        _, stps = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=0, time_threshold=0)
+        _, stps = pfs.as_positionfixes.generate_staypoints(
+            method="sliding", gap_threshold=1e6, dist_threshold=0, time_threshold=0
+        )
         _, locs_user = stps.as_staypoints.generate_locations(
             method="dbscan", epsilon=1e18, num_samples=1000, agg_level="user"
         )
@@ -138,7 +142,9 @@ class TestGenerate_locations:
         """Test nan is assigned for missing link between stps and locs."""
         pfs_file = os.path.join("tests", "data", "positionfixes.csv")
         pfs = ti.read_positionfixes_csv(pfs_file, sep=";", tz="utc", index_col="id")
-        _, stps = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=0, time_threshold=0)
+        _, stps = pfs.as_positionfixes.generate_staypoints(
+            method="sliding", gap_threshold=1e6, dist_threshold=0, time_threshold=0
+        )
         stps, _ = stps.as_staypoints.generate_locations(
             method="dbscan", epsilon=1e18, num_samples=1000, agg_level="user"
         )

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -56,7 +56,9 @@ class TestGenerate_trips:
 
         # create trips from geolife (based on positionfixes)
         pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join("tests", "data", "geolife_long"))
-        pfs, stps = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=25, time_threshold=5)
+        pfs, stps = pfs.as_positionfixes.generate_staypoints(
+            method="sliding", dist_threshold=25, time_threshold=5, gap_threshold=1e6
+        )
         stps = stps.as_staypoints.create_activity_flag(time_threshold=15)
         pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps)
 
@@ -231,7 +233,9 @@ class TestGenerate_trips:
 
         # create trips from geolife (based on positionfixes)
         pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join("tests", "data", "geolife_long"))
-        pfs, stps = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=25, time_threshold=5)
+        pfs, stps = pfs.as_positionfixes.generate_staypoints(
+            method="sliding", dist_threshold=25, time_threshold=5, gap_threshold=1e6
+        )
         stps = stps.as_staypoints.create_activity_flag(time_threshold=15)
         pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps)
 

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -15,7 +15,7 @@ def generate_staypoints(
     distance_metric="haversine",
     dist_threshold=100,
     time_threshold=5.0,
-    gap_threshold=1e6,
+    gap_threshold=15.0,
     include_last=False,
     print_progress=False,
 ):
@@ -41,12 +41,13 @@ def generate_staypoints(
     time_threshold : float, default 5.0 (minutes)
         The time threshold for the 'sliding' method in minutes.
 
-    gap_threshold : float, default 1e6 (minutes)
-        The time threshold of determine whether a gap exists between consecutive pfs. Staypoints
-        will not be generated between gaps. Only valid in 'sliding' method.
+    gap_threshold : float, default 15.0 (minutes)
+        The time threshold of determine whether a gap exists between consecutive pfs. Consecutive pfs with
+        temporal gaps larger than 'gap_threshold' will be excluded from staypoints generation.
+        Only valid in 'sliding' method.
 
     include_last: boolen, default False
-        The original algorithm (see Li et al. (2008)) only detects staypoint if the user steps out
+        The algorithm in Li et al. (2008) only detects staypoint if the user steps out
         of that staypoint. This will omit the last staypoint (if any). Set 'include_last'
         to True to include this last staypoint.
 
@@ -65,9 +66,9 @@ def generate_staypoints(
     -----
     The 'sliding' method is adapted from Li et al. (2008). In the original algorithm, the 'finished_at'
     time for the current staypoint lasts until the 'tracked_at' time of the first positionfix outside
-    this staypoint. This implies potential tracking gaps may be included in staypoints, and users
-    are assumed to be stationary during this missing period. To avoid including too large gaps, set
-    'gap_threshold' parameter to a small value, e.g., 15 min.
+    this staypoint. Users are assumed to be stationary during this missing period and potential tracking
+    gaps may be included in staypoints. To avoid including too large missing signal gaps, set 'gap_threshold'
+    to a small value, e.g., 15 min.
 
     Examples
     --------
@@ -413,7 +414,7 @@ def _generate_staypoints_sliding_user(
             # the duration of gap in the last two pfs
             gap_t = (pfs[curr]["tracked_at"] - pfs[curr - 1]["tracked_at"]).total_seconds()
 
-            # we want the spt to have long duration, but the gap of missing signal should not be too long
+            # we want the spt to have long duration, but the gap of two consecutive pfs should not be too long
             if (delta_t >= (time_threshold * 60)) and (gap_t < gap_threshold * 60):
                 new_stps = __create_new_staypoints(start, curr, pfs, idx, elevation_flag, geo_col)
                 # add staypoint

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -414,7 +414,8 @@ def _generate_staypoints_sliding_user(
             # the duration of gap in the last two pfs
             gap_t = (pfs[curr]["tracked_at"] - pfs[curr - 1]["tracked_at"]).total_seconds()
 
-            # we want the spt to have long duration, but the gap of two consecutive pfs should not be too long
+            # we want the staypoint to have long duration,
+            # but the gap of two consecutive positionfixes should not be too long
             if (delta_t >= (time_threshold * 60)) and (gap_t < gap_threshold * 60):
                 new_stps = __create_new_staypoints(start, curr, pfs, idx, elevation_flag, geo_col)
                 # add staypoint


### PR DESCRIPTION
closes #245

`gap_threshold` now default to 15 minutes. If signal is missing larger than `gap_threshold`, no staypoint will be generated. An example is given below. The signal between 469 and 470 is missing for several hours; originally this will generate a staypoint with a long duration, but setting `gap_threshold=15` will ignore this staypoint.
![image](https://user-images.githubusercontent.com/17105123/122535713-1b477500-d024-11eb-9ef5-129459843be6.png)

Some of our old test functions only worked when setting `gap_threshold` large. 
We have a test function `test_temporal` to test the different combinations of `time_threshold` and `gap_threshold`
