### PR TITLE
BLD: restrct pandas version - fix test error

### DIFF
--- a/ci/envs/37-latest-conda-forge.yaml
+++ b/ci/envs/37-latest-conda-forge.yaml
@@ -6,7 +6,7 @@ dependencies:
 - python=3.7
 - matplotlib
 - numpy
-- pandas
+- pandas<=1.2.5
 - geopandas
 - scikit-learn
 - networkx 

--- a/ci/envs/38-latest-conda-forge.yaml
+++ b/ci/envs/38-latest-conda-forge.yaml
@@ -6,7 +6,7 @@ dependencies:
 - python=3.8
 - matplotlib
 - numpy
-- pandas
+- pandas<=1.2.5
 - geopandas
 - scikit-learn
 - networkx 

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -6,7 +6,7 @@ dependencies:
 - python=3.9
 - matplotlib
 - numpy
-- pandas
+- pandas<=1.2.5
 - geopandas
 - scikit-learn
 - networkx 


### PR DESCRIPTION
The github action error originated from a **pandas** [update](https://github.com/pandas-dev/pandas/issues/42356) and triggered a **tqdm** function [calling error](https://github.com/tqdm/tqdm/issues/1199).

This shall be solved in the next **tqdm** release [next release v4.61.2 #1180](https://github.com/tqdm/tqdm/pull/1180), until then we could limit our **pandas** version to **pandas <= 1.2.5**

Also, the **numpy** update to v1.21 introduces new warnings in our test function [DEP: Deprecate error clearing for special method in array-coercion #19001](https://github.com/numpy/numpy/pull/19001), which _I think_ relates to **shapely** methods. We need to wait for **shapely** to suppress the warnings