### PR TITLE
ENH: Update read_*_postgis functions.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -39,7 +39,7 @@ You can import one of these by executing the following steps::
     conn_string = 'postgresql://test:1234@localhost:5432/' + database_name
 
     pfs = ti.read_positionfixes_csv('examples/data/posmo_trajectory_2.csv', sep=';')
-    pfs.as_positionfixes.to_postgis(conn_string, 'positionfixes', if_exists='append')
+    pfs.as_positionfixes.to_postgis('positionfixes', conn_string, if_exists='append')
 
 This will fill the positionfixes of ``posmo_trajectory_2.csv`` into the table
 ``positionfixes`` of the database ``trackintel-tests``. Make sure that you update the

--- a/examples/import_export_postgis.py
+++ b/examples/import_export_postgis.py
@@ -17,8 +17,8 @@ conn_string = "postgresql://test:1234@localhost:5432/trackintel-tests"
 
 # Geolife trajectory to PostGIS.
 pfs = ti.read_positionfixes_csv("examples/data/geolife_trajectory.csv", sep=";")
-# pfs.as_positionfixes.to_postgis(conn_string, 'positionfixes')
+# pfs.as_positionfixes.to_postgis('positionfixes', conn_string)
 
 # Geolife trajectory from PostGIS.
-# pfs = ti.read_positionfixes_postgis(conn_string, 'positionfixes')
+# pfs = ti.io.read_positionfixes_postgis('positionfixes', conn_string)
 pfs.as_positionfixes.plot()

--- a/examples/setup_example_database.py
+++ b/examples/setup_example_database.py
@@ -33,6 +33,6 @@ except Exception as e:
 # Now we fill in some new data.
 conn_string = "postgresql://test:1234@localhost:5432/" + database_name
 pfs = ti.read_positionfixes_csv("data/posmo_trajectory_2.csv", sep=";")
-pfs.as_positionfixes.to_postgis(conn_string, "positionfixes", if_exists="append")
+pfs.as_positionfixes.to_postgis("positionfixes", conn_string, if_exists="append")
 
 # We use the trackintel functionality to fill consecutive tables.

--- a/tests/io/test_file.py
+++ b/tests/io/test_file.py
@@ -74,10 +74,6 @@ class TestPositionfixes:
         pfs = ti.read_positionfixes_csv(file, sep=";", index_col=None)
         assert pfs.index.name is None
 
-    def test_from_to_postgis(self):
-        # TODO Implement some tests for PostGIS.
-        pass
-
 
 class TestTriplegs:
     """Test for 'read_triplegs_csv' and 'write_triplegs_csv' functions."""
@@ -148,10 +144,6 @@ class TestTriplegs:
         pfs = ti.read_triplegs_csv(file, sep=";", index_col=None)
         assert pfs.index.name is None
 
-    def test_from_to_postgis(self):
-        # TODO Implement some tests for PostGIS.
-        pass
-
 
 class TestStaypoints:
     """Test for 'read_staypoints_csv' and 'write_staypoints_csv' functions."""
@@ -219,10 +211,6 @@ class TestStaypoints:
         pfs = ti.read_staypoints_csv(file, sep=";", index_col=None)
         assert pfs.index.name is None
 
-    def test_from_to_postgis(self):
-        # TODO Implement some tests for PostGIS.
-        pass
-
 
 class TestLocations:
     """Test for 'read_locations_csv' and 'write_locations_csv' functions."""
@@ -263,10 +251,6 @@ class TestLocations:
         assert pfs.index.name == ind_name
         pfs = ti.read_locations_csv(file, sep=";", index_col=None)
         assert pfs.index.name is None
-
-    def test_from_to_postgis(self):
-        # TODO Implement some tests for PostGIS.
-        pass
 
 
 class TestTrips:
@@ -326,14 +310,8 @@ class TestTrips:
         gdf = ti.read_trips_csv(file, sep=";", index_col=None)
         assert gdf.index.name is None
 
-    def test_from_to_postgis(self):
-        # TODO Implement some tests for PostGIS.
-        pass
-
 
 class TestTours:
     """Test for 'read_tours_csv' and 'write_tours_csv' functions."""
 
-    def test_from_to_postgis(self):
-        # TODO Implement some tests for reading and writing tours.
-        pass
+    pass

--- a/tests/io/test_postgis_gpd.py
+++ b/tests/io/test_postgis_gpd.py
@@ -502,7 +502,7 @@ class Test_Handle_Con_String:
 
     def test_conn(self, conn_postgis):
         """Test handeling of connection input"""
-        _ , conn = conn_postgis
+        _, conn = conn_postgis
 
         @ti.io.postgis._handle_con_string
         def wrapped(con):

--- a/tests/io/test_postgis_gpd.py
+++ b/tests/io/test_postgis_gpd.py
@@ -58,11 +58,11 @@ def example_positionfixes():
     t3 = pd.Timestamp("1971-01-02 07:00:00", tz="utc")
 
     list_dict = [
-        {"user_id": 0, "tracked_at": t1, "geometry": p1},
-        {"user_id": 0, "tracked_at": t2, "geometry": p2},
-        {"user_id": 1, "tracked_at": t3, "geometry": p3},
+        {"user_id": 0, "tracked_at": t1, "geom": p1},
+        {"user_id": 0, "tracked_at": t2, "geom": p2},
+        {"user_id": 1, "tracked_at": t3, "geom": p3},
     ]
-    pfs = gpd.GeoDataFrame(data=list_dict, geometry="geometry", crs="EPSG:4326")
+    pfs = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
     pfs.index.name = "id"
     assert pfs.as_positionfixes
     return pfs
@@ -81,11 +81,11 @@ def example_staypoints():
     one_hour = datetime.timedelta(hours=1)
 
     list_dict = [
-        {"user_id": 0, "started_at": t1, "finished_at": t2, "geometry": p1},
-        {"user_id": 0, "started_at": t2, "finished_at": t3, "geometry": p2},
-        {"user_id": 1, "started_at": t3, "finished_at": t3 + one_hour, "geometry": p3},
+        {"user_id": 0, "started_at": t1, "finished_at": t2, "geom": p1},
+        {"user_id": 0, "started_at": t2, "finished_at": t3, "geom": p2},
+        {"user_id": 1, "started_at": t3, "finished_at": t3 + one_hour, "geom": p3},
     ]
-    stps = gpd.GeoDataFrame(data=list_dict, geometry="geometry", crs="EPSG:4326")
+    stps = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
     stps.index.name = "id"
     assert stps.as_staypoints
     return stps
@@ -105,12 +105,12 @@ def example_triplegs():
     one_hour = datetime.timedelta(hours=1)
 
     list_dict = [
-        {"id": 0, "user_id": 0, "started_at": t1, "finished_at": t2, "geometry": g1},
-        {"id": 1, "user_id": 0, "started_at": t2, "finished_at": t3, "geometry": g2},
-        {"id": 2, "user_id": 1, "started_at": t3, "finished_at": t3 + one_hour, "geometry": g3},
+        {"id": 0, "user_id": 0, "started_at": t1, "finished_at": t2, "geom": g1},
+        {"id": 1, "user_id": 0, "started_at": t2, "finished_at": t3, "geom": g2},
+        {"id": 2, "user_id": 1, "started_at": t3, "finished_at": t3 + one_hour, "geom": g3},
     ]
 
-    tpls = gpd.GeoDataFrame(data=list_dict, geometry="geometry", crs="EPSG:4326")
+    tpls = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
     tpls.set_index("id", inplace=True)
 
     assert tpls.as_triplegs
@@ -247,12 +247,14 @@ class TestPositionfixes:
         pfs = example_positionfixes.copy()
         conn_string, conn = conn_postgis
         table = "positionfixes"
+        sql = f"SELECT * FROM {table}"
         geom_col = pfs.geometry.name
 
         try:
             pfs.as_positionfixes.to_postgis(conn_string, table)
-            pfs_db = ti.io.read_positionfixes_postgis(conn_string, table, geom_col)
+            pfs_db = ti.io.read_positionfixes_postgis(sql, conn_string, geom_col)
             pfs_db = pfs_db.set_index("id")
+            print(pfs_db)
             assert_geodataframe_equal(pfs, pfs_db)
         finally:
             del_table(conn, table)
@@ -262,11 +264,12 @@ class TestPositionfixes:
         pfs = example_positionfixes.copy()
         conn_string, conn = conn_postgis
         table = "positionfixes"
+        sql = f"SELECT * FROM {table}"
         geom_col = pfs.geometry.name
         pfs.crs = None
         try:
             pfs.as_positionfixes.to_postgis(conn_string, table)
-            pfs_db = ti.io.read_positionfixes_postgis(conn_string, table, geom_col)
+            pfs_db = ti.io.read_positionfixes_postgis(sql, conn_string, geom_col)
             pfs_db = pfs_db.set_index("id")
             assert_geodataframe_equal(pfs, pfs_db)
         finally:
@@ -296,11 +299,12 @@ class TestStaypoints:
         spts = example_staypoints.copy()
         conn_string, conn = conn_postgis
         table = "staypoints"
+        sql = f"SELECT * FROM {table}"
         geom_col = spts.geometry.name
 
         try:
             spts.as_staypoints.to_postgis(conn_string, table)
-            spts_db = ti.io.read_staypoints_postgis(conn_string, table, geom_col)
+            spts_db = ti.io.read_staypoints_postgis(sql, conn_string, geom_col)
             assert_geodataframe_equal(spts, spts_db)
         finally:
             del_table(conn, table)
@@ -310,11 +314,12 @@ class TestStaypoints:
         spts = example_staypoints.copy()
         conn_string, conn = conn_postgis
         table = "staypoints"
+        sql = f"SELECT * FROM {table}"
         geom_col = example_staypoints.geometry.name
         spts.crs = None
         try:
             spts.as_staypoints.to_postgis(conn_string, table)
-            spts_db = ti.io.read_staypoints_postgis(conn_string, table, geom_col)
+            spts_db = ti.io.read_staypoints_postgis(sql, conn_string, geom_col)
             assert_geodataframe_equal(spts, spts_db)
         finally:
             del_table(conn, table)
@@ -343,11 +348,12 @@ class TestTriplegs:
         tpls = example_triplegs.copy()
         conn_string, conn = conn_postgis
         table = "triplegs"
+        sql = f"SELECT * FROM {table}"
         geom_col = tpls.geometry.name
 
         try:
             tpls.as_triplegs.to_postgis(conn_string, table)
-            tpls_db = ti.io.read_triplegs_postgis(conn_string, table, geom_col)
+            tpls_db = ti.io.read_triplegs_postgis(sql, conn_string, geom_col)
             assert_geodataframe_equal(tpls, tpls_db)
         finally:
             del_table(conn, table)
@@ -357,12 +363,13 @@ class TestTriplegs:
         tpls = example_triplegs.copy()
         conn_string, conn = conn_postgis
         table = "triplegs"
+        sql = f"SELECT * FROM {table}"
         geom_col = tpls.geometry.name
         tpls.crs = None
 
         try:
             tpls.as_triplegs.to_postgis(conn_string, table)
-            tpls_db = ti.io.read_triplegs_postgis(conn_string, table, geom_col)
+            tpls_db = ti.io.read_triplegs_postgis(sql, conn_string, geom_col)
             assert_geodataframe_equal(tpls, tpls_db)
         finally:
             del_table(conn, table)
@@ -391,11 +398,12 @@ class TestLocations:
         locs = example_locations.copy()
         conn_string, conn = conn_postgis
         table = "locations"
+        sql = f"SELECT * FROM {table}"
         geom_col = locs.geometry.name
 
         try:
             locs.as_locations.to_postgis(conn_string, table)
-            locs_db = ti.io.read_locations_postgis(conn_string, table, geom_col)
+            locs_db = ti.io.read_locations_postgis(sql, conn_string, geom_col)
             assert_geodataframe_equal(locs, locs_db)
         finally:
             del_table(conn, table)
@@ -405,11 +413,12 @@ class TestLocations:
         locs = example_locations.copy()
         conn_string, conn = conn_postgis
         table = "locations"
+        sql = f"SELECT * FROM {table}"
         geom_col = locs.geometry.name
         locs.crs = None
         try:
             locs.as_locations.to_postgis(conn_string, table)
-            locs_db = ti.io.read_locations_postgis(conn_string, table, geom_col)
+            locs_db = ti.io.read_locations_postgis(sql, conn_string, geom_col)
             assert_geodataframe_equal(locs, locs_db)
         finally:
             del_table(conn, table)
@@ -420,8 +429,8 @@ class TestLocations:
         table = "locations"
         coords = [[8.45, 47.6], [8.45, 47.4], [8.55, 47.4], [8.55, 47.6], [8.45, 47.6]]
         extent = Polygon(coords)
-        example_locations["extent"] = extent
-        example_locations["extent"] = gpd.GeoSeries(example_locations["extent"])
+        example_locations["extent"] = extent  # broadcasting
+        example_locations["extent"] = gpd.GeoSeries(example_locations["extent"])  # dtype
         try:
             example_locations.as_locations.to_postgis(conn_string, table)
             columns_db, dtypes = get_table_schema(conn, table)
@@ -457,10 +466,11 @@ class TestTrips:
         trips = example_trips.copy()
         conn_string, conn = conn_postgis
         table = "trips"
+        sql = f"SELECT * FROM {table}"
 
         try:
             trips.as_trips.to_postgis(conn_string, table)
-            trips_db = ti.io.read_trips_postgis(conn_string, table)
+            trips_db = ti.io.read_trips_postgis(sql, conn_string)
             assert_frame_equal(trips, trips_db)
         finally:
             del_table(conn, table)

--- a/tests/io/test_postgis_gpd.py
+++ b/tests/io/test_postgis_gpd.py
@@ -487,6 +487,7 @@ class Test_Handle_Con_String:
             assert isinstance(con, sqlalchemy.engine.Connection)
             assert not con.closed
             return con
+
         assert wrapped(conn_string).closed
 
     def test_conn(self, conn_postgis):
@@ -497,5 +498,7 @@ class Test_Handle_Con_String:
         def wrapped(con):
             assert con is conn
             return
+
         wrapped(conn)
+
     pass

--- a/tests/io/test_postgis_gpd.py
+++ b/tests/io/test_postgis_gpd.py
@@ -8,6 +8,7 @@ import pytest
 from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_frame_equal
 from shapely.geometry import LineString, Point, Polygon
+import sqlalchemy
 import trackintel as ti
 
 
@@ -474,3 +475,27 @@ class TestGetSrid:
         srid = 3857
         gdf.set_crs(f"epsg:{srid}", inplace=True)
         assert _get_srid(gdf) == srid
+
+
+class Test_Handle_Con_String:
+    def test_conn_string(self, conn_postgis):
+        """Test if decorator opens a connection with connection string and closes it."""
+        conn_string, conn = conn_postgis
+
+        @ti.io.postgis._handle_con_string
+        def wrapped(con):
+            assert isinstance(con, sqlalchemy.engine.Connection)
+            assert not con.closed
+            return con
+        assert wrapped(conn_string).closed
+
+    def test_conn(self, conn_postgis):
+        """Test handeling of connection input"""
+        conn_string, conn = conn_postgis
+
+        @ti.io.postgis._handle_con_string
+        def wrapped(con):
+            assert con is conn
+            return
+        wrapped(conn)
+    pass

--- a/tests/io/test_postgis_gpd.py
+++ b/tests/io/test_postgis_gpd.py
@@ -490,7 +490,7 @@ class TestGetSrid:
 class Test_Handle_Con_String:
     def test_conn_string(self, conn_postgis):
         """Test if decorator opens a connection with connection string and closes it."""
-        conn_string, conn = conn_postgis
+        conn_string, _ = conn_postgis
 
         @ti.io.postgis._handle_con_string
         def wrapped(con):
@@ -502,7 +502,7 @@ class Test_Handle_Con_String:
 
     def test_conn(self, conn_postgis):
         """Test handeling of connection input"""
-        conn_string, conn = conn_postgis
+        _ , conn = conn_postgis
 
         @ti.io.postgis._handle_con_string
         def wrapped(con):

--- a/tests/io/test_postgis_gpd.py
+++ b/tests/io/test_postgis_gpd.py
@@ -231,7 +231,7 @@ class TestPositionfixes:
         conn_string, conn = conn_postgis
         table = "positionfixes"
         try:
-            pfs.as_positionfixes.to_postgis(conn_string, table)
+            pfs.as_positionfixes.to_postgis(table, conn_string)
             columns_db, dtypes = get_table_schema(conn, table)
             columns = pfs.columns.tolist() + [pfs.index.name]
             assert len(columns_db) == len(columns)
@@ -251,7 +251,7 @@ class TestPositionfixes:
         geom_col = pfs.geometry.name
 
         try:
-            pfs.as_positionfixes.to_postgis(conn_string, table)
+            pfs.as_positionfixes.to_postgis(table, conn_string)
             pfs_db = ti.io.read_positionfixes_postgis(sql, conn_string, geom_col)
             pfs_db = pfs_db.set_index("id")
             print(pfs_db)
@@ -268,59 +268,10 @@ class TestPositionfixes:
         geom_col = pfs.geometry.name
         pfs.crs = None
         try:
-            pfs.as_positionfixes.to_postgis(conn_string, table)
+            pfs.as_positionfixes.to_postgis(table, conn_string)
             pfs_db = ti.io.read_positionfixes_postgis(sql, conn_string, geom_col)
             pfs_db = pfs_db.set_index("id")
             assert_geodataframe_equal(pfs, pfs_db)
-        finally:
-            del_table(conn, table)
-
-
-class TestStaypoints:
-    def test_write(self, example_staypoints, conn_postgis):
-        """Test if write of staypoints create correct schema in database."""
-        spts = example_staypoints.copy()
-        conn_string, conn = conn_postgis
-        table = "staypoints"
-        try:
-            spts.as_staypoints.to_postgis(conn_string, table)
-            columns_db, dtypes = get_table_schema(conn, table)
-            columns = spts.columns.tolist() + [spts.index.name]
-            assert len(columns_db) == len(columns)
-            assert set(columns_db) == set(columns)
-            srid = _get_srid(spts)
-            geom_schema = f"geometry(Point,{srid})"
-            assert geom_schema in dtypes
-        finally:
-            del_table(conn, table)
-
-    def test_read(self, example_staypoints, conn_postgis):
-        """Test if staypoints written to and read back from database are the same."""
-        spts = example_staypoints.copy()
-        conn_string, conn = conn_postgis
-        table = "staypoints"
-        sql = f"SELECT * FROM {table}"
-        geom_col = spts.geometry.name
-
-        try:
-            spts.as_staypoints.to_postgis(conn_string, table)
-            spts_db = ti.io.read_staypoints_postgis(sql, conn_string, geom_col)
-            assert_geodataframe_equal(spts, spts_db)
-        finally:
-            del_table(conn, table)
-
-    def test_no_crs(self, example_staypoints, conn_postgis):
-        """Test if writing reading to postgis also works correctly without CRS."""
-        spts = example_staypoints.copy()
-        conn_string, conn = conn_postgis
-        table = "staypoints"
-        sql = f"SELECT * FROM {table}"
-        geom_col = example_staypoints.geometry.name
-        spts.crs = None
-        try:
-            spts.as_staypoints.to_postgis(conn_string, table)
-            spts_db = ti.io.read_staypoints_postgis(sql, conn_string, geom_col)
-            assert_geodataframe_equal(spts, spts_db)
         finally:
             del_table(conn, table)
 
@@ -332,7 +283,7 @@ class TestTriplegs:
         conn_string, conn = conn_postgis
         table = "triplegs"
         try:
-            tpls.as_triplegs.to_postgis(conn_string, table)
+            tpls.as_triplegs.to_postgis(table, conn_string)
             columns_db, dtypes = get_table_schema(conn, table)
             columns = tpls.columns.tolist() + [tpls.index.name]
             assert len(columns_db) == len(columns)
@@ -352,7 +303,7 @@ class TestTriplegs:
         geom_col = tpls.geometry.name
 
         try:
-            tpls.as_triplegs.to_postgis(conn_string, table)
+            tpls.as_triplegs.to_postgis(table, conn_string)
             tpls_db = ti.io.read_triplegs_postgis(sql, conn_string, geom_col)
             assert_geodataframe_equal(tpls, tpls_db)
         finally:
@@ -368,9 +319,58 @@ class TestTriplegs:
         tpls.crs = None
 
         try:
-            tpls.as_triplegs.to_postgis(conn_string, table)
+            tpls.as_triplegs.to_postgis(table, conn_string)
             tpls_db = ti.io.read_triplegs_postgis(sql, conn_string, geom_col)
             assert_geodataframe_equal(tpls, tpls_db)
+        finally:
+            del_table(conn, table)
+
+
+class TestStaypoints:
+    def test_write(self, example_staypoints, conn_postgis):
+        """Test if write of staypoints create correct schema in database."""
+        spts = example_staypoints.copy()
+        conn_string, conn = conn_postgis
+        table = "staypoints"
+        try:
+            spts.as_staypoints.to_postgis(table, conn_string)
+            columns_db, dtypes = get_table_schema(conn, table)
+            columns = spts.columns.tolist() + [spts.index.name]
+            assert len(columns_db) == len(columns)
+            assert set(columns_db) == set(columns)
+            srid = _get_srid(spts)
+            geom_schema = f"geometry(Point,{srid})"
+            assert geom_schema in dtypes
+        finally:
+            del_table(conn, table)
+
+    def test_read(self, example_staypoints, conn_postgis):
+        """Test if staypoints written to and read back from database are the same."""
+        spts = example_staypoints.copy()
+        conn_string, conn = conn_postgis
+        table = "staypoints"
+        sql = f"SELECT * FROM {table}"
+        geom_col = spts.geometry.name
+
+        try:
+            spts.as_staypoints.to_postgis(table, conn_string)
+            spts_db = ti.io.read_staypoints_postgis(sql, conn_string, geom_col)
+            assert_geodataframe_equal(spts, spts_db)
+        finally:
+            del_table(conn, table)
+
+    def test_no_crs(self, example_staypoints, conn_postgis):
+        """Test if writing reading to postgis also works correctly without CRS."""
+        spts = example_staypoints.copy()
+        conn_string, conn = conn_postgis
+        table = "staypoints"
+        sql = f"SELECT * FROM {table}"
+        geom_col = example_staypoints.geometry.name
+        spts.crs = None
+        try:
+            spts.as_staypoints.to_postgis(table, conn_string)
+            spts_db = ti.io.read_staypoints_postgis(sql, conn_string, geom_col)
+            assert_geodataframe_equal(spts, spts_db)
         finally:
             del_table(conn, table)
 
@@ -382,7 +382,7 @@ class TestLocations:
         conn_string, conn = conn_postgis
         table = "locations"
         try:
-            locs.as_locations.to_postgis(conn_string, table)
+            locs.as_locations.to_postgis(table, conn_string)
             columns_db, dtypes = get_table_schema(conn, table)
             columns = locs.columns.tolist() + [locs.index.name]
             assert len(columns_db) == len(columns)
@@ -402,7 +402,7 @@ class TestLocations:
         geom_col = locs.geometry.name
 
         try:
-            locs.as_locations.to_postgis(conn_string, table)
+            locs.as_locations.to_postgis(table, conn_string)
             locs_db = ti.io.read_locations_postgis(sql, conn_string, geom_col)
             assert_geodataframe_equal(locs, locs_db)
         finally:
@@ -417,7 +417,7 @@ class TestLocations:
         geom_col = locs.geometry.name
         locs.crs = None
         try:
-            locs.as_locations.to_postgis(conn_string, table)
+            locs.as_locations.to_postgis(table, conn_string)
             locs_db = ti.io.read_locations_postgis(sql, conn_string, geom_col)
             assert_geodataframe_equal(locs, locs_db)
         finally:
@@ -432,7 +432,7 @@ class TestLocations:
         example_locations["extent"] = extent  # broadcasting
         example_locations["extent"] = gpd.GeoSeries(example_locations["extent"])  # dtype
         try:
-            example_locations.as_locations.to_postgis(conn_string, table)
+            example_locations.as_locations.to_postgis(table, conn_string)
             columns_db, dtypes = get_table_schema(conn, table)
             columns = example_locations.columns.tolist() + [example_locations.index.name]
             assert len(columns_db) == len(columns)
@@ -453,7 +453,7 @@ class TestTrips:
         conn_string, conn = conn_postgis
         table = "trips"
         try:
-            trips.as_trips.to_postgis(conn_string, table)
+            trips.as_trips.to_postgis(table, conn_string)
             columns_db, dtypes = get_table_schema(conn, table)
             columns = trips.columns.tolist() + [trips.index.name]
             assert len(columns_db) == len(columns)
@@ -469,7 +469,7 @@ class TestTrips:
         sql = f"SELECT * FROM {table}"
 
         try:
-            trips.as_trips.to_postgis(conn_string, table)
+            trips.as_trips.to_postgis(table, conn_string)
             trips_db = ti.io.read_trips_postgis(sql, conn_string)
             assert_frame_equal(trips, trips_db)
         finally:
@@ -507,8 +507,5 @@ class Test_Handle_Con_String:
         @ti.io.postgis._handle_con_string
         def wrapped(con):
             assert con is conn
-            return
 
         wrapped(conn)
-
-    pass

--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -65,7 +65,7 @@ def read_positionfixes_postgis(sql, con, geom_col="geom", *args, **kwargs):
 
     Examples
     --------
-    >>> pfs = ti.io.read_postifionfixes("SELECT * FROM postionfixes", con, geom_col="geom")
+    >>> pfs = ti.io.postgis.read_postifionfixes("SELECT * FROM postionfixes", con, geom_col="geom")
     """
     pfs = gpd.GeoDataFrame.from_postgis(sql, con, geom_col, *args, **kwargs)
     return ti.io.read_positionfixes_gpd(pfs, geom=geom_col)
@@ -103,6 +103,7 @@ def write_positionfixes_postgis(positionfixes, con, table_name, schema=None, sql
     Examples
     --------
     >>> pfs.as_positionfixes.to_postgis(conn_string, table_name)
+    >>> ti.io.postgis.write_positionfixes_postgis(pfs, conn_string, table_name)
     """
     positionfixes.to_postgis(table_name, con, if_exists=if_exists, schema=schema, index=True, chunksize=sql_chunksize)
 
@@ -171,6 +172,7 @@ def write_triplegs_postgis(
     Examples
     --------
     >>> tpls.as_triplegs.to_postgis(conn_string, table_name)
+    >>> ti.io.postgis.write_triplegs_postgis(tpls, conn_string, table_name)
     """
     triplegs.to_postgis(table_name, con, if_exists=if_exists, schema=schema, index=True, chunksize=sql_chunksize)
 
@@ -239,6 +241,7 @@ def write_staypoints_postgis(staypoints, con, table_name, schema=None, sql_chunk
     Examples
     --------
     >>> spts.as_staypoints.to_postgis(conn_string, table_name)
+    >>> ti.io.postgis.write_staypoints_postgis(spts, conn_string, table_name)
     """
 
     # todo: Think about a concept for the indices. At the moment, an index
@@ -312,6 +315,7 @@ def write_locations_postgis(locations, con, table_name, schema=None, sql_chunksi
     Examples
     --------
     >>> locs.as_locations.to_postgis(conn_string, table_name)
+    >>> ti.io.postgis.write_locations_postgis(locs, conn_string, table_name)
     """
     # Assums that "extent" is not geometry column but center is.
     # May build additional check for that.
@@ -394,5 +398,6 @@ def write_trips_postgis(trips, con, table_name, schema=None, sql_chunksize=None,
     Examples
     --------
     >>> trips.as_trips.to_postgis(conn_string, table_name)
+    >>> ti.io.postgis.write_trips_postgis(trips, conn_string, table_name)
     """
     trips.to_sql(table_name, con, if_exists=if_exists, schema=schema, index=True, chunksize=sql_chunksize)

--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -72,40 +72,10 @@ def read_positionfixes_postgis(sql, con, geom_col="geom", *args, **kwargs):
 
 
 @_handle_con_string
-def write_positionfixes_postgis(positionfixes, con, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
-    """Stores positionfixes to PostGIS. Usually, this is directly called on a positionfixes
-    DataFrame (see example below).
-
-    Parameters
-    ----------
-    positionfixes : GeoDataFrame
-        The positionfixes to store to the database.
-
-    con : str, sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
-        Connection string or active connection to PostGIS database.
-
-    table_name : str
-        The name of the table to write to.
-
-    schema : str, optional
-        The schema (if the database supports this) where the table resides.
-
-    sql_chunksize : int, optional
-        How many entries should be written at the same time.
-
-    if_exists : str, {'fail', 'replace', 'append'}, default 'fail'
-        How to behave if the table already exists.
-
-        - fail: Raise a ValueError.
-        - replace: Drop the table before inserting new values.
-        - append: Insert new values to the existing table.
-
-    Examples
-    --------
-    >>> pfs.as_positionfixes.to_postgis(conn_string, table_name)
-    >>> ti.io.postgis.write_positionfixes_postgis(pfs, conn_string, table_name)
-    """
-    positionfixes.to_postgis(table_name, con, if_exists=if_exists, schema=schema, index=True, chunksize=sql_chunksize)
+def write_positionfixes_postgis(
+    positionfixes, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
+):
+    positionfixes.to_postgis(name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
 
 @_handle_con_string
@@ -144,41 +114,9 @@ def read_triplegs_postgis(sql, con, geom_col="geom", *args, **kwargs):
 
 @_handle_con_string
 def write_triplegs_postgis(
-    triplegs, con, table_name, schema=None, sql_chunksize=None, if_exists="fail", *args, **kwargs
+    triplegs, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
 ):
-    """Stores triplegs to PostGIS. Usually, this is directly called on a triplegs
-    DataFrame (see example below).
-
-    Parameters
-    ----------
-    triplegs : GeoDataFrame
-        The triplegs to store to the database.
-
-    con : str, sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
-        Connection string or active connection to PostGIS database.
-
-    table_name : str
-        The name of the table to write to.
-
-    schema : str, optional
-        The schema (if the database supports this) where the table resides.
-
-    sql_chunksize : int, optional
-        How many entries should be written at the same time.
-
-    if_exists : str, {'fail', 'replace', 'append'}, default 'fail'
-        How to behave if the table already exists.
-
-        - fail: Raise a ValueError.
-        - replace: Drop the table before inserting new values.
-        - append: Insert new values to the existing table.
-
-    Examples
-    --------
-    >>> tpls.as_triplegs.to_postgis(conn_string, table_name)
-    >>> ti.io.postgis.write_triplegs_postgis(tpls, conn_string, table_name)
-    """
-    triplegs.to_postgis(table_name, con, if_exists=if_exists, schema=schema, index=True, chunksize=sql_chunksize)
+    triplegs.to_postgis(name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
 
 @_handle_con_string
@@ -219,46 +157,10 @@ def read_staypoints_postgis(sql, con, geom_col="geom", *args, **kwargs):
 
 
 @_handle_con_string
-def write_staypoints_postgis(staypoints, con, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
-    """Stores staypoints to PostGIS. Usually, this is directly called on a staypoints
-    DataFrame (see example below).
-
-    Parameters
-    ----------
-    staypoints : GeoDataFrame
-        The staypoints to store to the database.
-
-    con : str, sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
-        Connection string or active connection to PostGIS database.
-
-    table_name : str
-        The name of the table to write to.
-
-    schema : str, optional
-        The schema (if the database supports this) where the table resides.
-
-    sql_chunksize : int, optional
-        How many entries should be written at the same time.
-
-    if_exists : str, {'fail', 'replace', 'append'}, default 'fail'
-        How to behave if the table already exists.
-
-        - fail: Raise a ValueError.
-        - replace: Drop the table before inserting new values.
-        - append: Insert new values to the existing table.
-
-    Examples
-    --------
-    >>> spts.as_staypoints.to_postgis(conn_string, table_name)
-    >>> ti.io.write_staypoints_postgis(spts, conn_string, table_name)
-    """
-
-    # todo: Think about a concept for the indices. At the moment, an index
-    # column is required when downloading. This means, that the ID column is
-    # taken as pandas index. When uploading the default is "no index" and
-    # thereby the index column is lost
-
-    staypoints.to_postgis(table_name, con, if_exists=if_exists, schema=schema, index=True, chunksize=sql_chunksize)
+def write_staypoints_postgis(
+    staypoints, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
+):
+    staypoints.to_postgis(name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
 
 @_handle_con_string
@@ -297,38 +199,9 @@ def read_locations_postgis(sql, con, geom_col="geom", *args, **kwargs):
 
 
 @_handle_con_string
-def write_locations_postgis(locations, con, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
-    """Store locations to PostGIS. Usually, this is directly called on a locations GeoDataFrame (see example below).
-
-    Parameters
-    ----------
-    locations : GeoDataFrame
-        The locations to store to the database.
-
-    con : str, sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
-        Connection string or active connection to PostGIS database.
-
-    table_name : str
-        The name of the table to write to.
-
-    schema : str, optional
-        The schema (if the database supports this) where the table resides.
-
-    sql_chunksize : int, optional
-        How many entries should be written at the same time.
-
-    if_exists : str, {'fail', 'replace', 'append'}, default 'fail'
-        How to behave if the table already exists.
-
-        - fail: Raise a ValueError.
-        - replace: Drop the table before inserting new values.
-        - append: Insert new values to the existing table.
-
-    Examples
-    --------
-    >>> locs.as_locations.to_postgis(conn_string, table_name)
-    >>> ti.io.write_locations_postgis(locs, conn_string, table_name)
-    """
+def write_locations_postgis(
+    locations, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
+):
     # Assums that "extent" is not geometry column but center is.
     # May build additional check for that.
     if "extent" in locations.columns:
@@ -338,15 +211,15 @@ def write_locations_postgis(locations, con, table_name, schema=None, sql_chunksi
         else:
             srid = -1
         extent_schema = Geometry("POLYGON", srid)
-        dtype = {"extent": extent_schema}
+
+        if dtype is None:
+            dtype = {"extent": extent_schema}
+        else:
+            dtype["extent"] = extent_schema
         locations = locations.copy()
         locations["extent"] = locations["extent"].apply(lambda x: WKTElement(x.wkt, srid=srid))
-    else:
-        dtype = None
 
-    locations.to_postgis(
-        table_name, con, if_exists=if_exists, schema=schema, index=True, chunksize=sql_chunksize, dtype=dtype
-    )
+    locations.to_postgis(name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
 
 @_handle_con_string
@@ -384,37 +257,58 @@ def read_trips_postgis(sql, con, *args, **kwargs):
 
 
 @_handle_con_string
-def write_trips_postgis(trips, con, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
-    """Stores trips to PostGIS. Usually, this is directly called on a trips
+def write_trips_postgis(
+    trips, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
+):
+    trips.to_sql(name, con, schema, if_exists, index, index_label, chunksize, dtype)
+
+
+# helper docstring to change __doc__ of all write functions conveniently in one place
+__doc = """Stores {long} to PostGIS. Usually, this is directly called on a {long}
     DataFrame (see example below).
 
     Parameters
     ----------
-    trips : DataFrame
-        The trips to store to the database.
+    {long} : GeoDataFrame (as trackintel {long})
+        The {long} to store to the database.
+
+    name : str
+        The name of the table to write to.
 
     con : str, sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
         Connection string or active connection to PostGIS database.
 
-    table_name : str
-        The name of the table to write to.
-
     schema : str, optional
         The schema (if the database supports this) where the table resides.
 
-    sql_chunksize : int, optional
-        How many entries should be written at the same time.
-
-    if_exists : str, {'fail', 'replace', 'append'}, default 'fail'
+    if_exists : str, {{'fail', 'replace', 'append'}}, default 'fail'
         How to behave if the table already exists.
 
         - fail: Raise a ValueError.
         - replace: Drop the table before inserting new values.
         - append: Insert new values to the existing table.
 
+    index : bool, default True
+        Write DataFrame index as a column. Uses index_label as the column name in the table.
+
+    index_label : str or sequence, default None
+        Column label for index column(s). If None is given (default) and index is True, then the index names are used.
+
+    chunksize : int, optional
+        How many entries should be written at the same time.
+
+    dtype: dict of column name to SQL type, default None
+        Specifying the datatype for columns.
+        The keys should be the column names and the values should be the SQLAlchemy types.
+
     Examples
     --------
-    >>> trips.as_trips.to_postgis(conn_string, table_name)
-    >>> ti.io.write_trips_postgis(trips, conn_string, table_name)
-    """
-    trips.to_sql(table_name, con, if_exists=if_exists, schema=schema, index=True, chunksize=sql_chunksize)
+    >>> {short}.as_{long}.to_postgis(conn_string, table_name)
+    >>> ti.io.postgis.write_{long}_postgis(pfs, conn_string, table_name)
+"""
+
+write_positionfixes_postgis.__doc__ = __doc.format(long="positionfixes", short="pfs")
+write_triplegs_postgis.__doc__ = __doc.format(long="triplegs", short="tpls")
+write_staypoints_postgis.__doc__ = __doc.format(long="staypoints", short="spts")
+write_locations_postgis.__doc__ = __doc.format(long="locations", short="locs")
+write_trips_postgis.__doc__ = __doc.format(long="trips", short="trips")

--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -65,10 +65,10 @@ def read_positionfixes_postgis(sql, con, geom_col="geom", *args, **kwargs):
 
     Examples
     --------
-    >>> pfs = ti.io.postgis.read_postifionfixes("SELECT * FROM postionfixes", con, geom_col="geom")
+    >>> pfs = ti.io.read_postifionfixes_postgis("SELECT * FROM postionfixes", con, geom_col="geom")
     """
     pfs = gpd.GeoDataFrame.from_postgis(sql, con, geom_col, *args, **kwargs)
-    return ti.io.read_positionfixes_gpd(pfs, geom=geom_col)
+    return ti.io.read_positionfixes_gpd(pfs, geom_col=geom_col)
 
 
 @_handle_con_string
@@ -133,9 +133,13 @@ def read_triplegs_postgis(sql, con, geom_col="geom", *args, **kwargs):
     -------
     GeoDataFrame
         A GeoDataFrame containing the triplegs.
+
+    Examples
+    --------
+    >>> tpls = ti.io.read_triplegs_postgis("SELECT * FROM triplegs", con, geom_col="geom")
     """
     tpls = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", *args, **kwargs)
-    return ti.io.read_triplegs_gpd(tpls, geom=geom_col)
+    return ti.io.read_triplegs_gpd(tpls, geom_col=geom_col)
 
 
 @_handle_con_string
@@ -203,10 +207,15 @@ def read_staypoints_postgis(sql, con, geom_col="geom", *args, **kwargs):
     -------
     GeoDataFrame
         A GeoDataFrame containing the staypoints.
+
+    Examples
+    --------
+    >>> spts = ti.io.read_staypoints_postgis("SELECT * FROM staypoints", con, geom_col="geom")
+
     """
     spts = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", *args, **kwargs)
 
-    return ti.io.read_staypoints_gpd(spts, geom=geom_col)
+    return ti.io.read_staypoints_gpd(spts, geom_col=geom_col)
 
 
 @_handle_con_string
@@ -241,7 +250,7 @@ def write_staypoints_postgis(staypoints, con, table_name, schema=None, sql_chunk
     Examples
     --------
     >>> spts.as_staypoints.to_postgis(conn_string, table_name)
-    >>> ti.io.postgis.write_staypoints_postgis(spts, conn_string, table_name)
+    >>> ti.io.write_staypoints_postgis(spts, conn_string, table_name)
     """
 
     # todo: Think about a concept for the indices. At the moment, an index
@@ -249,7 +258,6 @@ def write_staypoints_postgis(staypoints, con, table_name, schema=None, sql_chunk
     # taken as pandas index. When uploading the default is "no index" and
     # thereby the index column is lost
 
-    # make a copy in order to avoid changing the geometry of the original array
     staypoints.to_postgis(table_name, con, if_exists=if_exists, schema=schema, index=True, chunksize=sql_chunksize)
 
 
@@ -278,6 +286,10 @@ def read_locations_postgis(sql, con, geom_col="geom", *args, **kwargs):
     -------
     GeoDataFrame
         A GeoDataFrame containing the locations.
+
+    Examples
+    --------
+    >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, geom_col="geom")
     """
     locs = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", *args, **kwargs)
 
@@ -315,7 +327,7 @@ def write_locations_postgis(locations, con, table_name, schema=None, sql_chunksi
     Examples
     --------
     >>> locs.as_locations.to_postgis(conn_string, table_name)
-    >>> ti.io.postgis.write_locations_postgis(locs, conn_string, table_name)
+    >>> ti.io.write_locations_postgis(locs, conn_string, table_name)
     """
     # Assums that "extent" is not geometry column but center is.
     # May build additional check for that.
@@ -360,6 +372,11 @@ def read_trips_postgis(sql, con, *args, **kwargs):
     -------
     DataFrame
         A DataFrame containing the trips.
+
+    Examples
+    --------
+    >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con, geom_col="geom")
+
     """
     trips = pd.read_sql(sql, con, index_col="id", *args, **kwargs)
 
@@ -398,6 +415,6 @@ def write_trips_postgis(trips, con, table_name, schema=None, sql_chunksize=None,
     Examples
     --------
     >>> trips.as_trips.to_postgis(conn_string, table_name)
-    >>> ti.io.postgis.write_trips_postgis(trips, conn_string, table_name)
+    >>> ti.io.write_trips_postgis(trips, conn_string, table_name)
     """
     trips.to_sql(table_name, con, if_exists=if_exists, schema=schema, index=True, chunksize=sql_chunksize)

--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -38,7 +38,7 @@ def _handle_con_string(func):
 
 
 @_handle_con_string
-def read_positionfixes_postgis(sql, con, geom_col="geom", *args, **kwargs):
+def read_positionfixes_postgis(sql, con, geom_col="geom", **kwargs):
     """Reads positionfixes from a PostGIS database.
 
     Parameters
@@ -52,9 +52,6 @@ def read_positionfixes_postgis(sql, con, geom_col="geom", *args, **kwargs):
     geom_col : str, default 'geom'
         The geometry column of the table.
 
-    *args
-        Further arguments as available in GeoPanda's GeoDataFrame.from_postgis().
-
     **kwargs
         Further keyword arguments as available in GeoPanda's GeoDataFrame.from_postgis().
 
@@ -67,7 +64,7 @@ def read_positionfixes_postgis(sql, con, geom_col="geom", *args, **kwargs):
     --------
     >>> pfs = ti.io.read_postifionfixes_postgis("SELECT * FROM postionfixes", con, geom_col="geom")
     """
-    pfs = gpd.GeoDataFrame.from_postgis(sql, con, geom_col, *args, **kwargs)
+    pfs = gpd.GeoDataFrame.from_postgis(sql, con, geom_col, **kwargs)
     return ti.io.read_positionfixes_gpd(pfs, geom_col=geom_col)
 
 
@@ -75,11 +72,20 @@ def read_positionfixes_postgis(sql, con, geom_col="geom", *args, **kwargs):
 def write_positionfixes_postgis(
     positionfixes, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
 ):
-    positionfixes.to_postgis(name, con, schema, if_exists, index, index_label, chunksize, dtype)
+    positionfixes.to_postgis(
+        name,
+        con,
+        schema=schema,
+        if_exists=if_exists,
+        index=index,
+        index_label=index_label,
+        chunksize=chunksize,
+        dtype=dtype,
+    )
 
 
 @_handle_con_string
-def read_triplegs_postgis(sql, con, geom_col="geom", *args, **kwargs):
+def read_triplegs_postgis(sql, con, geom_col="geom", **kwargs):
     """Reads triplegs from a PostGIS database.
 
     Parameters
@@ -93,9 +99,6 @@ def read_triplegs_postgis(sql, con, geom_col="geom", *args, **kwargs):
     geom_col : str, default 'geom'
         The geometry column of the table.
 
-    *args
-        Further arguments as available in GeoPanda's GeoDataFrame.from_postgis().
-
     **kwargs
         Further keyword arguments as available in GeoPanda's GeoDataFrame.from_postgis().
 
@@ -108,7 +111,7 @@ def read_triplegs_postgis(sql, con, geom_col="geom", *args, **kwargs):
     --------
     >>> tpls = ti.io.read_triplegs_postgis("SELECT * FROM triplegs", con, geom_col="geom")
     """
-    tpls = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", *args, **kwargs)
+    tpls = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", **kwargs)
     return ti.io.read_triplegs_gpd(tpls, geom_col=geom_col)
 
 
@@ -116,11 +119,20 @@ def read_triplegs_postgis(sql, con, geom_col="geom", *args, **kwargs):
 def write_triplegs_postgis(
     triplegs, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
 ):
-    triplegs.to_postgis(name, con, schema, if_exists, index, index_label, chunksize, dtype)
+    triplegs.to_postgis(
+        name,
+        con,
+        schema=schema,
+        if_exists=if_exists,
+        index=index,
+        index_label=index_label,
+        chunksize=chunksize,
+        dtype=dtype,
+    )
 
 
 @_handle_con_string
-def read_staypoints_postgis(sql, con, geom_col="geom", *args, **kwargs):
+def read_staypoints_postgis(sql, con, geom_col="geom", **kwargs):
     """Read staypoints from a PostGIS database.
 
     Parameters
@@ -133,9 +145,6 @@ def read_staypoints_postgis(sql, con, geom_col="geom", *args, **kwargs):
 
     geom_col : str, default 'geom'
         The geometry column of the table.
-
-    *args
-        Further arguments as available in GeoPanda's GeoDataFrame.from_postgis().
 
     **kwargs
         Further keyword arguments as available in GeoPanda's GeoDataFrame.from_postgis().
@@ -151,7 +160,7 @@ def read_staypoints_postgis(sql, con, geom_col="geom", *args, **kwargs):
     >>> spts = ti.io.read_staypoints_postgis("SELECT * FROM staypoints", con, geom_col="geom")
 
     """
-    spts = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", *args, **kwargs)
+    spts = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", **kwargs)
 
     return ti.io.read_staypoints_gpd(spts, geom_col=geom_col)
 
@@ -160,11 +169,20 @@ def read_staypoints_postgis(sql, con, geom_col="geom", *args, **kwargs):
 def write_staypoints_postgis(
     staypoints, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
 ):
-    staypoints.to_postgis(name, con, schema, if_exists, index, index_label, chunksize, dtype)
+    staypoints.to_postgis(
+        name,
+        con,
+        schema=schema,
+        if_exists=if_exists,
+        index=index,
+        index_label=index_label,
+        chunksize=chunksize,
+        dtype=dtype,
+    )
 
 
 @_handle_con_string
-def read_locations_postgis(sql, con, geom_col="geom", *args, **kwargs):
+def read_locations_postgis(sql, con, geom_col="geom", **kwargs):
     """Reads locations from a PostGIS database.
 
     Parameters
@@ -193,7 +211,7 @@ def read_locations_postgis(sql, con, geom_col="geom", *args, **kwargs):
     --------
     >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, geom_col="geom")
     """
-    locs = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", *args, **kwargs)
+    locs = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", **kwargs)
 
     return ti.io.read_locations_gpd(locs, center=geom_col)
 
@@ -219,11 +237,20 @@ def write_locations_postgis(
         locations = locations.copy()
         locations["extent"] = locations["extent"].apply(lambda x: WKTElement(x.wkt, srid=srid))
 
-    locations.to_postgis(name, con, schema, if_exists, index, index_label, chunksize, dtype)
+    locations.to_postgis(
+        name,
+        con,
+        schema=schema,
+        if_exists=if_exists,
+        index=index,
+        index_label=index_label,
+        chunksize=chunksize,
+        dtype=dtype,
+    )
 
 
 @_handle_con_string
-def read_trips_postgis(sql, con, *args, **kwargs):
+def read_trips_postgis(sql, con, **kwargs):
     """Read trips from a PostGIS database.
 
     Parameters
@@ -233,9 +260,6 @@ def read_trips_postgis(sql, con, *args, **kwargs):
 
     con : str, sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
         Connection string or active connection to PostGIS database.
-
-    *args
-        Further arguments as available in GeoPanda's GeoDataFrame.from_postgis().
 
     **kwargs
         Further keyword arguments as available in GeoPanda's GeoDataFrame.from_postgis().
@@ -251,7 +275,7 @@ def read_trips_postgis(sql, con, *args, **kwargs):
     >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con, geom_col="geom")
 
     """
-    trips = pd.read_sql(sql, con, index_col="id", *args, **kwargs)
+    trips = pd.read_sql(sql, con, index_col="id", **kwargs)
 
     return ti.io.read_trips_gpd(trips)
 
@@ -260,7 +284,16 @@ def read_trips_postgis(sql, con, *args, **kwargs):
 def write_trips_postgis(
     trips, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
 ):
-    trips.to_sql(name, con, schema, if_exists, index, index_label, chunksize, dtype)
+    trips.to_sql(
+        name,
+        con,
+        schema=schema,
+        if_exists=if_exists,
+        index=index,
+        index_label=index_label,
+        chunksize=chunksize,
+        dtype=dtype,
+    )
 
 
 # helper docstring to change __doc__ of all write functions conveniently in one place

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -64,7 +64,7 @@ class LocationsAccessor(object):
         """
         ti.io.file.write_locations_csv(self._obj, filename, *args, **kwargs)
 
-    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="replace"):
+    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
         """
         Store this collection of locations to PostGIS.
 

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -64,13 +64,17 @@ class LocationsAccessor(object):
         """
         ti.io.file.write_locations_csv(self._obj, filename, *args, **kwargs)
 
-    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
+    def to_postgis(
+        self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
+    ):
         """
         Store this collection of locations to PostGIS.
 
         See :func:`trackintel.io.postgis.write_locations_postgis`.
         """
-        ti.io.postgis.write_locations_postgis(self._obj, conn_string, table_name, schema, sql_chunksize, if_exists)
+        ti.io.postgis.write_locations_postgis(
+            self._obj, name, con, schema, if_exists, index, index_label, chunksize, dtype
+        )
 
     def spatial_filter(self, *args, **kwargs):
         """

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -100,7 +100,7 @@ class PositionfixesAccessor(object):
         """
         ti.io.file.write_positionfixes_csv(self._obj, filename, *args, **kwargs)
 
-    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="replace"):
+    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
         """
         Store this collection of positionfixes to PostGIS.
 

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -100,13 +100,17 @@ class PositionfixesAccessor(object):
         """
         ti.io.file.write_positionfixes_csv(self._obj, filename, *args, **kwargs)
 
-    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
+    def to_postgis(
+        self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
+    ):
         """
         Store this collection of positionfixes to PostGIS.
 
         See :func:`trackintel.io.postgis.write_positionfixes_postgis`.
         """
-        ti.io.postgis.write_positionfixes_postgis(self._obj, conn_string, table_name, schema, sql_chunksize, if_exists)
+        ti.io.postgis.write_positionfixes_postgis(
+            self._obj, name, con, schema, if_exists, index, index_label, chunksize, dtype
+        )
 
     def calculate_distance_matrix(self, *args, **kwargs):
         """

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -111,13 +111,13 @@ class StaypointsAccessor(object):
         """
         ti.io.file.write_staypoints_csv(self._obj, filename, *args, **kwargs)
 
-    def to_postgis(self, conn_string, table_name):
+    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
         """
         Store this collection of staypoints to PostGIS.
 
         See :func:`trackintel.io.postgis.write_staypoints_postgis`.
         """
-        ti.io.postgis.write_staypoints_postgis(self._obj, conn_string, table_name)
+        ti.io.postgis.write_staypoints_postgis(self._obj, conn_string, table_name, schema=schema, sql_chunksize=sql_chunksize, if_exists=if_exists)
 
     def temporal_tracking_quality(self, *args, **kwargs):
         """

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -111,14 +111,16 @@ class StaypointsAccessor(object):
         """
         ti.io.file.write_staypoints_csv(self._obj, filename, *args, **kwargs)
 
-    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
+    def to_postgis(
+        self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
+    ):
         """
         Store this collection of staypoints to PostGIS.
 
         See :func:`trackintel.io.postgis.write_staypoints_postgis`.
         """
         ti.io.postgis.write_staypoints_postgis(
-            self._obj, conn_string, table_name, schema=schema, sql_chunksize=sql_chunksize, if_exists=if_exists
+            self._obj, name, con, schema, if_exists, index, index_label, chunksize, dtype
         )
 
     def temporal_tracking_quality(self, *args, **kwargs):

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -117,7 +117,9 @@ class StaypointsAccessor(object):
 
         See :func:`trackintel.io.postgis.write_staypoints_postgis`.
         """
-        ti.io.postgis.write_staypoints_postgis(self._obj, conn_string, table_name, schema=schema, sql_chunksize=sql_chunksize, if_exists=if_exists)
+        ti.io.postgis.write_staypoints_postgis(
+            self._obj, conn_string, table_name, schema=schema, sql_chunksize=sql_chunksize, if_exists=if_exists
+        )
 
     def temporal_tracking_quality(self, *args, **kwargs):
         """

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -79,13 +79,13 @@ class TriplegsAccessor(object):
         """
         ti.io.file.write_triplegs_csv(self._obj, filename, *args, **kwargs)
 
-    def to_postgis(self, conn_string, table_name):
+    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
         """
         Store this collection of triplegs to PostGIS.
 
         See :func:`trackintel.io.postgis.store_positionfixes_postgis`.
         """
-        ti.io.postgis.write_triplegs_postgis(self._obj, conn_string, table_name)
+        ti.io.postgis.write_triplegs_postgis(self._obj, conn_string, table_name, schema=schema, sql_chunksize=sql_chunksize, if_exists=if_exists)
 
     def calculate_distance_matrix(self, *args, **kwargs):
         """

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -79,14 +79,16 @@ class TriplegsAccessor(object):
         """
         ti.io.file.write_triplegs_csv(self._obj, filename, *args, **kwargs)
 
-    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
+    def to_postgis(
+        self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
+    ):
         """
         Store this collection of triplegs to PostGIS.
 
         See :func:`trackintel.io.postgis.store_positionfixes_postgis`.
         """
         ti.io.postgis.write_triplegs_postgis(
-            self._obj, conn_string, table_name, schema=schema, sql_chunksize=sql_chunksize, if_exists=if_exists
+            self._obj, name, con, schema, if_exists, index, index_label, chunksize, dtype
         )
 
     def calculate_distance_matrix(self, *args, **kwargs):

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -85,7 +85,9 @@ class TriplegsAccessor(object):
 
         See :func:`trackintel.io.postgis.store_positionfixes_postgis`.
         """
-        ti.io.postgis.write_triplegs_postgis(self._obj, conn_string, table_name, schema=schema, sql_chunksize=sql_chunksize, if_exists=if_exists)
+        ti.io.postgis.write_triplegs_postgis(
+            self._obj, conn_string, table_name, schema=schema, sql_chunksize=sql_chunksize, if_exists=if_exists
+        )
 
     def calculate_distance_matrix(self, *args, **kwargs):
         """

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -6,11 +6,11 @@ import trackintel as ti
 @pd.api.extensions.register_dataframe_accessor("as_trips")
 class TripsAccessor(object):
     """A pandas accessor to treat (Geo)DataFrames as collections of trips.
-    
+
     This will define certain methods and accessors, as well as make sure that the DataFrame
     adheres to some requirements.
 
-    Requires at least the following columns: 
+    Requires at least the following columns:
     ['user_id', 'started_at', 'finished_at', 'origin_staypoint_id', 'destination_staypoint_id']
 
     The 'index' of the GeoDataFrame will be treated as unique identifier of the `Trips`
@@ -24,13 +24,13 @@ class TripsAccessor(object):
     (e.g., waiting) between two relevant activities.
 
     The following assumptions are implemented
-    
+
         - All movement before the first and after the last activity is omitted
         - If we do not record a person for more than `gap_threshold` minutes, we assume that the person performed an \
             activity in the recording gap and split the trip at the gap.
         - Trips that start/end in a recording gap can have an unknown origin/destination.
         - There are no trips without a (recored) tripleg.
-        
+
     'started_at' and 'finished_at' are timezone aware pandas datetime objects.
 
     Examples

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -77,13 +77,15 @@ class TripsAccessor(object):
         """
         ti.io.file.write_trips_csv(self._obj, filename, *args, **kwargs)
 
-    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
+    def to_postgis(
+        self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
+    ):
         """
         Store this collection of trips to PostGIS.
 
         See :func:`trackintel.io.postgis.write_trips_postgis`.
         """
-        ti.io.postgis.write_trips_postgis(self._obj, conn_string, table_name, schema, sql_chunksize, if_exists)
+        ti.io.postgis.write_trips_postgis(self._obj, name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
     def temporal_tracking_quality(self, *args, **kwargs):
         """

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -77,7 +77,7 @@ class TripsAccessor(object):
         """
         ti.io.file.write_trips_csv(self._obj, filename, *args, **kwargs)
 
-    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="replace"):
+    def to_postgis(self, conn_string, table_name, schema=None, sql_chunksize=None, if_exists="fail"):
         """
         Store this collection of trips to PostGIS.
 


### PR DESCRIPTION
closes #227 
closes #211
The following changes in this pull request.
- Decorator to handle not only connection strings, but also engines/connection objects
- WKT transformation for locations extent
- Updating accessor arguments (adding missing ones and `if_exists` to "fail".
- new argument `sql` instead of fix string.
- handing building GeoDataFrame to `read_*_gpd` functions
