### PR TITLE
Access geometry via geom_col attribute without renaming

### DIFF
--- a/examples/trackintel_basic_tutorial.ipynb
+++ b/examples/trackintel_basic_tutorial.ipynb
@@ -97,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pfs = ti.io.from_geopandas.read_positionfixes_gpd(gdf, tracked_at=\"time\", user_id=\"User\", geom=\"geometry\", tz='UTC')\n",
+    "pfs = ti.io.from_geopandas.read_positionfixes_gpd(gdf, tracked_at=\"time\", user_id=\"User\", geom_col=\"geometry\", tz='UTC')\n",
     "# now you can safely call .as_positionfixes or use any trackintel functions\n",
     "pfs.as_positionfixes.plot()"
    ]

--- a/tests/io/test_from_geopandas.py
+++ b/tests/io/test_from_geopandas.py
@@ -17,7 +17,7 @@ class TestFromGeopandas:
 
         pfs_file = os.path.join("tests", "data", "positionfixes.csv")
         pfs_from_csv = ti.read_positionfixes_csv(pfs_file, sep=";", tz="utc", index_col="id")
-        pfs_from_csv = pfs_from_csv.rename(columns={"geom":"geometry"})
+        pfs_from_csv = pfs_from_csv.rename(columns={"geom": "geometry"})
 
         pd.testing.assert_frame_equal(pfs_from_gpd, pfs_from_csv, check_exact=False)
 
@@ -29,7 +29,7 @@ class TestFromGeopandas:
 
         tpls_file = os.path.join("tests", "data", "triplegs.csv")
         tpls_from_csv = ti.read_triplegs_csv(tpls_file, sep=";", tz="utc", index_col="id")
-        tpls_from_csv = tpls_from_csv.rename(columns={"geom":"geometry"})
+        tpls_from_csv = tpls_from_csv.rename(columns={"geom": "geometry"})
 
         pd.testing.assert_frame_equal(tpls_from_gpd, tpls_from_csv, check_exact=False)
 

--- a/tests/io/test_from_geopandas.py
+++ b/tests/io/test_from_geopandas.py
@@ -13,10 +13,11 @@ class TestFromGeopandas:
         """Test if the results of reading from gpd and csv agrees."""
         gdf = gpd.read_file(os.path.join("tests", "data", "positionfixes.geojson"))
         gdf.set_index("id", inplace=True)
-        pfs_from_gpd = ti.io.from_geopandas.read_positionfixes_gpd(gdf, user_id="User", geom="geometry", tz="utc")
+        pfs_from_gpd = ti.io.from_geopandas.read_positionfixes_gpd(gdf, user_id="User", geom_col="geometry", tz="utc")
 
         pfs_file = os.path.join("tests", "data", "positionfixes.csv")
         pfs_from_csv = ti.read_positionfixes_csv(pfs_file, sep=";", tz="utc", index_col="id")
+        pfs_from_csv = pfs_from_csv.rename(columns={"geom":"geometry"})
 
         pd.testing.assert_frame_equal(pfs_from_gpd, pfs_from_csv, check_exact=False)
 
@@ -24,10 +25,11 @@ class TestFromGeopandas:
         """Test if the results of reading from gpd and csv agrees."""
         gdf = gpd.read_file(os.path.join("tests", "data", "triplegs.geojson"))
         gdf.set_index("id", inplace=True)
-        tpls_from_gpd = ti.io.from_geopandas.read_triplegs_gpd(gdf, user_id="User", geom="geometry", tz="utc")
+        tpls_from_gpd = ti.io.from_geopandas.read_triplegs_gpd(gdf, user_id="User", geom_col="geometry", tz="utc")
 
         tpls_file = os.path.join("tests", "data", "triplegs.csv")
         tpls_from_csv = ti.read_triplegs_csv(tpls_file, sep=";", tz="utc", index_col="id")
+        tpls_from_csv = tpls_from_csv.rename(columns={"geom":"geometry"})
 
         pd.testing.assert_frame_equal(tpls_from_gpd, tpls_from_csv, check_exact=False)
 
@@ -36,11 +38,12 @@ class TestFromGeopandas:
         gdf = gpd.read_file(os.path.join("tests", "data", "staypoints.geojson"))
         gdf.set_index("id", inplace=True)
         stps_from_gpd = ti.io.from_geopandas.read_staypoints_gpd(
-            gdf, "start_time", "end_time", geom="geometry", tz="utc"
+            gdf, "start_time", "end_time", geom_col="geometry", tz="utc"
         )
 
         stps_file = os.path.join("tests", "data", "staypoints.csv")
         stps_from_csv = ti.read_staypoints_csv(stps_file, sep=";", tz="utc", index_col="id")
+        stps_from_csv = stps_from_csv.rename(columns={"geom": "geometry"})
 
         pd.testing.assert_frame_equal(stps_from_gpd, stps_from_csv, check_exact=False)
 

--- a/trackintel/io/from_geopandas.py
+++ b/trackintel/io/from_geopandas.py
@@ -3,7 +3,7 @@ import pandas as pd
 from trackintel.io.file import _localize_timestamp
 
 
-def read_positionfixes_gpd(gdf, tracked_at="tracked_at", user_id="user_id", geom="geom", tz=None, mapper={}):
+def read_positionfixes_gpd(gdf, tracked_at="tracked_at", user_id="user_id", geom_col="geom", tz=None, mapper={}):
     """
     Read positionfixes from GeoDataFrames.
 
@@ -20,7 +20,7 @@ def read_positionfixes_gpd(gdf, tracked_at="tracked_at", user_id="user_id", geom
     user_id : str, default 'user_id'
         name of the column storing the user_id.
 
-    geom : str, default 'geom'
+    geom_col : str, default 'geom'
         name of the column storing the geometry.
 
     tz : str, optional
@@ -36,13 +36,13 @@ def read_positionfixes_gpd(gdf, tracked_at="tracked_at", user_id="user_id", geom
 
     Examples
     --------
-    >>> trackintel.read_positionfixes_gpd(gdf, user_id='User', geom='geometry', tz='utc')
+    >>> trackintel.read_positionfixes_gpd(gdf, user_id='User', geom_col='geom', tz='utc')
     """
-    columns = {tracked_at: "tracked_at", user_id: "user_id", geom: "geom"}
+    columns = {tracked_at: "tracked_at", user_id: "user_id"}
     columns.update(mapper)
 
     pfs = gdf.rename(columns=columns)
-    pfs = pfs.set_geometry("geom")
+    pfs = pfs.set_geometry(geom_col)
 
     # check and/or set timezone
     for col in ["tracked_at"]:
@@ -55,7 +55,7 @@ def read_positionfixes_gpd(gdf, tracked_at="tracked_at", user_id="user_id", geom
 
 
 def read_staypoints_gpd(
-    gdf, started_at="started_at", finished_at="finished_at", user_id="user_id", geom="geom", tz=None, mapper={}
+    gdf, started_at="started_at", finished_at="finished_at", user_id="user_id", geom_col="geom", tz=None, mapper={}
 ):
     """
     Read staypoints from GeoDataFrames.
@@ -76,7 +76,7 @@ def read_staypoints_gpd(
     user_id : str, default 'user_id'
         name of the column storing the user_id.
 
-    geom : str, default 'geom'
+    geom_col : str, default 'geom'
         name of the column storing the geometry.
 
     tz : str, optional
@@ -94,11 +94,11 @@ def read_staypoints_gpd(
     --------
     >>> trackintel.read_staypoints_gpd(gdf, started_at='start_time', finished_at='end_time', tz='utc')
     """
-    columns = {started_at: "started_at", finished_at: "finished_at", user_id: "user_id", geom: "geom"}
+    columns = {started_at: "started_at", finished_at: "finished_at", user_id: "user_id"}
     columns.update(mapper)
 
     stps = gdf.rename(columns=columns)
-    stps = stps.set_geometry("geom")
+    stps = stps.set_geometry(geom_col)
 
     # check and/or set timezone
     for col in ["started_at", "finished_at"]:
@@ -111,7 +111,7 @@ def read_staypoints_gpd(
 
 
 def read_triplegs_gpd(
-    gdf, started_at="started_at", finished_at="finished_at", user_id="user_id", geom="geometry", tz=None, mapper={}
+    gdf, started_at="started_at", finished_at="finished_at", user_id="user_id", geom_col="geom", tz=None, mapper={}
 ):
     """
     Read triplegs from GeoDataFrames.
@@ -132,7 +132,7 @@ def read_triplegs_gpd(
     user_id : str, default 'user_id'
         name of the column storing the user_id.
 
-    geom : str, default 'geom'
+    geom_col : str, default 'geom'
         name of the column storing the geometry.
 
     tz : str, optional
@@ -148,13 +148,13 @@ def read_triplegs_gpd(
 
     Examples
     --------
-    >>> trackintel.read_triplegs_gpd(gdf, user_id='User', geom='geometry', tz='utc')
+    >>> trackintel.read_triplegs_gpd(gdf, user_id='User', geom_col='geom', tz='utc')
     """
-    columns = {started_at: "started_at", finished_at: "finished_at", user_id: "user_id", geom: "geom"}
+    columns = {started_at: "started_at", finished_at: "finished_at", user_id: "user_id"}
     columns.update(mapper)
 
     tpls = gdf.rename(columns=columns)
-    tpls = tpls.set_geometry("geom")
+    tpls = tpls.set_geometry(geom_col)
 
     # check and/or set timezone
     for col in ["started_at", "finished_at"]:


### PR DESCRIPTION
closes #262

The geometry is now not renamed anymore and instead accessed via the attribute. The attribute was furthermore renamed from `geom` to `geom_col`. This requires a **change in the tutorial notebook**. 
Also, the tests fail because the generated table (e.g. `pfs_from_gpd`) does not correspond to the ground truth table loaded from a csv file (e.g. `tpls_from_csv`). To avoid a change in the test data, I renamed the column of the ground truth table in the test file. 