### PR TITLE
CLN: osx specifics in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,12 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# VS Code
+*.code-workspace
+
+# OSX specific
+.DS_Store
+
 # pyenv
 .python-version
 


### PR DESCRIPTION
Would be nice if we could add these things to the gitignore, for avoiding the OSX DS_Store files.