### PR TITLE
ENH: Copy docstring for accessor methods.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,12 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# VS Code
+*.code-workspace
+
+# OSX specific
+.DS_Store
+
 # pyenv
 .python-version
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Documentation Status](https://readthedocs.org/projects/trackintel/badge/?version=latest)](https://trackintel.readthedocs.io/en/latest/?badge=latest)
 [![codecov.io](https://codecov.io/gh/mie-lab/trackintel/coverage.svg?branch=master)](https://codecov.io/gh/mie-lab/trackintel)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-   
+[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/mie-lab/trackintel)
+
 *trackintel* is a library for the analysis of spatio-temporal tracking data with a focus on human mobility. The core of *trackintel* is the hierachical data model for movement data that is used in GIS, transport planning and related fields [[1]](#1). We provide functionalities for the full life-cycle of human mobility data analysis: import and export of tracking data of different types (e.g, trackpoints, check-ins, trajectories), preprocessing, data quality assessment, semantic enrichment, quantitative analysis and mining tasks, and visualization of data and results.
 Trackintel is based on [Pandas](https://pandas.pydata.org/) and [GeoPandas](https://geopandas.org/#)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ def setup(app):
 # The full version, including alpha/beta/rc tags
 # release = version
 
-version = "1.1.0"
+version = "1.1.1"
 release = version
 
 

--- a/docs/modules/model.rst
+++ b/docs/modules/model.rst
@@ -87,7 +87,7 @@ Data Model (SQL)
 
 For a general description of the data model, please refer to the 
 :doc:`/modules/model`. You can download the 
-complete SQL script `here <https://github.com/mie-lab/trackintel/blob/master/sql/create_tables_pg.sql>`_ 
+complete SQL script `here <https://github.com/mie-lab/trackintel/blob/master/sql/create_tables_pg.sql>`__
 in case you want to quickly set up a database. Also take a look at the `example on github 
 <https://github.com/mie-lab/trackintel/blob/master/examples/setup_example_database.py>`_.
 

--- a/docs/modules/model.rst
+++ b/docs/modules/model.rst
@@ -57,23 +57,44 @@ Available Accessors
 
 The following accessors are available within *trackintel*.
 
+UsersAccessor
+-------------
+
 .. autoclass:: trackintel.model.users.UsersAccessor
 	:members:
+
+PositionfixesAccessor
+---------------------
 
 .. autoclass:: trackintel.model.positionfixes.PositionfixesAccessor
 	:members:
 
+StaypointsAccessor
+------------------
+
 .. autoclass:: trackintel.model.staypoints.StaypointsAccessor
 	:members:
+
+TriplegsAccessor
+----------------
 
 .. autoclass:: trackintel.model.triplegs.TriplegsAccessor
 	:members:
 
+LocationsAccessor
+-----------------
+
 .. autoclass:: trackintel.model.locations.LocationsAccessor
 	:members:
 
+TripsAccessor
+-------------
+
 .. autoclass:: trackintel.model.trips.TripsAccessor
 	:members:
+
+ToursAccessor
+-------------
 
 .. autoclass:: trackintel.model.tours.ToursAccessor
 	:members:

--- a/trackintel/__version__.py
+++ b/trackintel/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 1, 0)
+VERSION = (1, 1, 1)
 
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
closes #209 

Added the function `copy_docstring` decorator that uses `functools.update_wrapper` to copy the docstring from the method to the accessor.
To copy the docstring from another function, the other function must be defined at creation time, so I added many imports for all functions. It needs to be verified that it works on other machines before we merge it, because I'm not sure if relative or absolute imports are used on my machine (and if that would matter).