### PR TITLE
ENH: Default to geometry for `read_*_gpd` functions.

### DIFF
--- a/tests/io/test_file.py
+++ b/tests/io/test_file.py
@@ -13,7 +13,7 @@ class TestPositionfixes:
         """Test basic reading and writing functions."""
         orig_file = os.path.join("tests", "data", "positionfixes.csv")
         mod_file = os.path.join("tests", "data", "positionfixes_mod_columns.csv")
-        tmp_file = os.path.join("tests", "data", "positionfixes_test.csv")
+        tmp_file = os.path.join("tests", "data", "positionfixes_test_1.csv")
 
         pfs = ti.read_positionfixes_csv(orig_file, sep=";", index_col="id")
 
@@ -47,7 +47,7 @@ class TestPositionfixes:
         # check if a timezone will be set after manually deleting the timezone
         pfs["tracked_at"] = pfs["tracked_at"].dt.tz_localize(None)
         assert not pd.api.types.is_datetime64tz_dtype(pfs["tracked_at"])
-        tmp_file = os.path.join("tests", "data", "positionfixes_test.csv")
+        tmp_file = os.path.join("tests", "data", "positionfixes_test_2.csv")
         pfs.as_positionfixes.to_csv(tmp_file, sep=";")
         pfs = ti.read_positionfixes_csv(tmp_file, sep=";", index_col="id", tz="utc")
 
@@ -82,7 +82,7 @@ class TestTriplegs:
         """Test basic reading and writing functions."""
         orig_file = os.path.join("tests", "data", "triplegs.csv")
         mod_file = os.path.join("tests", "data", "triplegs_mod_columns.csv")
-        tmp_file = os.path.join("tests", "data", "triplegs_test.csv")
+        tmp_file = os.path.join("tests", "data", "triplegs_test_1.csv")
         tpls = ti.read_triplegs_csv(orig_file, sep=";", tz="utc", index_col="id")
 
         column_mapping = {"start_time": "started_at", "end_time": "finished_at", "tripleg": "geom"}
@@ -117,7 +117,7 @@ class TestTriplegs:
         # check if a timezone will be set after manually deleting the timezone
         tpls["started_at"] = tpls["started_at"].dt.tz_localize(None)
         assert not pd.api.types.is_datetime64tz_dtype(tpls["started_at"])
-        tmp_file = os.path.join("tests", "data", "triplegs_test.csv")
+        tmp_file = os.path.join("tests", "data", "triplegs_test_2.csv")
         tpls.as_triplegs.to_csv(tmp_file, sep=";")
         tpls = ti.read_triplegs_csv(tmp_file, sep=";", index_col="id", tz="utc")
 
@@ -152,7 +152,7 @@ class TestStaypoints:
         """Test basic reading and writing functions."""
         orig_file = os.path.join("tests", "data", "staypoints.csv")
         mod_file = os.path.join("tests", "data", "staypoints_mod_columns.csv")
-        tmp_file = os.path.join("tests", "data", "staypoints_test.csv")
+        tmp_file = os.path.join("tests", "data", "staypoints_test_1.csv")
         stps = ti.read_staypoints_csv(orig_file, sep=";", tz="utc", index_col="id")
         mod_stps = ti.read_staypoints_csv(mod_file, columns={"User": "user_id"}, sep=";", index_col="id")
         assert mod_stps.equals(stps)
@@ -184,7 +184,7 @@ class TestStaypoints:
         # check if a timezone will be set after manually deleting the timezone
         stps["started_at"] = stps["started_at"].dt.tz_localize(None)
         assert not pd.api.types.is_datetime64tz_dtype(stps["started_at"])
-        tmp_file = os.path.join("tests", "data", "staypoints_test.csv")
+        tmp_file = os.path.join("tests", "data", "staypoints_test_2.csv")
         stps.as_staypoints.to_csv(tmp_file, sep=";")
         stps = ti.read_staypoints_csv(tmp_file, sep=";", index_col="id", tz="utc")
 
@@ -219,7 +219,7 @@ class TestLocations:
         """Test basic reading and writing functions."""
         orig_file = os.path.join("tests", "data", "locations.csv")
         mod_file = os.path.join("tests", "data", "locations_mod_columns.csv")
-        tmp_file = os.path.join("tests", "data", "locations_test.csv")
+        tmp_file = os.path.join("tests", "data", "locations_test_1.csv")
         mod_locs = ti.read_locations_csv(mod_file, columns={"geom": "center"}, sep=";", index_col="id")
         locs = ti.read_locations_csv(orig_file, sep=";", index_col="id")
         assert mod_locs.equals(locs)
@@ -260,7 +260,7 @@ class TestTrips:
         """Test basic reading and writing functions."""
         orig_file = os.path.join("tests", "data", "trips.csv")
         mod_file = os.path.join("tests", "data", "trips_mod_columns.csv")
-        tmp_file = os.path.join("tests", "data", "trips_test.csv")
+        tmp_file = os.path.join("tests", "data", "trips_test_1.csv")
         trips = ti.read_trips_csv(orig_file, sep=";", index_col="id")
         column_mapping = {"orig_stp": "origin_staypoint_id", "dest_stp": "destination_staypoint_id"}
         mod_trips = ti.read_trips_csv(mod_file, columns=column_mapping, sep=";", index_col="id")
@@ -284,7 +284,7 @@ class TestTrips:
         # check if a timezone will be set after manually deleting the timezone
         trips["started_at"] = trips["started_at"].dt.tz_localize(None)
         assert not pd.api.types.is_datetime64tz_dtype(trips["started_at"])
-        tmp_file = os.path.join("tests", "data", "trips_test.csv")
+        tmp_file = os.path.join("tests", "data", "trips_test_2.csv")
         trips.as_trips.to_csv(tmp_file, sep=";")
         trips = ti.read_trips_csv(tmp_file, sep=";", index_col="id", tz="utc")
 

--- a/trackintel/io/from_geopandas.py
+++ b/trackintel/io/from_geopandas.py
@@ -4,52 +4,6 @@ import geopandas as gpd
 from trackintel.io.file import _localize_timestamp
 
 
-def _trackintel_model(gdf, set_names=None, geom_col=None, crs=None, tz_cols=None, tz=None):
-    """Helper function to assure the trackintel model on a GeoDataFrame.
-
-    Parameters
-    ----------
-    gdf : GeoDataFrame
-
-    set_names : dict, optional
-        Renaming dictionary for the columns of the GeoDataFrame.
-
-    set_geometry : str, optional
-        Set geometry of GeoDataFrame.
-
-    crs : pyproj.crs or str, optional
-        Set coordinate reference system. The value can be anything accepted
-        by pyproj.CRS.from_user_input(), such as an authority string
-        (eg "EPSG:4326") or a WKT string.
-
-    tz_cols : list, optional
-        List of timezone aware datetime columns.
-
-    tz : str, optional
-        pytz compatible timezone string. If None UTC will be assumed
-    """
-    if set_names is not None:
-        gdf = gdf.rename(columns=set_names)
-
-    if geom_col is not None:
-        gdf = gdf.set_geometry(geom_col)
-    else:
-        try:
-            gdf.geometry
-        except AttributeError:
-            raise AttributeError("GeoDataFrame has no geometry, set it with keyword argument.")
-
-    if crs is not None:
-        gdf = gdf.set_crs(crs)
-
-    if tz_cols is not None:
-        for col in tz_cols:
-            if not pd.api.types.is_datetime64tz_dtype(gdf[col]):
-                gdf[col] = _localize_timestamp(dt_series=gdf[col], pytz_tzinfo=tz, col_name=col)
-
-    return gdf
-
-
 def read_positionfixes_gpd(
     gdf, tracked_at="tracked_at", user_id="user_id", geom_col=None, crs=None, tz=None, mapper=None
 ):
@@ -424,3 +378,55 @@ def read_tours_gpd(
     # trs.as_tours
     # return trs
     pass
+
+
+def _trackintel_model(gdf, set_names=None, geom_col=None, crs=None, tz_cols=None, tz=None):
+    """Help function to assure the trackintel model on a GeoDataFrame.
+
+    Parameters
+    ----------
+    gdf : GeoDataFrame
+        Input GeoDataFrame
+
+    set_names : dict, optional
+        Renaming dictionary for the columns of the GeoDataFrame.
+
+    set_geometry : str, optional
+        Set geometry of GeoDataFrame.
+
+    crs : pyproj.crs or str, optional
+        Set coordinate reference system. The value can be anything accepted
+        by pyproj.CRS.from_user_input(), such as an authority string
+        (eg "EPSG:4326") or a WKT string.
+
+    tz_cols : list, optional
+        List of timezone aware datetime columns.
+
+    tz : str, optional
+        pytz compatible timezone string. If None UTC will be assumed
+
+    Returns
+    -------
+    gdf : GeoDataFrame
+        The input GeoDataFrame transformed to match the trackintel format.
+    """
+    if set_names is not None:
+        gdf = gdf.rename(columns=set_names)
+
+    if geom_col is not None:
+        gdf = gdf.set_geometry(geom_col)
+    else:
+        try:
+            gdf.geometry
+        except AttributeError:
+            raise AttributeError("GeoDataFrame has no geometry, set it with keyword argument.")
+
+    if crs is not None:
+        gdf = gdf.set_crs(crs)
+
+    if tz_cols is not None:
+        for col in tz_cols:
+            if not pd.api.types.is_datetime64tz_dtype(gdf[col]):
+                gdf[col] = _localize_timestamp(dt_series=gdf[col], pytz_tzinfo=tz, col_name=col)
+
+    return gdf

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -1,11 +1,9 @@
 import warnings
 
+import geopandas as gpd
 import numpy as np
 import pandas as pd
-from shapely import geometry
-from tqdm import tqdm
-from shapely.geometry import MultiPoint, Point
-import geopandas as gpd
+from shapely.geometry import MultiPoint
 
 
 def smoothen_triplegs(triplegs, tolerance=1.0, preserve_topology=True):
@@ -164,7 +162,7 @@ def generate_trips(spts, tpls, gap_threshold=15, add_geometry=True):
 
     trips_grouper = spts_tpls_no_act.groupby("temp_trip_id")
     trips = trips_grouper.agg(
-        {"user_id": "mean", "started_at": min, "finished_at": max, "type": list, "spts_tpls_id": list}
+        {"user_id": "first", "started_at": min, "finished_at": max, "type": list, "spts_tpls_id": list}
     )
 
     def _seperate_ids(row):


### PR DESCRIPTION
closes #278 

Default of `read_*_gpd` functions now opt for the geometry of the GeoDataFrame if available.
Also added a function `_trackintel_model` that the functions call instead of doing everything themselves.
Added tests for this new function.
Added crs keyword to all `read_*_gpd` functions.
Added "extent" to `read_locations_gpd`.
Added geometry to `read_trips_gpd`
Set default from `mapper` from `{}` to `None` to avoid bugs with mutable datatypes.

~~Two test are still missing~~
~~1. checking if `read_trips_gpd` correctly return either DataFrame or GeoDataFrame.~~
~~2. checking if `read_locations_gpd` can handle an "extent" column.~~

I just wanted to to have a small and clean PR and now we have already 400 changed lines. :]