### PR TITLE
ENH: `read_*_gpd` arguments available for `read_*_postgis` functions.

### DIFF
--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -3,9 +3,9 @@ from inspect import signature
 
 import geopandas as gpd
 from geopandas.io.sql import _get_srid_from_crs
-from shapely.wkb import dumps
+from shapely import wkb
 import pandas as pd
-from geoalchemy2 import Geometry, WKTElement
+from geoalchemy2 import Geometry
 from sqlalchemy import create_engine
 
 import trackintel as ti
@@ -40,7 +40,18 @@ def _handle_con_string(func):
 
 
 @_handle_con_string
-def read_positionfixes_postgis(sql, con, geom_col="geom", **kwargs):
+def read_positionfixes_postgis(
+    sql,
+    con,
+    geom_col="geom",
+    crs=None,
+    index_col=None,
+    coerce_float=True,
+    parse_dates=None,
+    params=None,
+    chunksize=None,
+    **kwargs
+):
     """Reads positionfixes from a PostGIS database.
 
     Parameters
@@ -54,8 +65,37 @@ def read_positionfixes_postgis(sql, con, geom_col="geom", **kwargs):
     geom_col : str, default 'geom'
         The geometry column of the table.
 
+    crs : optional
+        Coordinate reference system to use for the returned GeoDataFrame
+
+    index_col : string or list of strings, optional, default: None
+        Column(s) to set as index(MultiIndex)
+
+    coerce_float : boolean, default True
+        Attempt to convert values of non-string, non-numeric objects (like
+        decimal.Decimal) to floating point, useful for SQL result sets
+
+    parse_dates : list or dict, default None
+        - List of column names to parse as dates.
+        - Dict of ``{column_name: format string}`` where format string is
+            strftime compatible in case of parsing string times, or is one of
+            (D, s, ns, ms, us) in case of parsing integer timestamps.
+        - Dict of ``{column_name: arg dict}``, where the arg dict
+            corresponds to the keyword arguments of
+            :func:`pandas.to_datetime`. Especially useful with databases
+            without native Datetime support, such as SQLite.
+
+    params : list, tuple or dict, optional, default None
+        List of parameters to pass to execute method.
+
+    chunksize : int, default None
+        If specified, return an iterator where chunksize is the number
+        of rows to include in each chunk.
+
     **kwargs
-        Further keyword arguments as available in GeoPanda's GeoDataFrame.from_postgis().
+        Further keyword arguments as available in trackintels trackintel.io.read_positionfixes_gpd().
+        Especially useful to rename column names from the SQL table to trackintel conform column names.
+        See second example how to use it in code.
 
     Returns
     -------
@@ -64,10 +104,22 @@ def read_positionfixes_postgis(sql, con, geom_col="geom", **kwargs):
 
     Examples
     --------
-    >>> pfs = ti.io.read_postifionfixes_postgis("SELECT * FROM postionfixes", con, geom_col="geom")
+    >>> pfs = ti.io.read_positionfixes_postgis("SELECT * FROM positionfixes", con, geom_col="geom")
+    >>> pfs = ti.io.read_positionfixes_postgis("SELECT * FROM positionfixes", con, geom_col="geom",
+    ...                                        index_col="id", user_id="USER", tracked_at="time")
     """
-    pfs = gpd.GeoDataFrame.from_postgis(sql, con, geom_col, **kwargs)
-    return ti.io.read_positionfixes_gpd(pfs, geom_col=geom_col)
+    pfs = gpd.GeoDataFrame.from_postgis(
+        sql,
+        con,
+        geom_col=geom_col,
+        crs=crs,
+        index_col=index_col,
+        coerce_float=coerce_float,
+        parse_dates=parse_dates,
+        params=params,
+        chunksize=chunksize,
+    )
+    return ti.io.read_positionfixes_gpd(pfs, **kwargs)
 
 
 @_handle_con_string
@@ -87,7 +139,18 @@ def write_positionfixes_postgis(
 
 
 @_handle_con_string
-def read_triplegs_postgis(sql, con, geom_col="geom", **kwargs):
+def read_triplegs_postgis(
+    sql,
+    con,
+    geom_col="geom",
+    crs=None,
+    index_col=None,
+    coerce_float=True,
+    parse_dates=None,
+    params=None,
+    chunksize=None,
+    **kwargs
+):
     """Reads triplegs from a PostGIS database.
 
     Parameters
@@ -101,8 +164,37 @@ def read_triplegs_postgis(sql, con, geom_col="geom", **kwargs):
     geom_col : str, default 'geom'
         The geometry column of the table.
 
+    crs : optional
+        Coordinate reference system to use for the returned GeoDataFrame
+
+    index_col : string or list of strings, optional, default: None
+        Column(s) to set as index(MultiIndex)
+
+    coerce_float : boolean, default True
+        Attempt to convert values of non-string, non-numeric objects (like
+        decimal.Decimal) to floating point, useful for SQL result sets
+
+    parse_dates : list or dict, default None
+        - List of column names to parse as dates.
+        - Dict of ``{column_name: format string}`` where format string is
+            strftime compatible in case of parsing string times, or is one of
+            (D, s, ns, ms, us) in case of parsing integer timestamps.
+        - Dict of ``{column_name: arg dict}``, where the arg dict
+            corresponds to the keyword arguments of
+            :func:`pandas.to_datetime`. Especially useful with databases
+            without native Datetime support, such as SQLite.
+
+    params : list, tuple or dict, optional, default None
+        List of parameters to pass to execute method.
+
+    chunksize : int, default None
+        If specified, return an iterator where chunksize is the number
+        of rows to include in each chunk.
+
     **kwargs
-        Further keyword arguments as available in GeoPanda's GeoDataFrame.from_postgis().
+        Further keyword arguments as available in trackintels trackintel.io.read_triplegs_gpd().
+        Especially useful to rename column names from the SQL table to trackintel conform column names.
+        See second example how to use it in code.
 
     Returns
     -------
@@ -112,9 +204,21 @@ def read_triplegs_postgis(sql, con, geom_col="geom", **kwargs):
     Examples
     --------
     >>> tpls = ti.io.read_triplegs_postgis("SELECT * FROM triplegs", con, geom_col="geom")
+    >>> tpls = ti.io.read_triplegs_postgis("SELECT * FROM triplegs", con, geom_col="geom", index_col="id",
+    ...                                    started_at="start_time", finished_at="end_time", user_id="USER")
     """
-    tpls = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", **kwargs)
-    return ti.io.read_triplegs_gpd(tpls, geom_col=geom_col)
+    tpls = gpd.GeoDataFrame.from_postgis(
+        sql,
+        con,
+        geom_col=geom_col,
+        crs=crs,
+        index_col=index_col,
+        coerce_float=coerce_float,
+        parse_dates=parse_dates,
+        params=params,
+        chunksize=chunksize,
+    )
+    return ti.io.read_triplegs_gpd(tpls, **kwargs)
 
 
 @_handle_con_string
@@ -134,7 +238,18 @@ def write_triplegs_postgis(
 
 
 @_handle_con_string
-def read_staypoints_postgis(sql, con, geom_col="geom", **kwargs):
+def read_staypoints_postgis(
+    sql,
+    con,
+    geom_col="geom",
+    crs=None,
+    index_col=None,
+    coerce_float=True,
+    parse_dates=None,
+    params=None,
+    chunksize=None,
+    **kwargs
+):
     """Read staypoints from a PostGIS database.
 
     Parameters
@@ -148,8 +263,37 @@ def read_staypoints_postgis(sql, con, geom_col="geom", **kwargs):
     geom_col : str, default 'geom'
         The geometry column of the table.
 
+    crs : optional
+        Coordinate reference system to use for the returned GeoDataFrame
+
+    index_col : string or list of strings, optional, default: None
+        Column(s) to set as index(MultiIndex)
+
+    coerce_float : boolean, default True
+        Attempt to convert values of non-string, non-numeric objects (like
+        decimal.Decimal) to floating point, useful for SQL result sets
+
+    parse_dates : list or dict, default None
+        - List of column names to parse as dates.
+        - Dict of ``{column_name: format string}`` where format string is
+            strftime compatible in case of parsing string times, or is one of
+            (D, s, ns, ms, us) in case of parsing integer timestamps.
+        - Dict of ``{column_name: arg dict}``, where the arg dict
+            corresponds to the keyword arguments of
+            :func:`pandas.to_datetime`. Especially useful with databases
+            without native Datetime support, such as SQLite.
+
+    params : list, tuple or dict, optional, default None
+        List of parameters to pass to execute method.
+
+    chunksize : int, default None
+        If specified, return an iterator where chunksize is the number
+        of rows to include in each chunk.
+
     **kwargs
-        Further keyword arguments as available in GeoPanda's GeoDataFrame.from_postgis().
+        Further keyword arguments as available in trackintels trackintel.io.read_staypoints_gpd().
+        Especially useful to rename column names from the SQL table to trackintel conform column names.
+        See second example how to use it in code.
 
 
     Returns
@@ -160,11 +304,22 @@ def read_staypoints_postgis(sql, con, geom_col="geom", **kwargs):
     Examples
     --------
     >>> spts = ti.io.read_staypoints_postgis("SELECT * FROM staypoints", con, geom_col="geom")
-
+    >>> spts = ti.io.read_staypoints_postgis("SELECT * FROM staypoints", con, geom_col="geom", index_col="id",
+    ...                                      started_at="start_time", finished_at="end_time", user_id="USER")
     """
-    spts = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", **kwargs)
+    spts = gpd.GeoDataFrame.from_postgis(
+        sql,
+        con,
+        geom_col=geom_col,
+        crs=crs,
+        index_col=index_col,
+        coerce_float=coerce_float,
+        parse_dates=parse_dates,
+        params=params,
+        chunksize=chunksize,
+    )
 
-    return ti.io.read_staypoints_gpd(spts, geom_col=geom_col)
+    return ti.io.read_staypoints_gpd(spts, **kwargs)
 
 
 @_handle_con_string
@@ -184,7 +339,18 @@ def write_staypoints_postgis(
 
 
 @_handle_con_string
-def read_locations_postgis(sql, con, geom_col="geom", **kwargs):
+def read_locations_postgis(
+    sql,
+    con,
+    center="center",
+    crs=None,
+    index_col=None,
+    coerce_float=True,
+    parse_dates=None,
+    params=None,
+    chunksize=None,
+    **kwargs
+):
     """Reads locations from a PostGIS database.
 
     Parameters
@@ -195,14 +361,40 @@ def read_locations_postgis(sql, con, geom_col="geom", **kwargs):
     con : str, sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
         Connection string or active connection to PostGIS database.
 
-    geom_col : str, default 'geom'
+    center : str, default 'center'
         The geometry column of the table. For the center of the location.
 
-    *args
-        Further arguments as available in GeoPanda's GeoDataFrame.from_postgis().
+    crs : optional
+        Coordinate reference system to use for the returned GeoDataFrame
+
+    index_col : string or list of strings, optional, default: None
+        Column(s) to set as index(MultiIndex)
+
+    coerce_float : boolean, default True
+        Attempt to convert values of non-string, non-numeric objects (like
+        decimal.Decimal) to floating point, useful for SQL result sets
+
+    parse_dates : list or dict, default None
+        - List of column names to parse as dates.
+        - Dict of ``{column_name: format string}`` where format string is
+            strftime compatible in case of parsing string times, or is one of
+            (D, s, ns, ms, us) in case of parsing integer timestamps.
+        - Dict of ``{column_name: arg dict}``, where the arg dict
+            corresponds to the keyword arguments of
+            :func:`pandas.to_datetime`. Especially useful with databases
+            without native Datetime support, such as SQLite.
+
+    params : list, tuple or dict, optional, default None
+        List of parameters to pass to execute method.
+
+    chunksize : int, default None
+        If specified, return an iterator where chunksize is the number
+        of rows to include in each chunk.
 
     **kwargs
-        Further keyword arguments as available in GeoPanda's GeoDataFrame.from_postgis().
+        Further keyword arguments as available in trackintels trackintel.io.read_locations_gpd().
+        Especially useful to rename column names from the SQL table to trackintel conform column names.
+        See second example how to use it in code.
 
     Returns
     -------
@@ -211,11 +403,24 @@ def read_locations_postgis(sql, con, geom_col="geom", **kwargs):
 
     Examples
     --------
-    >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, geom_col="geom")
+    >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, center="center")
+    >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, center="geom", index_col="id",
+    ...                                     user_id="USER", extent="extent")
+    )
     """
-    locs = gpd.GeoDataFrame.from_postgis(sql, con, geom_col=geom_col, index_col="id", **kwargs)
+    locs = gpd.GeoDataFrame.from_postgis(
+        sql,
+        con,
+        geom_col=center,
+        crs=crs,
+        index_col=index_col,
+        coerce_float=coerce_float,
+        parse_dates=parse_dates,
+        params=params,
+        chunksize=chunksize,
+    )
 
-    return ti.io.read_locations_gpd(locs, center=geom_col)
+    return ti.io.read_locations_gpd(locs, center=center, **kwargs)
 
 
 @_handle_con_string
@@ -234,7 +439,7 @@ def write_locations_postgis(
         else:
             dtype["extent"] = extent_schema
         locations = locations.copy()
-        locations["extent"] = locations["extent"].apply(lambda x: dumps(x, srid=srid, hex=True))
+        locations["extent"] = locations["extent"].apply(lambda x: wkb.dumps(x, srid=srid, hex=True))
 
     locations.to_postgis(
         name,
@@ -249,7 +454,18 @@ def write_locations_postgis(
 
 
 @_handle_con_string
-def read_trips_postgis(sql, con, **kwargs):
+def read_trips_postgis(
+    sql,
+    con,
+    geom_col=None,
+    crs=None,
+    index_col=None,
+    coerce_float=True,
+    parse_dates=None,
+    params=None,
+    chunksize=None,
+    **kwargs
+):
     """Read trips from a PostGIS database.
 
     Parameters
@@ -260,39 +476,107 @@ def read_trips_postgis(sql, con, **kwargs):
     con : str, sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
         Connection string or active connection to PostGIS database.
 
+    geom_col : str, optional
+        The geometry column of the table (if exists). Start and endpoint of the trip.
+
+    crs : optional
+        Coordinate reference system if table has geometry.
+
+    index_col : string or list of strings, optional, default: None
+        Column(s) to set as index(MultiIndex)
+
+    coerce_float : boolean, default True
+        Attempt to convert values of non-string, non-numeric objects (like
+        decimal.Decimal) to floating point, useful for SQL result sets
+
+    parse_dates : list or dict, default None
+        - List of column names to parse as dates.
+        - Dict of ``{column_name: format string}`` where format string is
+            strftime compatible in case of parsing string times, or is one of
+            (D, s, ns, ms, us) in case of parsing integer timestamps.
+        - Dict of ``{column_name: arg dict}``, where the arg dict
+            corresponds to the keyword arguments of
+            :func:`pandas.to_datetime`. Especially useful with databases
+            without native Datetime support, such as SQLite.
+
+    params : list, tuple or dict, optional, default None
+        List of parameters to pass to execute method.
+
+    chunksize : int, default None
+        If specified, return an iterator where chunksize is the number
+        of rows to include in each chunk.
+
     **kwargs
-        Further keyword arguments as available in GeoPanda's GeoDataFrame.from_postgis().
+        Further keyword arguments as available in trackintels trackintel.io.read_trips_gpd().
+        Especially useful to rename column names from the SQL table to trackintel conform column names.
+        See second example how to use it in code.
 
 
     Returns
     -------
-    DataFrame
-        A DataFrame containing the trips.
+    GeoDataFrame
+        A GeoDataFrame containing the trips.
 
     Examples
     --------
-    >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con, geom_col="geom")
+    >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con)
+    >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con, geom_col="geom", index_col="id",
+    ...                                  started_at="start_time", finished_at="end_time", user_id="USER",
+    ...                                  origin_staypoint_id="ORIGIN", destination_staypoint_id="DEST")
 
     """
-    trips = pd.read_sql(sql, con, index_col="id", **kwargs)
+    if geom_col is None:
+        trips = pd.read_sql(
+            sql,
+            con,
+            index_col=index_col,
+            coerce_float=coerce_float,
+            params=params,
+            parse_dates=parse_dates,
+            chunksize=chunksize,
+        )
+    else:
+        trips = gpd.GeoDataFrame.from_postgis(
+            sql,
+            con,
+            geom_col=geom_col,
+            crs=crs,
+            index_col=index_col,
+            coerce_float=coerce_float,
+            parse_dates=parse_dates,
+            params=params,
+            chunksize=chunksize,
+        )
 
-    return ti.io.read_trips_gpd(trips)
+    return ti.io.read_trips_gpd(trips, **kwargs)
 
 
 @_handle_con_string
 def write_trips_postgis(
     trips, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
 ):
-    trips.to_sql(
-        name,
-        con,
-        schema=schema,
-        if_exists=if_exists,
-        index=index,
-        index_label=index_label,
-        chunksize=chunksize,
-        dtype=dtype,
-    )
+    if isinstance(trips, gpd.GeoDataFrame):
+        trips.to_postgis(
+            name,
+            con,
+            schema=schema,
+            if_exists=if_exists,
+            index=index,
+            index_label=index_label,
+            chunksize=chunksize,
+            dtype=dtype,
+        )
+    else:  # is DataFrame
+        trips.to_sql(
+            name,
+            con,
+            schema=schema,
+            if_exists=if_exists,
+            index=index,
+            index_label=index_label,
+            chunksize=chunksize,
+            dtype=dtype,
+        )
 
 
 # helper docstring to change __doc__ of all write functions conveniently in one place


### PR DESCRIPTION
closes #277 
closes #301 

Added all `from_postgis` kwargs to `read_*_postgis` functions so that the arguments of `read_*_gpd` functions are also accessible via keywords arguments.
Also added distinction between the two trip models.