### PR TITLE
BUG: Fix threshold

### DIFF
--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import sys
-import re
+from pandas import Timestamp
 
 import geopandas as gpd
 import numpy as np
@@ -254,6 +254,37 @@ class TestGenerate_staypoints:
                 pfs.dropna(subset=["staypoint_id"], inplace=True)
                 pfs.drop_duplicates(subset=["staypoint_id"], keep="last", inplace=True)
                 assert (pfs["diff"] < gap_threshold).all()
+
+    def test_gap_threshold(self):
+        """Test for gap_threshold for consecutive pfs."""
+        # two pfs far apart in time that could potentially form a sp spatially.
+        pfs_dict = [
+            {
+                "latitude": 39.976,
+                "longitude": 116.330683333333,
+                "tracked_at": Timestamp("2007-08-09 01:35:46+0000", tz="UTC"),
+                "user_id": 55,
+            },
+            {
+                "latitude": 39.975818526,
+                "longitude": 116.331600228,
+                "tracked_at": Timestamp("2011-08-03 09:12:52+0000", tz="UTC"),
+                "user_id": 55,
+            },
+        ]
+        df = pd.DataFrame(pfs_dict)
+        pfs = gpd.GeoDataFrame(df, geometry=gpd.points_from_xy(df.longitude, df.latitude))
+        pfs.as_positionfixes
+        
+        # using the default gap_threshold will generate no sp
+        warn_string = "No staypoints can be generated, returning empty sp."
+        with pytest.warns(UserWarning, match=warn_string):
+            _, sp = pfs.as_positionfixes.generate_staypoints(include_last=True)
+            assert len(sp) == 0
+            
+        # using large gap_threshold one sp will be generated
+        _, sp = pfs.as_positionfixes.generate_staypoints(gap_threshold=1e8, include_last=True)
+        assert len(sp) == 1
 
 
 class TestGenerate_triplegs:

--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -275,13 +275,13 @@ class TestGenerate_staypoints:
         df = pd.DataFrame(pfs_dict)
         pfs = gpd.GeoDataFrame(df, geometry=gpd.points_from_xy(df.longitude, df.latitude))
         pfs.as_positionfixes
-        
+
         # using the default gap_threshold will generate no sp
         warn_string = "No staypoints can be generated, returning empty sp."
         with pytest.warns(UserWarning, match=warn_string):
             _, sp = pfs.as_positionfixes.generate_staypoints(include_last=True)
             assert len(sp) == 0
-            
+
         # using large gap_threshold one sp will be generated
         _, sp = pfs.as_positionfixes.generate_staypoints(gap_threshold=1e8, include_last=True)
         assert len(sp) == 1

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -18,7 +18,9 @@ from trackintel.preprocessing.triplegs import generate_trips
 def example_triplegs():
     """Generate input data for trip generation from geolife positionfixes"""
     pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join("tests", "data", "geolife_long"))
-    pfs, stps = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=25, time_threshold=5)
+    pfs, stps = pfs.as_positionfixes.generate_staypoints(
+        method="sliding", dist_threshold=25, time_threshold=5, gap_threshold=1e6
+    )
     stps = stps.as_staypoints.create_activity_flag(time_threshold=15)
     pfs, tpls = pfs.as_positionfixes.generate_triplegs(stps)
     return stps, tpls

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -429,17 +429,21 @@ def _generate_staypoints_sliding_user(
     for i in range(1, len(pfs)):
         curr = i
 
+        # the duration of gap in the last two pfs
+        gap_t = (pfs[curr]["tracked_at"] - pfs[curr - 1]["tracked_at"]).total_seconds()
+        # the gap of two consecutive positionfixes should not be too long
+        if gap_t > gap_threshold * 60:
+            start = curr
+            continue
+
         delta_dist = dist_func(pfs[start][geo_col].x, pfs[start][geo_col].y, pfs[curr][geo_col].x, pfs[curr][geo_col].y)
 
         if delta_dist >= dist_threshold:
             # the total duration of the staypoints
             delta_t = (pfs[curr]["tracked_at"] - pfs[start]["tracked_at"]).total_seconds()
-            # the duration of gap in the last two pfs
-            gap_t = (pfs[curr]["tracked_at"] - pfs[curr - 1]["tracked_at"]).total_seconds()
 
-            # we want the staypoint to have long duration,
-            # but the gap of two consecutive positionfixes should not be too long
-            if (delta_t >= (time_threshold * 60)) and (gap_t < gap_threshold * 60):
+            # we want the staypoint to have long duration
+            if delta_t >= (time_threshold * 60):
                 new_stps = __create_new_staypoints(start, curr, pfs, idx, elevation_flag, geo_col)
                 # add staypoint
                 ret_stps.append(new_stps)


### PR DESCRIPTION
closes #308

The solution is to move the gap_t condition before the time condition. I think this is then what we truly want, and is actually a stricter filtering criterion than before.
As one test for tripleg generation function depends on this change, I have to increase the gap_threshold for the fixture.