### PR TITLE
ENH: embed version number 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ else:
 # Where the magic happens:
 setup(
     name=NAME,
-    version=about["__version__"],
+    version=__version__,
     description=DESCRIPTION,
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/trackintel/__init__.py
+++ b/trackintel/__init__.py
@@ -10,4 +10,5 @@ from trackintel.io.file import read_locations_csv
 from trackintel.io.file import read_trips_csv
 
 #
+from trackintel.__version__ import __version__
 from .core import print_version

--- a/trackintel/core.py
+++ b/trackintel/core.py
@@ -6,7 +6,7 @@ def print_version():
 
     print(
         "This is trackintel v"
-        + str(__version__.__version__)
+        + str(__version__)
         + ". You can find more information "
         + "under https://github.com/mie-lab/trackintel. Thank you for using it!"
     )


### PR DESCRIPTION
Issue:
`ti.__version__` was not printing anything; It was returning a pointer to a function whereas `__version__.__version__` and `__version__.VERSION` were printing the version name.

Test: 
Previously we had: 
<img width="885" alt="Screenshot 2021-08-26 at 9 43 17 PM" src="https://user-images.githubusercontent.com/9101260/130973604-a5565d42-5728-4dbd-b110-aa74ccf1551c.png">


After this fix, we have:
<img width="323" alt="Screenshot 2021-08-26 at 9 17 21 PM" src="https://user-images.githubusercontent.com/9101260/130969428-42495542-558c-434a-af9c-5d573b5a03ab.png">

Soluton based on [this]( https://stackoverflow.com/a/16084844/3896008 ) stackoverflow answer from users: [sorin](https://stackoverflow.com/users/99834/sorin) and [nico-schlömer](https://stackoverflow.com/users/353337/nico-schl%c3%b6mer)