### PR TITLE
CLN: Add examples to `preprocessing` functions

### DIFF
--- a/trackintel/preprocessing/trips.py
+++ b/trackintel/preprocessing/trips.py
@@ -19,11 +19,14 @@ def get_trips_grouped(trips, tours):
     tours: GeoDataFrame (as trackintel tours)
         Output of generate_tours function, must contain column "trips" with list of trip ids on tour
 
-
     Returns
     -------
     trips_grouped_by_tour: DataFrameGroupBy object
         Trips grouped by tour id
+
+    Examples
+    --------
+    >>> get_trips_grouped(trips, tours)
 
     Notes
     -------
@@ -90,6 +93,10 @@ def generate_tours(
 
     tours: GeoDataFrame (as trackintel tours)
         The generated tours
+
+    Examples
+    --------
+    >>> trips.as_trips.generate_tours(staypoints)
 
     Notes
     -------

--- a/trackintel/preprocessing/util.py
+++ b/trackintel/preprocessing/util.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 
 def calc_temp_overlap(start_1, end_1, start_2, end_2):
     """
-    Calculate the portion of the first time span that overlaps with the second
+    Calculate the portion of the first time span that overlaps with the second.
 
     Parameters
     ----------
@@ -21,7 +21,11 @@ def calc_temp_overlap(start_1, end_1, start_2, end_2):
     Returns
     -------
     float:
-        The ratio by which the
+        The ratio by which the first timespan overlaps with the second.
+
+    Examples
+    --------
+    >>> ti.preprocessing.calc_temp_overlap(start_1, end_1, start_2, end_2)
 
     """
 
@@ -94,6 +98,11 @@ def applyParallel(dfGrouped, func, n_jobs, print_progress, **kwargs):
     -------
     pd.DataFrame:
         The result of dfGrouped.apply(func)
+
+    Examples
+    --------
+    >>> from trackintel.preprocessing.util import applyParallel
+    >>> applyParallel(tpfs.groupby("user_id", as_index=False), func, n_jobs=2)
     """
     df_ls = Parallel(n_jobs=n_jobs)(
         delayed(func)(group, **kwargs) for _, group in tqdm(dfGrouped, disable=not print_progress)


### PR DESCRIPTION
closes #339 

Added examples for:
- `generate_tours`
- `get_trips_grouped`
- `calc_temp_overlap`
- `applyParallel`