### PR TITLE
CLN: Add examples for visualization functions

### DIFF
--- a/trackintel/visualization/osm.py
+++ b/trackintel/visualization/osm.py
@@ -1,12 +1,12 @@
 import logging
 
 import osmnx as ox
-from networkx.exception import NetworkXPointlessConcept
 from matplotlib.collections import LineCollection
+from networkx.exception import NetworkXPointlessConcept
 
 
 def plot_osm_streets(north, south, east, west, ax):
-    """Plots OpenStreetMap streets onto an axis.
+    """Plots with osmnx OpenStreetMap streets onto an axis.
 
     Parameters
     ----------
@@ -21,6 +21,13 @@ def plot_osm_streets(north, south, east, west, ax):
 
     west : float
         The westernmost coordinate.
+
+    ax : matplotlib.pyplot.Artist, optional
+        Axis on which to draw the plot.
+
+    Examples
+    --------
+    >>> ti.visualization.osm.plot_osm_street(47.392, 47.364, 8.557, 8.509, ax)
     """
     try:
         G = ox.graph_from_bbox(north, south, east, west, network_type="drive")

--- a/trackintel/visualization/util.py
+++ b/trackintel/visualization/util.py
@@ -1,15 +1,10 @@
-import time
 import logging
-import warnings
+import time
 
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-
-from functools import partial
 from pint import UnitRegistry
-from shapely.geometry import Point
-
 
 ureg = UnitRegistry()
 
@@ -32,6 +27,10 @@ def a4_figsize(fig_height_mm=None, columns=2):
     -------
     (float, float)
         The width and height in which to plot a figure to fit on an A4 sheet.
+
+    Examples
+    --------
+    >>> ti.visualization.util.a4_figsize(columns=4)
     """
     if columns == 1:
         fig_width_mm = 84.0
@@ -100,6 +99,10 @@ def save_fig(out_filename, tight="tight", formats=["png", "pdf"]):
         How the bounding box should be drawn.
     formats : list
         A list denoting in which formats this figure should be saved ('png' or 'pdf').
+
+    Examples
+    --------
+    >>> ti.visualization.util("figure", formats=["png"])
     """
 
     if out_filename.endswith(".png"):


### PR DESCRIPTION
Added examples for:
- `a4_figsize`
- `save_fig`
- `plot_osm_streets`

`regular_figure` I deemed too trivial to include an example.

closes #340