### PR TITLE
ENH: use pd.Grouper for tracking quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You should then be able to run the examples in the `examples` folder or import t
 ```{python}
 import trackintel as ti
 
-ti.print_version()
+ti.print_version() 
 ```
 
 ## Requirements and dependencies

--- a/tests/analysis/test_tracking_quality.py
+++ b/tests/analysis/test_tracking_quality.py
@@ -221,6 +221,48 @@ class TestTemporal_tracking_quality:
         with pytest.warns(UserWarning):
             ti.analysis.tracking_quality.temporal_tracking_quality(sp)
 
+    def test_last_day_same_as_last_day_in_record(self):
+        """Test the take the last tracking record's day and assert it is the same as the
+        last absolute date in the quality."""
+        p1 = Point(8.5067847, 47.4)
+        t1 = pd.Timestamp("1971-01-01 00:00:00", tz="utc")
+
+        ten_days = pd.Timedelta(days=10)
+
+        list_dict = [
+            {"user_id": 0, "started_at": t1, "finished_at": t1, "geom": p1},  # duration 0 at midnight
+            {"user_id": 0, "started_at": t1, "finished_at": t1 - ten_days, "geom": p1},  # negative duration
+            {"user_id": 0, "started_at": t1, "finished_at": t1 + ten_days, "geom": p1},  # positive duration
+        ]
+
+        sp = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
+        sp.index.name = "id"
+
+        quality = ti.analysis.tracking_quality.temporal_tracking_quality(sp, granularity="day")
+        # get the "date" of the last record and compare to the last "date" in data
+        assert quality.values[-1][-2] == (t1 + ten_days - pd.Timedelta(days=1))
+
+    def test_last_day_same_as_last_week_in_record(self):
+        """Test the take the last tracking record's day and assert it is the same as the
+        last absolute date in the quality."""
+        p1 = Point(8.5067847, 47.4)
+        t1 = pd.Timestamp("1971-01-01 00:00:00", tz="utc")
+
+        four_weeks = pd.Timedelta(weeks=4)
+
+        list_dict = [
+            {"user_id": 0, "started_at": t1, "finished_at": t1, "geom": p1},  # duration 0 at midnight
+            {"user_id": 0, "started_at": t1, "finished_at": t1 - four_weeks, "geom": p1},  # negative duration
+            {"user_id": 0, "started_at": t1, "finished_at": t1 + four_weeks, "geom": p1},  # positive duration
+        ]
+
+        sp = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
+        sp.index.name = "id"
+
+        quality = ti.analysis.tracking_quality.temporal_tracking_quality(sp, granularity="week")
+        # get the "week" of the last record and compare to the last "week" in data
+        assert (quality.values[-1][-2]).week == (t1 + four_weeks).week
+
     def test_non_positive_duration_filtered(self):
         """Test the non positive duration records are filtered and do not affect the result."""
         p1 = Point(8.5067847, 47.4)

--- a/tests/analysis/test_tracking_quality.py
+++ b/tests/analysis/test_tracking_quality.py
@@ -69,8 +69,8 @@ class TestTemporal_tracking_quality:
         # test if the result of the user agrees
         quality = ti.analysis.tracking_quality.temporal_tracking_quality(sp_tpls, granularity="day")
 
-        assert quality_manual == quality.loc[(quality["user_id"] == 0) & (quality["day"] == 0), "quality"].values[0]
-        assert (quality["quality"] < 1).all()
+        assert quality_manual == quality.iloc[0]["quality"]
+        assert (quality["quality"] <= 1).all()
 
     def test_tracking_quality_week(self, testdata_sp_tpls_geolife_long):
         """Test if the calculated tracking quality per week is correct."""
@@ -92,7 +92,7 @@ class TestTemporal_tracking_quality:
         quality = ti.analysis.tracking_quality.temporal_tracking_quality(sp_tpls, granularity="week")
 
         assert quality_manual == quality.loc[(quality["user_id"] == 0), "quality"].values[0]
-        assert (quality["quality"] < 1).all()
+        assert (quality["quality"] <= 1).all()
 
     def test_tracking_quality_weekday(self, testdata_sp_tpls_geolife_long):
         """Test if the calculated tracking quality per weekday is correct."""
@@ -116,7 +116,7 @@ class TestTemporal_tracking_quality:
         quality = ti.analysis.tracking_quality.temporal_tracking_quality(sp_tpls, granularity="weekday")
 
         assert quality_manual == quality.loc[(quality["user_id"] == 0) & (quality["weekday"] == 3), "quality"].values[0]
-        assert (quality["quality"] < 1).all()
+        assert (quality["quality"] <= 1).all()
 
     def test_tracking_quality_hour(self, testdata_sp_tpls_geolife_long):
         """Test if the calculated tracking quality per hour is correct."""

--- a/trackintel/analysis/tracking_quality.py
+++ b/trackintel/analysis/tracking_quality.py
@@ -40,17 +40,33 @@ def temporal_tracking_quality(source, granularity="all", max_iter=60):
     datamodels and their combinations (e.g., staypoints and triplegs sequence).
 
     The temporal tracking quality is the ratio of tracking time and the total time extent. It is
-    calculated and returned per-user in the defined ``granularity``. The possible time extents of
-    the different granularities are different:
+    calculated and returned per-user in the defined ``granularity``. The time extents
+    and the columns for the returned ``quality`` df for different ``granularity`` are:
 
-    - ``all`` considers the time between the latest "finished_at" and the earliest "started_at";
-    - ``week`` considers the whole week (604800 sec)
-    - ``day`` and ``weekday`` consider the whole day (86400 sec)
-    - ``hour`` considers the whole hour (3600 sec).
+    - ``all``:
 
-    The tracking quality of each user is calculated based on his or her own tracking extent.
-    For granularity = ``day`` or ``week``, the quality["day"] or quality["week"] column displays the
-    time relative to the first record in the entire dataset.
+        - time extent: between the latest "finished_at" and the earliest "started_at" for each user.
+        - columns: ``['user_id', 'quality']``.
+
+    - ``week``:
+
+        - time extent: the whole week (604800 sec) for each user.
+        - columns: ``['user_id', 'week_monday', 'quality']``.
+
+    - ``day``:
+
+        - time extent: the whole day (86400 sec) for each user
+        - columns: ``['user_id', 'day', 'quality']``
+
+    - ``weekday``
+
+        - time extent: the whole day (86400 sec) * number of tracked weeks for each user for each user
+        - columns: ``['user_id', 'weekday', 'quality']``
+
+    - ``hour``:
+
+        - time extent: the whole hour (3600 sec) * number of tracked days for each user
+        - columns: ``['user_id', 'hour', 'quality']``
 
     Examples
     --------
@@ -80,66 +96,46 @@ def temporal_tracking_quality(source, granularity="all", max_iter=60):
 
     if granularity == "all":
         quality = df.groupby("user_id", as_index=False).apply(_get_tracking_quality_user, granularity)
+        return quality
 
-    elif granularity == "day":
-        # split records that span several days
-        df = _split_overlaps(df, granularity=granularity, max_iter=max_iter)
-        # get the tracked day relative to the first day
-        start_date = df["started_at"].min().date()
-        df["day"] = df["started_at"].apply(lambda x: (x.date() - start_date).days)
-
-        # calculate per-user per-day raw tracking quality
-        raw_quality = df.groupby(["user_id", "day"], as_index=False).apply(_get_tracking_quality_user, granularity)
-        # add quality = 0 records
-        quality = _get_all_quality(df, raw_quality, granularity)
+    # split records that span several days
+    df = _split_overlaps(df, granularity="day", max_iter=max_iter)
+    if granularity == "day":
+        grouper = pd.Grouper(key="started_at", freq="D")
+        column_name = "day"
 
     elif granularity == "week":
-        # split records that span several days
-        df = _split_overlaps(df, granularity="day", max_iter=max_iter)
-        # get the tracked week relative to the first day
-        start_date = df["started_at"].min().date()
-        df["week"] = df["started_at"].apply(lambda x: (x.date() - start_date).days // 7)
-
-        # calculate per-user per-week raw tracking quality
-        raw_quality = df.groupby(["user_id", "week"], as_index=False).apply(_get_tracking_quality_user, granularity)
-        # add quality = 0 records
-        quality = _get_all_quality(df, raw_quality, granularity)
+        grouper = pd.Grouper(key="started_at", freq="W")
+        column_name = "week_monday"
 
     elif granularity == "weekday":
-        # split records that span several days
-        df = _split_overlaps(df, granularity="day", max_iter=max_iter)
-
         # get the tracked week relative to the first day
         start_date = df["started_at"].min().date()
         df["week"] = df["started_at"].apply(lambda x: (x.date() - start_date).days // 7)
-        # get the weekday
-        df["weekday"] = df["started_at"].dt.weekday
 
-        # calculate per-user per-weekday raw tracking quality
-        raw_quality = df.groupby(["user_id", "weekday"], as_index=False).apply(_get_tracking_quality_user, granularity)
-        # add quality = 0 records
-        quality = _get_all_quality(df, raw_quality, granularity)
+        grouper = df["started_at"].dt.weekday
+        column_name = "weekday"
 
     elif granularity == "hour":
-        # first do a day split to speed up the hour split
-        df = _split_overlaps(df, granularity="day", max_iter=max_iter)
-        df = _split_overlaps(df, granularity=granularity)
-
+        df = _split_overlaps(df, granularity="hour")
         # get the tracked day relative to the first day
         start_date = df["started_at"].min().date()
         df["day"] = df["started_at"].apply(lambda x: (x.date() - start_date).days)
-        # get the hour
-        df["hour"] = df["started_at"].dt.hour
 
-        # calculate per-user per-hour raw tracking quality
-        raw_quality = df.groupby(["user_id", "hour"], as_index=False).apply(_get_tracking_quality_user, granularity)
-        # add quality = 0 records
-        quality = _get_all_quality(df, raw_quality, granularity)
+        grouper = df["started_at"].dt.hour
+        column_name = "hour"
 
     else:
         raise AttributeError(
             f"granularity unknown. We only support ['all', 'day', 'week', 'weekday', 'hour']. You passed {granularity}"
         )
+
+    # calculate per-user per-grouper tracking quality
+    quality = df.groupby(["user_id", grouper]).apply(_get_tracking_quality_user, granularity).reset_index()
+
+    # rename and reorder
+    quality.rename(columns={"started_at": column_name}, inplace=True)
+    quality = quality[["user_id", column_name, "quality"]]
 
     return quality
 


### PR DESCRIPTION
closes #258

main changes:
- We use pd.Grouper to group days or weeks and return the datatime object. The granularity == "day" and "week" now only returns the absolute date. 
- As we have no relative days, we no longer fill in quality == 0 records (_get_all_quality() is now unused).
- Description added to the docstrings