### PR TITLE
TST: Fix test error

### DIFF
--- a/tests/geogr/test_distances.py
+++ b/tests/geogr/test_distances.py
@@ -112,7 +112,8 @@ class TestCalculate_distance_matrix:
         yx = np.concatenate((y_rad.reshape(-1, 1), x_rad.reshape(-1, 1)), axis=1)
 
         their_d_matrix = pairwise_distances(yx, metric="haversine") * 6371000
-        assert np.allclose(our_d_matrix, their_d_matrix, atol=0.001)  # atol = 1mm
+        # atol = 1mm
+        assert np.allclose(our_d_matrix, their_d_matrix, atol=0.001)  
 
     def test_trajectory_distance_dtw(self, geolife_tpls):
         """Calculate Linestring length using dtw, single and multi core."""

--- a/tests/geogr/test_distances.py
+++ b/tests/geogr/test_distances.py
@@ -113,7 +113,7 @@ class TestCalculate_distance_matrix:
 
         their_d_matrix = pairwise_distances(yx, metric="haversine") * 6371000
         # atol = 1mm
-        assert np.allclose(our_d_matrix, their_d_matrix, atol=0.001)  
+        assert np.allclose(our_d_matrix, their_d_matrix, atol=0.001)
 
     def test_trajectory_distance_dtw(self, geolife_tpls):
         """Calculate Linestring length using dtw, single and multi core."""

--- a/tests/geogr/test_distances.py
+++ b/tests/geogr/test_distances.py
@@ -112,8 +112,8 @@ class TestCalculate_distance_matrix:
         yx = np.concatenate((y_rad.reshape(-1, 1), x_rad.reshape(-1, 1)), axis=1)
 
         their_d_matrix = pairwise_distances(yx, metric="haversine") * 6371000
-        # atol = 1mm
-        assert np.allclose(our_d_matrix, their_d_matrix, atol=0.001)
+        # atol = 10mm
+        assert np.allclose(our_d_matrix, their_d_matrix, atol=0.01)
 
     def test_trajectory_distance_dtw(self, geolife_tpls):
         """Calculate Linestring length using dtw, single and multi core."""

--- a/tests/geogr/test_distances.py
+++ b/tests/geogr/test_distances.py
@@ -99,6 +99,7 @@ class TestCalculate_distance_matrix:
         assert np.array_equal(d_euc, d_mink2)
 
     def test_compare_haversine_to_scikit_xy(self):
+        """Test the results using our haversine function and scikit function."""
         sp_file = os.path.join("tests", "data", "geolife", "geolife_staypoints.csv")
         sp = ti.read_staypoints_csv(sp_file, tz="utc", index_col="id")
         our_d_matrix = calculate_distance_matrix(X=sp, Y=sp, dist_metric="haversine")
@@ -111,7 +112,7 @@ class TestCalculate_distance_matrix:
         yx = np.concatenate((y_rad.reshape(-1, 1), x_rad.reshape(-1, 1)), axis=1)
 
         their_d_matrix = pairwise_distances(yx, metric="haversine") * 6371000
-        assert np.allclose(np.abs(our_d_matrix - their_d_matrix), 0, atol=0.001)  # atol = 1mm
+        assert np.allclose(our_d_matrix, their_d_matrix, atol=0.001)  # atol = 1mm
 
     def test_trajectory_distance_dtw(self, geolife_tpls):
         """Calculate Linestring length using dtw, single and multi core."""


### PR DESCRIPTION
Fixes the error originated from `sklearn.metrics.pairwise_distances`: The atol is increased to 0.01 (1cm) instead of 0.001 (1mm). 

I suspect the error originated from their new 1.0.2 release, but I did not find any related changes in their [changelog](https://scikit-learn.org/dev/whats_new/v1.0.html#sklearn-metrics)