### PR TITLE
ENH: Add `_explode_agg` to simplify id assignment in staypoint generation

### DIFF
--- a/tests/preprocessing/test_util.py
+++ b/tests/preprocessing/test_util.py
@@ -1,8 +1,10 @@
 import datetime
 
+import pandas as pd
+from pandas.testing import assert_frame_equal
 import pytest
 
-from trackintel.preprocessing.util import calc_temp_overlap
+from trackintel.preprocessing.util import calc_temp_overlap, _explode_agg
 
 
 @pytest.fixture
@@ -35,3 +37,36 @@ class TestCalc_temp_overlap:
         """If the two intervals do not overlap the ratio should be 0"""
         ratio = calc_temp_overlap(time_1, time_1 + one_hour, time_1 + one_hour, time_1 + 2 * one_hour)
         assert ratio == 0
+
+
+class TestExplodeAgg:
+    """Test util method _explode_agg"""
+    def test_empty_agg(self):
+        """Test function with empty agg DataFrame"""
+        orig = [
+            {"a": 1, "b": "i", "c": None},
+            {"a": 2, "b": "i", "c": None},
+        ]
+        orig_df = pd.DataFrame(orig, columns=["a", "b"])
+        agg_df = pd.DataFrame({}, columns=["id", "c"])
+        returned_df = _explode_agg("id", "c", orig_df, agg_df)
+        solution_df = pd.DataFrame(orig)
+        assert_frame_equal(returned_df, solution_df)
+
+    def test_list_column(self):
+        """Test function with a column of lists."""
+        orig = [
+            {"a": 1, "c": 0},
+            {"a": 2, "c": 0},
+            {"a": 3, "c": None},
+            {"a": 4, "c": 1},
+        ]
+        agg = [
+            {"id": [0, 1], "c": 0},
+            {"id": [3], "c": 1},
+        ]
+        orig_df = pd.DataFrame(orig, columns=["a"])
+        agg_df = pd.DataFrame(agg)
+        returned_df = _explode_agg("id", "c", orig_df, agg_df)
+        solution_df = pd.DataFrame(orig)
+        assert_frame_equal(returned_df, solution_df)

--- a/tests/preprocessing/test_util.py
+++ b/tests/preprocessing/test_util.py
@@ -41,6 +41,7 @@ class TestCalc_temp_overlap:
 
 class TestExplodeAgg:
     """Test util method _explode_agg"""
+
     def test_empty_agg(self):
         """Test function with empty agg DataFrame"""
         orig = [

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -143,6 +143,8 @@ def generate_staypoints(
         sp["staypoint_id"] = sp.index
         sp.index.name = "id"
 
+        if "pfs_id" not in sp.columns:
+            sp["pfs_id"] = None
         pfs = _explode_agg("pfs_id", "staypoint_id", pfs, sp)
     sp = gpd.GeoDataFrame(sp, columns=sp_column, geometry=geo_col, crs=pfs.crs)
 

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -247,7 +247,7 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
     tpls = _explode_agg("tpls", "trip_id", tpls, trips)
 
     # assign trip_id to sp, for non-activity sp
-    trips = _explode_agg("sp", "trip_id", sp, trips)
+    sp = _explode_agg("sp", "trip_id", sp, trips)
 
     # fill missing points and convert to MultiPoint
     # for all trips with missing 'origin_staypoint_id' we now assign the startpoint of the first tripleg of the trip.

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -5,6 +5,8 @@ import numpy as np
 import pandas as pd
 from shapely.geometry import MultiPoint, Point
 
+from trackintel.preprocessing.util import _explode_agg
+
 
 def smoothen_triplegs(triplegs, tolerance=1.0, preserve_topology=True):
     """
@@ -242,16 +244,10 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
 
     # now handle the data that is aggregated in the trips
     # assign trip_id to tpls
-    temp = trips.explode("tpls")
-    temp.index = temp["tpls"]
-    temp = temp[temp["tpls"].notna()]
-    tpls = tpls.join(temp["trip_id"], how="left")
+    tpls = _explode_agg("tpls", "trip_id", tpls, trips)
 
     # assign trip_id to sp, for non-activity sp
-    temp = trips.explode("sp")
-    temp.index = temp["sp"]
-    temp = temp[temp["sp"].notna()]
-    sp = sp.join(temp["trip_id"], how="left")
+    trips = _explode_agg("sp", "trip_id", sp, trips)
 
     # fill missing points and convert to MultiPoint
     # for all trips with missing 'origin_staypoint_id' we now assign the startpoint of the first tripleg of the trip.

--- a/trackintel/preprocessing/util.py
+++ b/trackintel/preprocessing/util.py
@@ -108,3 +108,29 @@ def applyParallel(dfGrouped, func, n_jobs, print_progress, **kwargs):
         delayed(func)(group, **kwargs) for _, group in tqdm(dfGrouped, disable=not print_progress)
     )
     return pd.concat(df_ls)
+
+
+def _explode_agg(column, agg, orig_df, agg_df):
+    """
+    Assign new aggrated information back to the original dataframe.
+
+    Parameters
+    ----------
+    column : IndexLabel
+        Column(s) to explode. Should be index column of orig_df.
+    agg : IndexLabel
+        Aggregate column to join back to original df.
+    orig_df : pd.DataFrame
+        Original Dataframe without the aggregate column.
+    agg_df : pd.DataFrame
+        Dataframe with the aggregate column.
+
+    Returns
+    -------
+    pd.DataFrame
+        Original Dataframe with additional colum from aggregated DataFrame.
+    """
+    temp = agg_df.explode(column)
+    temp.index = temp[column]
+    temp = temp[temp[column].notna()]
+    return orig_df.join(temp[agg], how="left")


### PR DESCRIPTION
closes #326 
Adds new function `_explode_agg` and tests for that function.
This function is used in `generate_trips` and `generate_staypoints`.