### PR TITLE
BUG: Fix osna idxmax over labels without any accumulated time

### DIFF
--- a/tests/analysis/test_location_identification.py
+++ b/tests/analysis/test_location_identification.py
@@ -418,22 +418,22 @@ class TestOsna_Method:
         example_osna.loc[example_osna["location_id"] == 1, "purpose"] = "work"
         assert_geodataframe_equal(example_osna, result)
 
-    # def test_multiple_users_with_only_one_location(self):
-    #     """Test that function can handle multiple users with only one location."""
-    #     t_leis = pd.Timestamp("2021-07-14 01:00:00", tz="utc")
-    #     t_work = pd.Timestamp("2021-07-14 18:00:00", tz="utc")
-    #     h = pd.Timedelta("1h")
-    #     list_dict = [
-    #         {"user_id": 0, "location_id": 0, "started_at": t_leis, "finished_at": t_leis + h},
-    #         {"user_id": 0, "location_id": 1, "started_at": t_work, "finished_at": t_work + h},
-    #         {"user_id": 1, "location_id": 0, "started_at": t_leis, "finished_at": t_leis + h},
-    #         {"user_id": 2, "location_id": 0, "started_at": t_work, "finished_at": t_work + h},
-    #     ]
-    #     sp = pd.DataFrame(list_dict)
-    #     sp.index.name = "id"
-    #     result = osna_method(sp)
-    #     sp["purpose"] = ["home", "work", "home", "work"]
-    #     assert_frame_equal(sp, result)
+    def test_multiple_users_with_only_one_location(self):
+        """Test that function can handle multiple users with only one location."""
+        t_leis = pd.Timestamp("2021-07-14 01:00:00", tz="utc")
+        t_work = pd.Timestamp("2021-07-14 18:00:00", tz="utc")
+        h = pd.Timedelta("1h")
+        list_dict = [
+            {"user_id": 0, "location_id": 0, "started_at": t_leis, "finished_at": t_leis + h},
+            {"user_id": 0, "location_id": 1, "started_at": t_work, "finished_at": t_work + h},
+            {"user_id": 1, "location_id": 0, "started_at": t_leis, "finished_at": t_leis + h},
+            {"user_id": 2, "location_id": 0, "started_at": t_work, "finished_at": t_work + h},
+        ]
+        sp = pd.DataFrame(list_dict)
+        sp.index.name = "id"
+        result = osna_method(sp)
+        sp["purpose"] = ["home", "work", "home", "work"]
+        assert_frame_equal(sp, result)
 
 
 class Test_osna_label_timeframes:


### PR DESCRIPTION
With removing pandas version <=v.1.2.5 we got also a change that broke
the osna method in location identification.
I could not really trace the origin of the change but in the end the
`idxmax` from pandas uses `nanargmax` from numpy. That works even if
everything is nan, but only if it is nan and not any other NA value.
In our case that was pd.NaT for the Timedeltas. In my opinion that is a bug
in pandas as their documentation is stating that it works for NA
(that includes NaT).
Well in the end I only had to change the dtype of the aggregated column. :D

TLDR: Changed dtype such that idxmax gets np.nan

closes #380 
(and partially #378) 