### PR TITLE
BUG: Fix dtype change in `_explode_agg`

### DIFF
--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -284,22 +284,22 @@ class TestGenerate_trips:
         # test if generated staypoints/triplegs are equal (especially important for trip ids)
         assert_frame_equal(sp_tpls_loaded, sp_tpls, check_dtype=False)
 
-    # def test_generate_trips_id_management(self, example_triplegs_higher_gap_threshold):
-    #     """Test if we can generate the example trips based on example data."""
-    #     sp_tpls_loaded = pd.read_csv(os.path.join("tests", "data", "geolife_long", "sp_tpls.csv"), index_col="id")
-    #     sp_tpls_loaded["started_at"] = pd.to_datetime(sp_tpls_loaded["started_at"])
-    #     sp_tpls_loaded["started_at_next"] = pd.to_datetime(sp_tpls_loaded["started_at_next"])
-    #     sp_tpls_loaded["finished_at"] = pd.to_datetime(sp_tpls_loaded["finished_at"])
+    def test_generate_trips_id_management(self, example_triplegs_higher_gap_threshold):
+        """Test if we can generate the example trips based on example data."""
+        sp_tpls_loaded = pd.read_csv(os.path.join("tests", "data", "geolife_long", "sp_tpls.csv"), index_col="id")
+        sp_tpls_loaded["started_at"] = pd.to_datetime(sp_tpls_loaded["started_at"])
+        sp_tpls_loaded["started_at_next"] = pd.to_datetime(sp_tpls_loaded["started_at_next"])
+        sp_tpls_loaded["finished_at"] = pd.to_datetime(sp_tpls_loaded["finished_at"])
 
-    #     sp, tpls = example_triplegs_higher_gap_threshold
+        sp, tpls = example_triplegs_higher_gap_threshold
 
-    #     # generate trips and a joint staypoint/triplegs dataframe
-    #     gap_threshold = 15
-    #     sp, tpls, _ = generate_trips(sp, tpls, gap_threshold=gap_threshold)
-    #     sp_tpls = _create_debug_sp_tpls_data(sp, tpls, gap_threshold=gap_threshold)
+        # generate trips and a joint staypoint/triplegs dataframe
+        gap_threshold = 15
+        sp, tpls, _ = generate_trips(sp, tpls, gap_threshold=gap_threshold)
+        sp_tpls = _create_debug_sp_tpls_data(sp, tpls, gap_threshold=gap_threshold)
 
-    #     # test if generated staypoints/triplegs are equal (especially important for trip ids)
-    #     assert_frame_equal(sp_tpls_loaded, sp_tpls, check_dtype=False)
+        # test if generated staypoints/triplegs are equal (especially important for trip ids)
+        assert_frame_equal(sp_tpls_loaded, sp_tpls, check_dtype=False)
 
     def test_only_staypoints_in_trip(self):
         """Test that trips with only staypoints (non-activities) are deleted."""

--- a/tests/preprocessing/test_util.py
+++ b/tests/preprocessing/test_util.py
@@ -71,3 +71,15 @@ class TestExplodeAgg:
         returned_df = _explode_agg("id", "c", orig_df, agg_df)
         solution_df = pd.DataFrame(orig)
         assert_frame_equal(returned_df, solution_df)
+
+    def test_index_dtype_with_None(self):
+        """Test if dtype of index isn't changed with None values."""
+        orig = [
+            {"a": 1, "c": 0},
+        ]
+        agg = [{"id": [0, 1], "c": 0}, {"id": [], "c": 1}]
+        orig_df = pd.DataFrame(orig, columns=["a"])
+        agg_df = pd.DataFrame(agg)
+        returned_df = _explode_agg("id", "c", orig_df, agg_df)
+        solution_df = pd.DataFrame(orig)
+        assert_frame_equal(returned_df, solution_df)

--- a/trackintel/preprocessing/util.py
+++ b/trackintel/preprocessing/util.py
@@ -131,6 +131,6 @@ def _explode_agg(column, agg, orig_df, agg_df):
         Original Dataframe with additional colum from aggregated DataFrame.
     """
     temp = agg_df.explode(column)
-    temp.index = temp[column]
     temp = temp[temp[column].notna()]
+    temp.index = temp[column]
     return orig_df.join(temp[agg], how="left")


### PR DESCRIPTION
Dtype of index changed after using the `_explode_agg` function because nan are filtered one step too late. 