### PR TITLE
ENH: Handle shapely 2.0 deprecation warnings

### DIFF
--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -115,7 +115,7 @@ class TestGenerate_trips:
 
         # Check start and destination points of all rows
         for i, row in trips.iterrows():
-            start_point_trips = row["geom"][0]  # get origin Point in generated trips
+            start_point_trips = row["geom"].geoms[0]  # get origin Point in generated trips
             if not pd.isna(row["origin_staypoint_id"]):
                 # compare to the Point in the staypoints
                 correct_start_point = sp.loc[row["origin_staypoint_id"], "geom"]
@@ -124,11 +124,11 @@ class TestGenerate_trips:
                 # get all triplegs on this trip
                 tpls_on_trip = tpls[tpls["trip_id"] == row.name]
                 # correct point is the first point on the tripleg
-                correct_start_point, _ = tpls_on_trip.iloc[0]["geom"].boundary
+                correct_start_point, _ = tpls_on_trip.iloc[0]["geom"].boundary.geoms
 
             assert correct_start_point == start_point_trips
 
-            dest_point_trips = row["geom"][1]  # get destination Point in generated trips
+            dest_point_trips = row["geom"].geoms[1]  # get destination Point in generated trips
             if not pd.isna(row["destination_staypoint_id"]):
                 correct_dest_point = sp.loc[row["destination_staypoint_id"], "geom"]
                 # compare to the Point in the staypoints
@@ -137,7 +137,7 @@ class TestGenerate_trips:
                 # get all triplegs on this trip
                 tpls_on_trip = tpls[tpls["trip_id"] == row.name]
                 # correct point is the first point on the tripleg
-                _, correct_dest_point = tpls_on_trip.iloc[-1]["geom"].boundary
+                _, correct_dest_point = tpls_on_trip.iloc[-1]["geom"].boundary.geoms
 
             assert correct_dest_point == dest_point_trips
 
@@ -364,7 +364,7 @@ class TestGenerate_trips:
         sp, tpls, trips = ti.preprocessing.triplegs.generate_trips(sp, tpls, gap_threshold=15)
 
         # test if start of first trip is (0,0)
-        assert trips.loc[0, "geom"][0] == Point(0, 0)
+        assert trips.loc[0, "geom"].geoms[0] == Point(0, 0)
 
 
 def _create_debug_sp_tpls_data(sp, tpls, gap_threshold):

--- a/tests/preprocessing/test_trips.py
+++ b/tests/preprocessing/test_trips.py
@@ -124,8 +124,8 @@ def example_nested_tour(example_trip_data):
 
     # construct trips that lie between trips 6 and 15 and form a tour on their own
     # define start and end points of these trips
-    first_trip_subtour = MultiPoint((trips.loc[15, "geom"][0], Point(9.5067847, 47.20001)))
-    second_trip_subtour = MultiPoint((Point(9.5067847, 47.20001), trips.loc[15, "geom"][0]))
+    first_trip_subtour = MultiPoint((trips.loc[15, "geom"].geoms[0], Point(9.5067847, 47.20001)))
+    second_trip_subtour = MultiPoint((Point(9.5067847, 47.20001), trips.loc[15, "geom"].geoms[0]))
     # define time of start and time at the intermediate point
     start_time_subtour = pd.Timestamp("1971-01-02 08:45:00", tz="utc")
     middle_time = pd.Timestamp("1971-01-02 08:55:00", tz="utc")

--- a/trackintel/preprocessing/trips.py
+++ b/trackintel/preprocessing/trips.py
@@ -257,8 +257,8 @@ def _generate_tours_user(
             else:
                 # If no locations are available, check whether the distance is smaller than max_dist
                 end_start_at_same_loc = _check_max_dist(
-                    user_trip_df.loc[start_candidates[-1], geom_col][1],  # destination point of previous trip
-                    row[geom_col][0],  # start point of current trip
+                    user_trip_df.loc[start_candidates[-1], geom_col].geoms[1],  # destination point of previous trip
+                    row[geom_col].geoms[0],  # start point of current trip
                     max_dist,
                     crs_is_projected,
                 )
@@ -318,8 +318,8 @@ def _generate_tours_user(
             else:
                 # if no locations are available, check whether the distance is smaller than max_dist
                 end_start_at_same_loc = _check_max_dist(
-                    user_trip_df.loc[cand, geom_col][0],  # start point of first trip
-                    row[geom_col][1],  # destination point of current trip
+                    user_trip_df.loc[cand, geom_col].geoms[0],  # start point of first trip
+                    row[geom_col].geoms[1],  # destination point of current trip
                     max_dist,
                     crs_is_projected=crs_is_projected,
                 )


### PR DESCRIPTION
Shapely 2.0.0 will do some internal refactoring to improve performance (based on pygeos), but will also bring some changes. Read more about it [here](https://shapely.readthedocs.io/en/latest/migration.html).
So far, these changes have only generated warnings, but I've updated the relevant sections.
This doesn't involve much more than adding `.geoms` everywhere so that it works as before.