### PR TITLE
ENH: Replace df.append with pd.concat (Future warning)

### DIFF
--- a/tests/analysis/test_location_identification.py
+++ b/tests/analysis/test_location_identification.py
@@ -308,7 +308,7 @@ class TestOsna_Method:
         ]
         sp = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
         sp.index.name = "id"
-        sp = example_osna.append(sp)
+        sp = pd.concat((example_osna, sp))
 
         result = osna_method(sp).iloc[:-2]
         example_osna.loc[example_osna["location_id"] == 0, "purpose"] = "home"
@@ -339,7 +339,7 @@ class TestOsna_Method:
 
     def test_two_users(self, example_osna):
         """Test if two users are handled correctly."""
-        two_user = example_osna.append(example_osna)
+        two_user = pd.concat((example_osna, example_osna))
         two_user.iloc[len(example_osna) :, 0] = 1  # second user gets id 1
         result = osna_method(two_user)
         two_user.loc[two_user["location_id"] == 0, "purpose"] = "home"

--- a/tests/analysis/test_tracking_quality.py
+++ b/tests/analysis/test_tracking_quality.py
@@ -18,7 +18,7 @@ def testdata_sp_tpls_geolife_long():
 
     tpls["type"] = "tripleg"
     sp["type"] = "staypoint"
-    sp_tpls = sp.append(tpls, ignore_index=True).sort_values(by="started_at")
+    sp_tpls = pd.concat((sp, tpls), ignore_index=True).sort_values(by="started_at")
     return sp_tpls
 
 

--- a/tests/io/test_dataset_reader.py
+++ b/tests/io/test_dataset_reader.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from re import M
 
 import pandas as pd
 import pytest
@@ -171,21 +172,16 @@ class TestGeolife_add_modes_to_triplegs:
         triplegs, labels_raw = matching_data
 
         # add one record to the labels_raw: mode bus which are 1 min shorter than mode bike
-        labels_raw = (
-            labels_raw.reset_index()
-            .append(
-                [
-                    {
-                        "id": 2,
-                        # this record started 1 minute later than id=1 record - the final match ratio will be lower
-                        "started_at": labels_raw.iloc[-1]["started_at"] + datetime.timedelta(minutes=1),
-                        "finished_at": labels_raw.iloc[-1]["finished_at"],
-                        "mode": "bus",
-                    },
-                ]
-            )
-            .set_index("id")
-        )
+        labels_raw.reset_index(inplace=True)
+        entry = {
+            "id": 2,
+            # this record started 1 minute later than id=1 record - the final match ratio will be lower
+            "started_at": labels_raw.iloc[-1]["started_at"] + datetime.timedelta(minutes=1),
+            "finished_at": labels_raw.iloc[-1]["finished_at"],
+            "mode": "bus",
+        }
+        entry = pd.DataFrame([entry])
+        labels_raw = pd.concat((labels_raw, entry)).set_index("id")
         labels = {0: labels_raw}
 
         # the correct behaviour is to only choose one mode per tripleg id based on overlapping ratio

--- a/tests/io/test_dataset_reader.py
+++ b/tests/io/test_dataset_reader.py
@@ -1,11 +1,9 @@
 import datetime
 import os
-from re import M
 
 import pandas as pd
 import pytest
 from geopandas.testing import assert_geodataframe_equal
-from pandas.testing import assert_frame_equal
 from shapely.geometry import Point
 
 import trackintel as ti

--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -493,7 +493,7 @@ class TestGenerate_triplegs:
 
         sp = sp[["started_at", "finished_at", "user_id"]]
         tpls = tpls[["started_at", "finished_at", "user_id"]]
-        sp_tpls = sp.append(tpls)
+        sp_tpls = pd.concat((sp, tpls))
         sp_tpls.sort_values(by=["user_id", "started_at"], inplace=True)
 
         for user_id_this in sp["user_id"].unique():

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -372,9 +372,9 @@ def _create_debug_sp_tpls_data(sp, tpls, gap_threshold):
     # create table with relevant information from triplegs and staypoints.
     tpls["type"] = "tripleg"
     sp["type"] = "staypoint"
-    sp_tpls = sp[
-        ["started_at", "finished_at", "user_id", "type", "is_activity", "trip_id", "prev_trip_id", "next_trip_id"]
-    ].append(tpls[["started_at", "finished_at", "user_id", "type", "trip_id"]])
+    cols_sp = ["started_at", "finished_at", "user_id", "type", "is_activity", "trip_id", "prev_trip_id", "next_trip_id"]
+    cols_tpls = ["started_at", "finished_at", "user_id", "type", "trip_id"]
+    sp_tpls = pd.concat((sp[cols_sp], tpls[cols_tpls]))
 
     # transform nan to bool
     sp_tpls["is_activity"] = sp_tpls["is_activity"] == True

--- a/trackintel/analysis/tracking_quality.py
+++ b/trackintel/analysis/tracking_quality.py
@@ -262,7 +262,7 @@ def _split_overlaps(source, granularity="day", max_iter=60):
         new_df.loc[change_flag, "started_at"] = df.loc[change_flag, "finished_at"]
         new_df.loc[change_flag, "finished_at"] = finished_at_temp
 
-        df = df.append(new_df, ignore_index=True, sort=True)
+        df = pd.concat((df, new_df), ignore_index=True, sort=True)
 
         change_flag = __get_split_index(df, granularity=granularity)
         iter_count += 1


### PR DESCRIPTION
In future versions of Pandas, `concat` will be deprecated. 
Read more about this [here](https://github.com/pandas-dev/pandas/issues/35407).