### PR TITLE
ENH: Refactor file IO

### DIFF
--- a/.github/envs/39-latest-conda-forge.yaml
+++ b/.github/envs/39-latest-conda-forge.yaml
@@ -18,7 +18,7 @@ dependencies:
 - tqdm
 - similaritymeasures
 - jupyter
-- geopandas
+- geopandas>=0.9.0
 - shapely
 
 # tests

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
 # - python=3.8
-- geopandas
+- geopandas>=0.9.0
 - pip:
   - numpy
   - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - numpy
 - matplotlib
 - pandas
-- geopandas
+- geopandas>=0.9.0
 - scikit-learn
 - networkx 
 - pint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 matplotlib
 pandas
-geopandas
+geopandas>=0.9.0
 scikit-learn
 networkx 
 pint 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ LICENSE = "MIT"
 # What packages are required for this module to be executed?
 REQUIRED = [
     "pandas",
-    "geopandas",
+    "geopandas>=0.9.0",
     "matplotlib",
     "numpy",
     "pint",
@@ -46,7 +46,7 @@ install_requires = [
     "osmnx",
     "scikit-learn",
     "tqdm",
-    "geopandas",
+    "geopandas>=0.9.0",
     "similaritymeasures",
 ]
 

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -6,7 +6,14 @@ import geopandas as gpd
 import pandas as pd
 from geopandas.geodataframe import GeoDataFrame
 from shapely import wkt
-from trackintel.io.from_geopandas import read_locations_gpd, read_positionfixes_gpd, _localize_timestamp, read_staypoints_gpd, read_tours_gpd, read_triplegs_gpd, read_trips_gpd
+from trackintel.io.from_geopandas import (
+    read_locations_gpd,
+    read_positionfixes_gpd,
+    read_staypoints_gpd,
+    read_tours_gpd,
+    read_triplegs_gpd,
+    read_trips_gpd,
+)
 
 
 def _index_warning_default_none(func):
@@ -193,7 +200,7 @@ def read_triplegs_csv(*args, columns=None, tz=None, index_col=None, geom_col="ge
     df["started_at"] = pd.to_datetime(df["started_at"])
     df["finished_at"] = pd.to_datetime(df["finished_at"])
     df[geom_col] = gpd.GeoSeries.from_wkt(df[geom_col])
-    return read_triplegs_gpd(df, geom_col=geom_col, crs=crs, tz=tz,  mapper=columns)
+    return read_triplegs_gpd(df, geom_col=geom_col, crs=crs, tz=tz, mapper=columns)
 
 
 def write_triplegs_csv(triplegs, filename, *args, **kwargs):

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -1,7 +1,8 @@
 import warnings
+from functools import wraps
+from inspect import signature
 
 import geopandas as gpd
-import numpy as np
 import pandas as pd
 import pytz
 from geopandas.geodataframe import GeoDataFrame
@@ -9,7 +10,24 @@ from shapely import wkt
 from shapely.geometry import Point
 
 
-def read_positionfixes_csv(*args, columns=None, tz=None, index_col=object(), geom_col="geom", crs=None, **kwargs):
+def _index_warning_default_none(func):
+    """Decorator function that warns if index_col None is not set explicit."""
+
+    @wraps(func)  # copy all metadata
+    def wrapper(*args, **kwargs):
+        bound_values = signature(func).bind(*args, **kwargs)  # binds only available args and kwargs
+        if "index_col" not in bound_values.arguments:
+            warnings.warn(
+                "Assuming default index as unique identifier. "
+                "Pass 'index_col=None' as explicit argument to avoid a warning when reading csv files."
+            )
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@_index_warning_default_none
+def read_positionfixes_csv(*args, columns=None, tz=None, index_col=None, geom_col="geom", crs=None, **kwargs):
     """
     Read positionfixes from csv file.
 
@@ -71,14 +89,7 @@ def read_positionfixes_csv(*args, columns=None, tz=None, index_col=object(), geo
     4     2008-10-23 02:53:25+00:00        0  POINT (116.31826 39.98465)
     """
     columns = {} if columns is None else columns
-
-    # Warning if no 'index_col' parameter is provided
-    if type(index_col) == object:
-        warnings.warn(
-            "Assuming default index as unique identifier. Pass 'index_col=None' as explicit"
-            + "argument to avoid a warning when reading csv files."
-        )
-    elif index_col is not None:
+    if index_col is not None:
         kwargs["index_col"] = index_col
 
     df = pd.read_csv(*args, **kwargs)
@@ -144,7 +155,8 @@ def write_positionfixes_csv(positionfixes, filename, *args, **kwargs):
     df.to_csv(filename, index=True, *args, **kwargs)
 
 
-def read_triplegs_csv(*args, columns=None, tz=None, index_col=object(), geom_col="geom", crs=None, **kwargs):
+@_index_warning_default_none
+def read_triplegs_csv(*args, columns=None, tz=None, index_col=None, geom_col="geom", crs=None, **kwargs):
     """
     Read triplegs from csv file.
 
@@ -195,14 +207,7 @@ def read_triplegs_csv(*args, columns=None, tz=None, index_col=object(), geom_col
     1         1 2015-11-27 12:00:00+00:00 2015-11-27 14:00:00+00:00  LINESTRING (8.56340 47.95600, 8.64560 47.23345...
     """
     columns = {} if columns is None else columns
-
-    # Warning if no 'index_col' parameter is provided
-    if type(index_col) == object:
-        warnings.warn(
-            "Assuming default index as unique identifier. Pass 'index_col=None' as explicit"
-            + "argument to avoid a warning when reading csv files."
-        )
-    elif index_col is not None:
+    if index_col is not None:
         kwargs["index_col"] = index_col
 
     df = pd.read_csv(*args, **kwargs)
@@ -260,7 +265,8 @@ def write_triplegs_csv(triplegs, filename, *args, **kwargs):
     df.to_csv(filename, index=True, *args, **kwargs)
 
 
-def read_staypoints_csv(*args, columns=None, tz=None, index_col=object(), geom_col="geom", crs=None, **kwargs):
+@_index_warning_default_none
+def read_staypoints_csv(*args, columns=None, tz=None, index_col=None, geom_col="geom", crs=None, **kwargs):
     """
     Read staypoints from csv file.
 
@@ -312,14 +318,7 @@ def read_staypoints_csv(*args, columns=None, tz=None, index_col=object(), geom_c
     1         1 2015-11-27 12:00:00+00:00 2015-11-27 14:00:00+00:00  POINT (8.54340 47.95600)
     """
     columns = {} if columns is None else columns
-
-    # Warning if no 'index_col' parameter is provided
-    if type(index_col) == object:
-        warnings.warn(
-            "Assuming default index as unique identifier. Pass 'index_col=None' as explicit"
-            + "argument to avoid a warning when reading csv files."
-        )
-    elif index_col is not None:
+    if index_col is not None:
         kwargs["index_col"] = index_col
 
     df = pd.read_csv(*args, **kwargs)
@@ -377,7 +376,8 @@ def write_staypoints_csv(staypoints, filename, *args, **kwargs):
     df.to_csv(filename, index=True, *args, **kwargs)
 
 
-def read_locations_csv(*args, columns=None, index_col=object(), geom_col="geom", crs=None, **kwargs):
+@_index_warning_default_none
+def read_locations_csv(*args, columns=None, index_col=None, crs=None, **kwargs):
     """
     Read locations from csv file.
 
@@ -422,14 +422,7 @@ def read_locations_csv(*args, columns=None, index_col=object(), geom_col="geom",
     1         1  POINT (8.56340 47.95600)  POLYGON ((8.5634 47.956, 8.6456 47.23345, 8.45...
     """
     columns = {} if columns is None else columns
-
-    # Warning if no 'index_col' parameter is provided
-    if type(index_col) == object:
-        warnings.warn(
-            "Assuming default index as unique identifier. Pass 'index_col=None' as explicit"
-            + "argument to avoid a warning when reading csv files."
-        )
-    elif index_col is not None:
+    if index_col is not None:
         kwargs["index_col"] = index_col
 
     df = pd.read_csv(*args, **kwargs)
@@ -481,7 +474,8 @@ def write_locations_csv(locations, filename, *args, **kwargs):
     df.to_csv(filename, index=True, *args, **kwargs)
 
 
-def read_trips_csv(*args, columns=None, tz=None, index_col=object(), geom_col=None, crs=None, **kwargs):
+@_index_warning_default_none
+def read_trips_csv(*args, columns=None, tz=None, index_col=None, geom_col=None, crs=None, **kwargs):
     """
     Read trips from csv file.
 
@@ -542,13 +536,7 @@ def read_trips_csv(*args, columns=None, tz=None, index_col=object(), geom_col=No
     1   MULTIPOINT (116.29873 39.98402, 116.32480 40.009269)
     """
     columns = {} if columns is None else columns
-
-    if type(index_col) == object:
-        warnings.warn(
-            "Assuming default index as unique identifier. Pass 'index_col=None' as explicit"
-            + "argument to avoid a warning when reading csv files."
-        )
-    elif index_col is not None:
+    if index_col is not None:
         kwargs["index_col"] = index_col
 
     trips = pd.read_csv(*args, **kwargs)
@@ -605,7 +593,8 @@ def write_trips_csv(trips, filename, *args, **kwargs):
     df.to_csv(filename, index=True, *args, **kwargs)
 
 
-def read_tours_csv(*args, columns=None, index_col=object(), tz=None, **kwargs):
+@_index_warning_default_none
+def read_tours_csv(*args, columns=None, index_col=None, tz=None, **kwargs):
     """
     Read tours from csv file.
 
@@ -620,6 +609,9 @@ def read_tours_csv(*args, columns=None, index_col=object(), tz=None, **kwargs):
 
     columns : dict, optional
         The column names to rename in the format {'old_name':'trackintel_standard_name'}.
+
+    index_col : str, optional
+        column name to be used as index. If None the default index is assumed as unique identifier.
 
     tz : str, optional
         pytz compatible timezone string. If None UTC is assumed.
@@ -637,13 +629,7 @@ def read_tours_csv(*args, columns=None, index_col=object(), tz=None, **kwargs):
     >>> trackintel.read_tours_csv('data.csv', columns={'uuid':'user_id'})
     """
     columns = {} if columns is None else columns
-
-    if type(index_col) == object:
-        warnings.warn(
-            "Assuming default index as unique identifier. Pass 'index_col=None' as explicit"
-            + "argument to avoid a warning when reading csv files."
-        )
-    elif index_col is not None:
+    if index_col is not None:
         kwargs["index_col"] = index_col
 
     tours = pd.read_csv(*args, **kwargs)

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -481,6 +481,9 @@ def read_trips_csv(*args, columns=None, tz=None, index_col=None, geom_col=None, 
     trips["started_at"] = pd.to_datetime(trips["started_at"])
     trips["finished_at"] = pd.to_datetime(trips["finished_at"])
 
+    if geom_col is not None:
+        trips[geom_col] = gpd.GeoSeries.from_wkt(trips[geom_col])
+
     return read_trips_gpd(trips, geom_col=geom_col, crs=crs, tz=tz)
 
 

--- a/trackintel/io/from_geopandas.py
+++ b/trackintel/io/from_geopandas.py
@@ -1,7 +1,7 @@
+import warnings
 import pandas as pd
 import geopandas as gpd
-
-from trackintel.io.file import _localize_timestamp
+import pytz
 
 
 def read_positionfixes_gpd(
@@ -425,3 +425,31 @@ def _trackintel_model(gdf, set_names=None, geom_col=None, crs=None, tz_cols=None
         gdf = gdf.set_crs(crs)
 
     return gdf
+
+
+def _localize_timestamp(dt_series, pytz_tzinfo, col_name):
+    """
+    Add timezone info to timestamp.
+
+    Parameters
+    ----------
+    dt_series : pandas.Series
+        a pandas datetime series
+
+    pytz_tzinfo : str
+        pytz compatible timezone string. If none UTC will be assumed
+
+    col_name : str
+        Column name for informative warning message
+
+    Returns
+    -------
+    pd.Series
+        a timezone aware pandas datetime series
+    """
+    if pytz_tzinfo is None:
+        warnings.warn("Assuming UTC timezone for column {}".format(col_name))
+        pytz_tzinfo = "utc"
+
+    timezone = pytz.timezone(pytz_tzinfo)
+    return dt_series.apply(pd.Timestamp, tz=timezone)


### PR DESCRIPTION
I have read about some black magic in the `inspect` module and wanted to change how we do the warning when `index_col` is not explicitly set. Previously we used `index_col=object()` as the default value, now with the `_index_warning_default_none` wrapper we can use `index_col=None` as we can see what keyword arguments the user has provided.

As a bad habit of mine, I also saw that the io functions redo a lot of code that we have already implemented in the `from_geopandas` module. So I went ahead and minimized the work we do in the file IO functions. 

- Added `_index_warning_default_none` to handle non-explicit set `index_col`
- ``read_*_csv`` function now call their ``read_*_gpd`` counterparts