### PR TITLE
ENH: speedup of calculating haversine LineStrings length

### DIFF
--- a/.github/envs/39-latest-conda-forge.yaml
+++ b/.github/envs/39-latest-conda-forge.yaml
@@ -20,6 +20,7 @@ dependencies:
 - jupyter
 - geopandas>=0.9.0
 - shapely
+- pygeos
 
 # tests
 - pytest

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ ti.print_version()
 * tqdm
 * OSMnx
 * similaritymeasures
+* pygeos
 
 ## Development
 You can find the development roadmap under `ROADMAP.md` and further development guidelines under `CONTRIBUTING.md`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ autodoc_mock_imports = [
     "geoalchemy2",
     "tqdm",
     "similaritymeasures",
+    "pygeos",
 ]
 
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,3 +19,4 @@ dependencies:
   - sphinx_rtd_theme
   - tqdm
   - similaritymeasures
+  - pygeos

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,4 @@ dependencies:
 - psycopg2
 - tqdm
 - similaritymeasures
+- pygeos

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ osmnx
 psycopg2
 tqdm
 similaritymeasures
+pygeos

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ install_requires = [
     "tqdm",
     "geopandas>=0.9.0",
     "similaritymeasures",
-    "pygeos"
+    "pygeos",
 ]
 
 # What packages are optional?

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ REQUIRED = [
     "scikit-learn",
     "tqdm",
     "similaritymeasures",
+    "pygeos",
 ]
 
 install_requires = [
@@ -48,6 +49,7 @@ install_requires = [
     "tqdm",
     "geopandas>=0.9.0",
     "similaritymeasures",
+    "pygeos"
 ]
 
 # What packages are optional?

--- a/tests/geogr/test_distances.py
+++ b/tests/geogr/test_distances.py
@@ -1,18 +1,16 @@
 import os
-import datetime
+from math import radians
 
 import geopandas as gpd
 import pandas as pd
 import numpy as np
 import pytest
 
-from math import radians
 from shapely import wkt
 from shapely.geometry import LineString, MultiLineString
 from sklearn.metrics import pairwise_distances
 from geopandas.testing import assert_geodataframe_equal
 from shapely.geometry import Point
-
 
 import trackintel as ti
 from trackintel.geogr.distances import (
@@ -20,8 +18,8 @@ from trackintel.geogr.distances import (
     meters_to_decimal_degrees,
     calculate_distance_matrix,
     calculate_haversine_length,
-    _calculate_haversine_length_single,
 )
+from trackintel.geogr.point_distances import haversine_dist
 
 
 @pytest.fixture
@@ -243,15 +241,8 @@ class Testcalc_haversine_length:
     def test_length(self, gdf_lineStrings):
         """Check if `calculate_haversine_length` runs without errors."""
         length = calculate_haversine_length(gdf_lineStrings)
-
         assert length[0] < length[1]
-
-
-class Test_calculate_haversine_length_single:
-    """Tests for the _calculate_haversine_length_single() function."""
-
-    def Test_length(self, single_linestring):
-        """Check if the length of a longer linestring is calculated correctly up to some meters."""
-        length = _calculate_haversine_length_single(single_linestring)
-
-        assert 1020 < length < 1030
+        ls1, ls2 = gdf_lineStrings.geometry
+        ls1, ls2 = np.array(ls1.coords), np.array(ls2.coords)
+        assert length[0] == np.sum(haversine_dist(ls1[:-1, 0], ls1[:-1, 1], ls1[1:, 0], ls1[1:, 1]))
+        assert length[1] == np.sum(haversine_dist(ls2[:-1, 0], ls2[:-1, 1], ls2[1:, 0], ls2[1:, 1]))


### PR DESCRIPTION
Increased the speed of this method by using methods from pygeos.
Removed `_calculate_haversine_length_single` and updated the test as before nothing was really tested.

closes #401

Edit: Added pygeos to environment that should lead to no further dependencies as geopandas already uses it.