### PR TITLE
BUG: access geometry in smoothing correctly

### DIFF
--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -8,12 +8,11 @@ import pytest
 from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_frame_equal, assert_series_equal, assert_index_equal
 
-from shapely import geometry
 from shapely.geometry import LineString, Point
 from tqdm import tqdm
 
 import trackintel as ti
-from trackintel.preprocessing.triplegs import generate_trips
+from trackintel.preprocessing.triplegs import generate_trips, smoothen_triplegs
 
 
 @pytest.fixture
@@ -46,7 +45,7 @@ class TestSmoothen_triplegs:
     def test_smoothen_triplegs(self):
         tpls_file = os.path.join("tests", "data", "triplegs_with_too_many_points_test.csv")
         tpls = ti.read_triplegs_csv(tpls_file, sep=";", index_col=None)
-        tpls_smoothed = ti.preprocessing.triplegs.smoothen_triplegs(tpls, tolerance=0.0001)
+        tpls_smoothed = smoothen_triplegs(tpls, tolerance=0.0001)
         line1 = tpls.iloc[0].geom
         line1_smoothed = tpls_smoothed.iloc[0].geom
         line2 = tpls.iloc[1].geom
@@ -58,6 +57,12 @@ class TestSmoothen_triplegs:
         assert len(line2.coords) == 7
         assert len(line1_smoothed.coords) == 4
         assert len(line2_smoothed.coords) == 3
+
+    def test_geometry_name(self, example_triplegs):
+        """Test if the geometry name can be set freely."""
+        _, tpls = example_triplegs
+        tpls["freely_set_geometry_name"] = LineString([[1, 1], [2, 2]])
+        smoothen_triplegs(tpls)
 
 
 class TestGenerate_trips:

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -33,10 +33,7 @@ def smoothen_triplegs(triplegs, tolerance=1.0, preserve_topology=True):
         The simplified triplegs GeoDataFrame
     """
     ret_tpls = triplegs.copy()
-    origin_geom = ret_tpls.geom
-    simplified_geom = origin_geom.simplify(tolerance, preserve_topology=preserve_topology)
-    ret_tpls.geom = simplified_geom
-
+    ret_tpls.geometry = ret_tpls.geometry.simplify(tolerance, preserve_topology=preserve_topology)
     return ret_tpls
 
 


### PR DESCRIPTION
The `smoothen_triplegs` has the bug that it tries accessing the geometry over the "geom" column. 
This PR fixes this. But generally I would also suggest removing this function as the wrapper is so thin that I don't see the advantage in adding it to trackintel. 