### PR TITLE
BLD: set lowest pygeos version number

### DIFF
--- a/.github/envs/39-latest-conda-forge.yaml
+++ b/.github/envs/39-latest-conda-forge.yaml
@@ -20,7 +20,7 @@ dependencies:
 - jupyter
 - geopandas>=0.9.0
 - shapely
-- pygeos
+- pygeos>=0.10.0
 
 # tests
 - pytest

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - sphinx_rtd_theme
   - tqdm
   - similaritymeasures
-  - pygeos
+  - pygeos>=0.10.0

--- a/environment.yml
+++ b/environment.yml
@@ -17,4 +17,4 @@ dependencies:
 - psycopg2
 - tqdm
 - similaritymeasures
-- pygeos
+- pygeos>=0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ osmnx
 psycopg2
 tqdm
 similaritymeasures
-pygeos
+pygeos>=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ REQUIRED = [
     "scikit-learn",
     "tqdm",
     "similaritymeasures",
-    "pygeos",
+    "pygeos>=0.10.0",
 ]
 
 install_requires = [
@@ -49,7 +49,7 @@ install_requires = [
     "tqdm",
     "geopandas>=0.9.0",
     "similaritymeasures",
-    "pygeos",
+    "pygeos>=0.10.0",
 ]
 
 # What packages are optional?


### PR DESCRIPTION
Related to #415 
Sets version number of pygeos to `>=0.10.0` to be able to use the `return_index` keyword [here](https://github.com/mie-lab/trackintel/blob/c401f3d7e38f1ef60e7db877f4793c7e78f6c3bd/trackintel/geogr/distances.py#L256).