### PR TITLE
ENH: Remove `.apply` in `get_speed_triplegs`

### DIFF
--- a/tests/model/test_util.py
+++ b/tests/model/test_util.py
@@ -139,6 +139,21 @@ class TestPfsMeanSpeedTriplegs:
         tpls_speed_normal = ti.model.util.get_speed_triplegs(tpls, pfs, method="pfs_mean_speed")
         assert_geodataframe_equal(tpls_speed_acc, tpls_speed_normal)
 
+    def test_pfs_exist_assertion(self, example_triplegs):
+        """Test whether an AttributeError is raised if no positionfixes are provided as input"""
+        error_msg = 'Method "pfs_mean_speed" requires positionfixes as input.'
+        _, tpls = example_triplegs
+        with pytest.raises(AttributeError, match=error_msg):
+            ti.model.util.get_speed_triplegs(tpls, None, method="pfs_mean_speed")
+
+    def test_tripleg_id_assertion(self, example_triplegs):
+        """Test whether an AttributeError is raised if positionfixes do not provide column "tripleg_id"."""
+        error_msg = 'Positionfixes must include column "tripleg_id".'
+        pfs, tpls = example_triplegs
+        pfs.drop(columns=["tripleg_id"], inplace=True)
+        with pytest.raises(AttributeError, match=error_msg):
+            ti.model.util.get_speed_triplegs(tpls, pfs, method="pfs_mean_speed")
+
 
 class TestSimpleSpeedTriplegs:
     def test_triplegs_stable(self, example_triplegs):

--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -85,7 +85,7 @@ def get_speed_triplegs(triplegs, positionfixes=None, method="tpls_speed"):
         if positionfixes is None:
             raise AttributeError('Method "pfs_mean_speed" requires positionfixes as input.')
         if "tripleg_id" not in positionfixes:
-            raise AttributeError('Positionfixes mut include column "tripleg_id"')
+            raise AttributeError('Positionfixes must include column "tripleg_id".')
         # group positionfixes by triplegs and compute average speed for each collection of positionfixes
         grouped_pfs = positionfixes.groupby("tripleg_id").apply(_single_tripleg_mean_speed)
         # add the speed values to the triplegs column


### PR DESCRIPTION
Minor performance increase. Replaced a `apply` call with the direct vectorization.
Additionally replaced the asserts with raised errors as asserts should be used to detect bugs and not to communicate missing parameters. (e.g. https://stackoverflow.com/questions/944592/best-practice-for-using-assert?noredirect=1&lq=1)