### PR TITLE
PERF: faster mode for only floats in haversine distance

### DIFF
--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -174,9 +174,10 @@ class TestGenerate_staypoints:
         """Test if using large thresholds, stp extraction yield no pfs."""
         pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join("tests", "data", "geolife"))
         warn_string = "No staypoints can be generated, returning empty sp."
+        max_time = pd.Timedelta.max.total_seconds() // 60
         with pytest.warns(UserWarning, match=warn_string):
             _, sp = pfs.as_positionfixes.generate_staypoints(
-                method="sliding", dist_threshold=sys.maxsize, time_threshold=sys.maxsize
+                method="sliding", dist_threshold=sys.maxsize, time_threshold=max_time
             )
         assert len(sp) == 0
 
@@ -184,12 +185,13 @@ class TestGenerate_staypoints:
         """Test nan is assigned for missing link between pfs and sp."""
         pfs, _ = ti.io.dataset_reader.read_geolife(os.path.join("tests", "data", "geolife"))
         warn_string = "No staypoints can be generated, returning empty sp."
+        max_time = pd.Timedelta.max.total_seconds() // 60
         with pytest.warns(UserWarning, match=warn_string):
             pfs, _ = pfs.as_positionfixes.generate_staypoints(
-                method="sliding", dist_threshold=sys.maxsize, time_threshold=sys.maxsize
+                method="sliding", dist_threshold=sys.maxsize, time_threshold=max_time
             )
 
-        assert pd.isna(pfs["staypoint_id"]).any()
+        assert pd.isna(pfs["staypoint_id"]).all()
 
     def test_dtype_consistent(self, geolife_pfs_sp_long):
         """Test the dtypes for the generated columns."""
@@ -203,7 +205,7 @@ class TestGenerate_staypoints:
         """Test the generated index start from 0 for different methods."""
         _, sp = geolife_pfs_sp_long
 
-        assert (sp.index == np.arange(len(sp))).any()
+        assert (sp.index == np.arange(len(sp))).all()
 
     def test_include_last(self):
         """Test if the include_last arguement will include the last pfs as stp."""

--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -294,6 +294,17 @@ class TestGenerate_staypoints:
         assert len(sp) == 1
 
 
+class Test_Generate_staypoints_sliding_user:
+    """Test for _generate_staypoints_sliding_user."""
+
+    def test_unknown_distance_metric(self, example_positionfixes):
+        """Test if the distance metric is unknown, an AttributeError will be raised."""
+        with pytest.raises(AttributeError):
+            example_positionfixes.as_positionfixes.generate_staypoints(
+                method="sliding", dist_threshold=100, time_threshold=5, distance_metric="unknown"
+            )
+
+
 class TestGenerate_triplegs:
     """Tests for generate_triplegs() method."""
 

--- a/trackintel/geogr/point_distances.py
+++ b/trackintel/geogr/point_distances.py
@@ -1,7 +1,8 @@
 import numpy as np
+import math
 
 
-def haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000):
+def haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_calc=False):
     """
     Compute the great circle or haversine distance between two coordinates in WGS84.
 
@@ -25,9 +26,12 @@ def haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000):
         Radius of the reference sphere for the calculation.
         The average Earth radius is 6'371'000 m.
 
+    float_calc : bool, default False
+        Optimization flag. Set to True if you are sure that you are only using floats as args.
+
     Returns
     -------
-    float
+    float or numpy.array
         An approximation of the distance between two points in WGS84 given in meters.
 
     Examples
@@ -40,6 +44,19 @@ def haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000):
     https://en.wikipedia.org/wiki/Haversine_formula
     https://stackoverflow.com/questions/19413259/efficient-way-to-calculate-distance-matrix-given-latitude-and-longitude-data-in
     """
+    if float_calc:
+        lon_1 = math.radians(lon_1)
+        lat_1 = math.radians(lat_1)
+        lon_2 = math.radians(lon_2)
+        lat_2 = math.radians(lat_2)
+
+        cos_lat2 = math.cos(lat_2)
+        cos_lat1 = math.cos(lat_1)
+        cos_lat_d = math.cos(lat_1 - lat_2)
+        cos_lon_d = math.cos(lon_1 - lon_2)
+
+        return r * math.acos(cos_lat_d - cos_lat1 * cos_lat2 * (1 - cos_lon_d))
+
     lon_1 = np.deg2rad(lon_1).ravel()
     lat_1 = np.deg2rad(lat_1).ravel()
     lon_2 = np.deg2rad(lon_2).ravel()

--- a/trackintel/geogr/point_distances.py
+++ b/trackintel/geogr/point_distances.py
@@ -2,7 +2,7 @@ import numpy as np
 import math
 
 
-def haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_calc=False):
+def haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_flag=False):
     """
     Compute the great circle or haversine distance between two coordinates in WGS84.
 
@@ -26,7 +26,7 @@ def haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_calc=False):
         Radius of the reference sphere for the calculation.
         The average Earth radius is 6'371'000 m.
 
-    float_calc : bool, default False
+    float_flag : bool, default False
         Optimization flag. Set to True if you are sure that you are only using floats as args.
 
     Returns
@@ -44,7 +44,7 @@ def haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_calc=False):
     https://en.wikipedia.org/wiki/Haversine_formula
     https://stackoverflow.com/questions/19413259/efficient-way-to-calculate-distance-matrix-given-latitude-and-longitude-data-in
     """
-    if float_calc:
+    if float_flag:
         lon_1 = math.radians(lon_1)
         lat_1 = math.radians(lat_1)
         lon_2 = math.radians(lon_2)

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -392,7 +392,7 @@ def generate_triplegs(
 def _generate_staypoints_sliding_user(
     df, geo_col, elevation_flag, dist_threshold, time_threshold, gap_threshold, distance_metric, include_last=False
 ):
-    """User level staypoint geenration using sliding method, see generate_staypoints() function for parameter meaning."""
+    """User level staypoint generation using sliding method, see generate_staypoints() function for parameter meaning."""
     if distance_metric == "haversine":
         dist_func = haversine_dist
     else:
@@ -402,7 +402,8 @@ def _generate_staypoints_sliding_user(
 
     # transform times to pandas Timedelta to simplify comparisons
     gap_threshold = pd.Timedelta(gap_threshold, unit="minutes")
-    # to numpy as access time of numpy numpy is faster than pandas array
+    time_threshold = pd.Timedelta(time_threshold, unit="minutes")
+    # to numpy as access time of numpy array is faster than pandas Series
     gap_times = pd.eval("((df.tracked_at - df.tracked_at.shift(1)) > gap_threshold)").to_numpy()
 
     # put x and y into numpy arrays to speed up the access in the for loop (shapely is slow)
@@ -418,24 +419,18 @@ def _generate_staypoints_sliding_user(
             start = curr
             continue
 
-        delta_dist = dist_func(x[start], y[start], x[curr], y[curr], float_calc=True)
+        delta_dist = dist_func(x[start], y[start], x[curr], y[curr], float_flag=True)
         if delta_dist >= dist_threshold:
-            # the total duration (minutes) of the staypoints
-            delta_t = (df["tracked_at"].iloc[curr] - df["tracked_at"].iloc[start]).total_seconds() // 60
-
-            # we want the staypoint to have long duration
-            if delta_t >= time_threshold:
-                # add new staypoint
+            # we want the staypoint to have long enough duration
+            if (df["tracked_at"].iloc[curr] - df["tracked_at"].iloc[start]) >= time_threshold:
                 ret_sp.append(__create_new_staypoints(start, curr, df, elevation_flag, geo_col))
             # distance large enough but time is too short -> not a staypoint
             # also initializer when new sp is added
             start = curr
 
-    # when we arrive at the last positionfix, and want to aggregate remaining positionfixes
-    if include_last:
-        # additional control: we want to create staypoints with duration larger than time_threshold
-        delta_t = (df["tracked_at"].iloc[curr] - df["tracked_at"].iloc[start]).total_seconds() // 60
-        if delta_t >= time_threshold:
+    if include_last:  # aggregate remaining positionfixes
+        # additional control: we aggregate only if duration longer than time_threshold
+        if (df["tracked_at"].iloc[curr] - df["tracked_at"].iloc[start]) >= time_threshold:
             new_sp = __create_new_staypoints(start, curr, df, elevation_flag, geo_col, last_flag=True)
             ret_sp.append(new_sp)
 


### PR DESCRIPTION
This PR increases the performance of `staypoint_generation` by 4x. We achieved that by adding an extra mode to `haversine_distance` that uses `math` functions functions that avoid the overhead of `numpy` functions and is that way 10x faster.
That is of course only possible for float values and not for arrays therefore an extra flag is added that can be set to get this speedup. 

Additionally made some minor cleanups in the function. 