### PR TITLE
TST: Failing tests because of geopandas 0.11

### DIFF
--- a/tests/model/test_positionfixes.py
+++ b/tests/model/test_positionfixes.py
@@ -27,11 +27,11 @@ class TestPositionfixes:
             pfs.drop(["user_id"], axis=1).as_positionfixes
 
     def test_accessor_geometry(self, testdata_geolife):
-        """Test if the as_positionfixes accessor requires geometry column."""
+        """Test if the as_positionfixes accessor accesses geometry column."""
         pfs = testdata_geolife.copy()
 
         # check geometry
-        with pytest.raises(AttributeError, match="No geometry data set yet"):
+        with pytest.raises(AttributeError):
             pfs.drop(["geom"], axis=1).as_positionfixes
 
     def test_accessor_geometry_type(self, testdata_geolife):

--- a/tests/model/test_positionfixes.py
+++ b/tests/model/test_positionfixes.py
@@ -27,7 +27,7 @@ class TestPositionfixes:
             pfs.drop(["user_id"], axis=1).as_positionfixes
 
     def test_accessor_geometry(self, testdata_geolife):
-        """Test if the as_positionfixes accessor accesses geometry column."""
+        """Test if the as_positionfixes accessor requires geometry column."""
         pfs = testdata_geolife.copy()
 
         # check geometry

--- a/tests/model/test_staypoints.py
+++ b/tests/model/test_staypoints.py
@@ -31,7 +31,7 @@ class TestStaypoints:
         sp = testdata_sp.copy()
 
         # geometery
-        with pytest.raises(AttributeError, match="No geometry data set yet"):
+        with pytest.raises(AttributeError):
             sp.drop(["geom"], axis=1).as_staypoints
 
     def test_accessor_geometry_type(self, testdata_sp):

--- a/tests/model/test_triplegs.py
+++ b/tests/model/test_triplegs.py
@@ -34,7 +34,7 @@ class TestTriplegs:
         tpls = testdata_tpls.copy()
 
         # check geometry
-        with pytest.raises(AttributeError, match="No geometry data set yet"):
+        with pytest.raises(AttributeError):
             tpls.drop(["geom"], axis=1).as_triplegs
 
     def test_accessor_geometry_type(self, testdata_tpls):

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -127,11 +127,11 @@ def generate_locations(
         else:
             ## generate user-location pairs with same geometries across users
             # get user-location pairs
-            locs = temp_sp.dissolve(by=["user_id", "location_id"], as_index=False).drop(columns={temp_sp.geometry.name})
+            locs = temp_sp[["user_id", "location_id"]].drop_duplicates(ignore_index=True)
             # get location geometries
-            geom_df = temp_sp.dissolve(by=["location_id"], as_index=False).drop(columns={"user_id"})
+            geom_gdf = temp_sp.dissolve(by=["location_id"], as_index=False).drop(columns={"user_id"})
             # merge pairs with location geometries
-            locs = locs.merge(geom_df, on="location_id", how="left")
+            locs = geom_gdf.merge(locs, on="location_id", how="right")
 
         # filter staypoints not belonging to locations
         locs = locs.loc[locs["location_id"] != -1]


### PR DESCRIPTION
Geopandas 0.11 is more consistent in the way the conversion from GeoDataFrames to DataFrames are handled, now consistently every time you drop the Geometry column you get a DataFrame back.
This caused one bug in the code and one test bug in some tests.
1. the bug was in `preprocessing/staypoints.py` where the variable `locs` was a GeoDataFrame before the change and is now a DataFrame.
2. accessor tests failed because they expected error messages from a GeoDataFrame for missing geometry columns and not from a DataFrame. 

Release notes here: https://github.com/geopandas/geopandas/releases/tag/v0.11.0

closes #438 