### PR TITLE
BUG: fix index error pfs_mean_speed

### DIFF
--- a/tests/preprocessing/test_trips.py
+++ b/tests/preprocessing/test_trips.py
@@ -134,6 +134,7 @@ def example_nested_tour(example_trip_data):
     trips.loc[100] = [0, start_time_subtour, middle_time, 5, 7, first_trip_subtour]
     trips.loc[200] = [0, middle_time, trips.loc[15, "started_at"], 7, 5, second_trip_subtour]
     trips.sort_values(by=["user_id", "started_at", "origin_staypoint_id", "destination_staypoint_id"], inplace=True)
+    trips.set_geometry("geom", crs=4326, inplace=True)
     return trips
 
 

--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -90,7 +90,7 @@ def get_speed_triplegs(triplegs, positionfixes=None, method="tpls_speed"):
         grouped_pfs = positionfixes.groupby("tripleg_id").apply(_single_tripleg_mean_speed)
         # add the speed values to the triplegs column
         tpls = pd.merge(triplegs, grouped_pfs.rename("speed"), left_index=True, right_index=True)
-        tpls.index = tpls.index.astype("int64")
+        tpls.index = triplegs.index
         return tpls
 
     else:

--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -89,8 +89,8 @@ def get_speed_triplegs(triplegs, positionfixes=None, method="tpls_speed"):
         # group positionfixes by triplegs and compute average speed for each collection of positionfixes
         grouped_pfs = positionfixes.groupby("tripleg_id").apply(_single_tripleg_mean_speed)
         # add the speed values to the triplegs column
-        tpls = pd.merge(triplegs, grouped_pfs.rename("speed"), left_index=True, right_index=True)
-        tpls.index = triplegs.index
+        tpls = pd.merge(triplegs, grouped_pfs.rename("speed"), how="left", left_index=True, right_index=True)
+        tpls.index = tpls.index.astype("int64")
         return tpls
 
     else:


### PR DESCRIPTION
Fixes #449

Apparently the behavior of `pd.merge`  changed after an update.
Other places in the code should not be affected by the `pd.merge` change.

Also fix error in test where override of geometry column resulted in cast to Series with object type.