### PR TITLE
TST: test error fixes with pandas 2.0

### DIFF
--- a/examples/trackintel_basic_tutorial.ipynb
+++ b/examples/trackintel_basic_tutorial.ipynb
@@ -227,7 +227,8 @@
    "outputs": [],
    "source": [
     "# we concate sp and tpls to get the whole mobility trace\n",
-    "trace = sp.append(tpls)\n",
+    "trace = pd.concat([sp, tpls])\n",
+    "\n",
     "# calculate the overall tracking coverage\n",
     "ti.analysis.tracking_quality.temporal_tracking_quality(trace, granularity='all')"
    ]
@@ -332,7 +333,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -226,7 +226,6 @@ class TestGenerate_trips:
             sep=";",
             index_col="id",
             parse_dates=[0, 1],
-            infer_datetime_format=True,
             dayfirst=True,
         )
         sp_in["geom"] = Point(1, 1)
@@ -238,7 +237,6 @@ class TestGenerate_trips:
             sep=";",
             index_col="id",
             parse_dates=[0, 1],
-            infer_datetime_format=True,
             dayfirst=True,
         )
         tpls_in["geom"] = LineString([[1, 1], [2, 2]])

--- a/tests/preprocessing/test_util.py
+++ b/tests/preprocessing/test_util.py
@@ -78,18 +78,18 @@ class TestExplodeAgg:
         agg_df = pd.DataFrame(agg)
         returned_df = _explode_agg("id", "c", orig_df, agg_df)
         solution_df = pd.DataFrame(orig)
+
         assert_frame_equal(returned_df, solution_df)
 
     def test_index_dtype_with_None(self):
         """Test if dtype of index isn't changed with None values."""
-        orig = [
-            {"a": 1, "c": 0},
-        ]
+        orig = [{"a": 1, "c": 0}]
         agg = [{"id": [0, 1], "c": 0}, {"id": [], "c": 1}]
         orig_df = pd.DataFrame(orig, columns=["a"])
         agg_df = pd.DataFrame(agg)
         returned_df = _explode_agg("id", "c", orig_df, agg_df)
         solution_df = pd.DataFrame(orig)
+
         assert_frame_equal(returned_df, solution_df)
 
 

--- a/trackintel/preprocessing/util.py
+++ b/trackintel/preprocessing/util.py
@@ -107,7 +107,11 @@ def _explode_agg(column, agg, orig_df, agg_df):
     temp = agg_df.explode(column)
     temp = temp[temp[column].notna()]
     temp.index = temp[column]
-    return orig_df.join(temp[agg], how="left")
+
+    return_df = orig_df.join(temp[agg], how="left")
+    # ensure index dtype the same as input
+    return_df.index = return_df.index.astype(orig_df.index.dtype)
+    return return_df
 
 
 def angle_centroid_multipoints(geometry):


### PR DESCRIPTION
Pandas released v2.0 which causes some errors in our test functions:

- `append` function deprecated and shall be replaced by `concat`:

> Removed deprecated Series.append(), DataFrame.append(), use [concat()](https://pandas.pydata.org/docs/reference/api/pandas.concat.html#pandas.concat) instead ([GH35407](https://github.com/pandas-dev/pandas/issues/35407))

- More flexible dtypes for pandas.index, [link](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#index-can-now-hold-numpy-numeric-dtypes)


In addition, `infer_datetime_format` argument is depricated:

> Deprecated argument infer_datetime_format in [to_datetime()](https://pandas.pydata.org/docs/reference/api/pandas.to_datetime.html#pandas.to_datetime) and [read_csv()](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html#pandas.read_csv), as a strict version of it is now the default ([GH48621](https://github.com/pandas-dev/pandas/issues/48621))