### PR TITLE
add progress_bar to function generate_tripleg

### DIFF
--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -167,7 +167,11 @@ def generate_staypoints(
 
 
 def generate_triplegs(
-    positionfixes, staypoints=None, method="between_staypoints", gap_threshold=15, print_progress=False
+    positionfixes, 
+    staypoints=None,
+    method="between_staypoints",
+    gap_threshold=15,
+    print_progress=False,
 ):
     """Generate triplegs from positionfixes.
 
@@ -191,7 +195,7 @@ def generate_triplegs(
         `gap_threshold` minutes, a new tripleg will be generated.
 
     print_progress: boolean, default False
-        Show progress bar if set to true, only valid if pfs do not have a column 'staypoint_id' but staypoint are provided.
+        Show the progress bar for assigning staypoints to positionfixes if set to True.
 
     Returns
     -------

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -250,13 +250,10 @@ def generate_triplegs(
             insert_index_ls = []
             pfs["staypoint_id"] = pd.NA
 
-            # check if print_progress is True.
-            if print_progress:
-                # Determine the maximum value of iterations
-                max_value = len(pfs.groupby("user_id"))
-                progress_bar = tqdm(total=max_value, desc="Assign staypoint ids to positionfixes", unit="user")
-
-            for user_id_this in pfs["user_id"].unique():
+            # initalize the variable 'disable' to control display of progress bar.
+            disable = not print_progress
+    
+            for user_id_this in tqdm(pfs["user_id"].unique(), disable=disable):
                 sp_user = staypoints[staypoints["user_id"] == user_id_this]
                 pfs_user = pfs[pfs["user_id"] == user_id_this]
 
@@ -276,10 +273,6 @@ def generate_triplegs(
 
                 # store the insert insert_position_user in an array
                 insert_index_ls.extend(list(insert_index_user))
-
-                # update progress bar
-                if print_progress:
-                    progress_bar.update(1)
             #
             cond_staypoints_case2 = pd.Series(False, index=pfs.index)
             cond_staypoints_case2.loc[insert_index_ls] = True

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -251,7 +251,7 @@ def generate_triplegs(
             pfs["staypoint_id"] = pd.NA
             
             # check if print_progress is True.
-            if print_progress == True:
+            if print_progress:
                 # Determine the maximum value of iterations
                 max_value = len(pfs.groupby("user_id"),)
                 progress_bar = tqdm(total=max_value, desc="Assign staypoint ids to positionfixes", unit="user")
@@ -278,7 +278,7 @@ def generate_triplegs(
                 insert_index_ls.extend(list(insert_index_user))
                 
                 #update progress bar
-                if print_progress == True:
+                if print_progress:
                     progress_bar.update(1)
             #
             cond_staypoints_case2 = pd.Series(False, index=pfs.index)

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -252,7 +252,7 @@ def generate_triplegs(
 
             # initalize the variable 'disable' to control display of progress bar.
             disable = not print_progress
-    
+
             for user_id_this in tqdm(pfs["user_id"].unique(), disable=disable):
                 sp_user = staypoints[staypoints["user_id"] == user_id_this]
                 pfs_user = pfs[pfs["user_id"] == user_id_this]

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -167,7 +167,7 @@ def generate_staypoints(
 
 
 def generate_triplegs(
-    positionfixes, 
+    positionfixes,
     staypoints=None,
     method="between_staypoints",
     gap_threshold=15,

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -274,8 +274,8 @@ def generate_triplegs(
 
                 # store the insert insert_position_user in an array
                 insert_index_ls.extend(list(insert_index_user))
-                
-                #update progress bar
+
+                # update progress bar
                 if print_progress:
                     progress_bar.update(1)
             #

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -249,9 +249,7 @@ def generate_triplegs(
             # check if print_progress is True.
             if print_progress:
                 # Determine the maximum value of iterations
-                max_value = len(
-                    pfs.groupby("user_id"),
-                )
+                max_value = len(pfs.groupby("user_id"))
                 progress_bar = tqdm(total=max_value, desc="Assign staypoint ids to positionfixes", unit="user")
 
             for user_id_this in pfs["user_id"].unique():


### PR DESCRIPTION
Add print progress option to generate_triplegs #414

The progress bar is only valid in CASE 2: pfs do not have a column 'staypoint_id' but staypoint are provided.

Please let me know if my update meets the requirement of this issue.