### PR TITLE
ENH: replace pygeos with calls to shapely 2.0

### DIFF
--- a/.github/envs/39-latest-conda-forge.yaml
+++ b/.github/envs/39-latest-conda-forge.yaml
@@ -19,7 +19,6 @@ dependencies:
 - similaritymeasures
 - jupyter
 - geopandas>=0.10.0
-- pygeos>=0.10.0
 
 # tests
 - pytest

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ ti.print_version()
 * tqdm
 * OSMnx
 * similaritymeasures
-* pygeos
 
 ## Development
 You can find the development roadmap under `ROADMAP.md` and further development guidelines under `CONTRIBUTING.md`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,6 @@ autodoc_mock_imports = [
     "geoalchemy2",
     "tqdm",
     "similaritymeasures",
-    "pygeos",
 ]
 
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,4 +19,3 @@ dependencies:
   - sphinx_rtd_theme
   - tqdm
   - similaritymeasures
-  - pygeos>=0.10.0

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,3 @@ dependencies:
 - psycopg2
 - tqdm
 - similaritymeasures
-- pygeos>=0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ osmnx
 psycopg2
 tqdm
 similaritymeasures
-pygeos>=0.10.0
 virtualenv

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ REQUIRED = [
     "scikit-learn",
     "tqdm",
     "similaritymeasures",
-    "pygeos>=0.10.0",
 ]
 
 install_requires = [
@@ -49,7 +48,6 @@ install_requires = [
     "tqdm",
     "geopandas>=0.10.0",
     "similaritymeasures",
-    "pygeos>=0.10.0",
 ]
 
 # What packages are optional?

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -250,7 +250,7 @@ def calculate_haversine_length(gdf):
     >>> from trackintel.geogr.distances import calculate_haversine_length
     >>> triplegs['length'] = calculate_haversine_length(triplegs)
     """
-    geom = shapely.from_shapely(gdf.geometry)
+    geom = gdf.geometry
     assert np.any(shapely.get_type_id(geom) == 1)  # 1 is LineStrings
     geom, index = shapely.get_coordinates(geom, return_index=True)
     no_mix = index[:-1] == index[1:]  # mask where LineStrings are not overlapping

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -5,10 +5,10 @@ from math import cos, pi
 
 import numpy as np
 import pandas as pd
-import pygeos
+import shapely
+import similaritymeasures
 from scipy.spatial.distance import cdist
 from sklearn.metrics import pairwise_distances
-import similaritymeasures
 
 from trackintel.geogr.point_distances import haversine_dist
 
@@ -250,9 +250,9 @@ def calculate_haversine_length(gdf):
     >>> from trackintel.geogr.distances import calculate_haversine_length
     >>> triplegs['length'] = calculate_haversine_length(triplegs)
     """
-    geom = pygeos.from_shapely(gdf.geometry)
-    assert np.any(pygeos.get_type_id(geom) == 1)  # 1 is LineStrings
-    geom, index = pygeos.get_coordinates(geom, return_index=True)
+    geom = shapely.from_shapely(gdf.geometry)
+    assert np.any(shapely.get_type_id(geom) == 1)  # 1 is LineStrings
+    geom, index = shapely.get_coordinates(geom, return_index=True)
     no_mix = index[:-1] == index[1:]  # mask where LineStrings are not overlapping
     dist = haversine_dist(geom[:-1, 0], geom[:-1, 1], geom[1:, 0], geom[1:, 1])
     return np.bincount((index[:-1])[no_mix], weights=dist[no_mix])

--- a/trackintel/preprocessing/util.py
+++ b/trackintel/preprocessing/util.py
@@ -127,8 +127,7 @@ def angle_centroid_multipoints(geometry):
     geopandas.GeometryArray
         Centroid of geometries (shapely.Point)
     """
-    g = shapely.from_shapely(geometry)
-    g, index = shapely.get_coordinates(g, return_index=True)
+    g, index = shapely.get_coordinates(geometry, return_index=True)
     # number of coordinate pairs per MultiPoint
     count = np.bincount(index)
     x, y = g[:, 0], g[:, 1]

--- a/trackintel/preprocessing/util.py
+++ b/trackintel/preprocessing/util.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-import pygeos
+import shapely
 from joblib import Parallel, delayed
 from shapely.geometry.base import BaseGeometry
 from tqdm import tqdm
@@ -127,8 +127,8 @@ def angle_centroid_multipoints(geometry):
     geopandas.GeometryArray
         Centroid of geometries (shapely.Point)
     """
-    g = pygeos.from_shapely(geometry)
-    g, index = pygeos.get_coordinates(g, return_index=True)
+    g = shapely.from_shapely(geometry)
+    g, index = shapely.get_coordinates(g, return_index=True)
     # number of coordinate pairs per MultiPoint
     count = np.bincount(index)
     x, y = g[:, 0], g[:, 1]


### PR DESCRIPTION
With pygeos being integrated into shapely we don't need this dependency anymore.
Thus this PR removes all calls to pygeos. 