### PR TITLE
ENH: remove as_staypoints calls from location_identification

### DIFF
--- a/trackintel/analysis/location_identification.py
+++ b/trackintel/analysis/location_identification.py
@@ -48,9 +48,6 @@ def location_identifier(staypoints, method="FREQ", pre_filter=True, **pre_filter
     >>> from ti.analysis.location_identification import location_identifier
     >>> location_identifier(staypoints, pre_filter=True, method="FREQ")
     """
-    # assert validity of staypoints
-    staypoints.as_staypoints
-
     sp = staypoints.copy()
     if "location_id" not in sp.columns:
         raise KeyError(
@@ -125,9 +122,6 @@ def pre_filter_locations(
     >>> mask = pre_filter_locations(staypoints)
     >>> staypoints = staypoints[mask]
     """
-    # assert validity of staypoints
-    staypoints.as_staypoints
-
     sp = staypoints.copy()
     if isinstance(thresh_loc_time, str):
         thresh_loc_time = pd.to_timedelta(thresh_loc_time)


### PR DESCRIPTION
closes #476
This PR removes the `as_staypoints` assertions, as the staypoints need to be created initially and there this property is cached.
It doesn't really solve the verify problem, but my argument is that we require a `GeoDataFrame (as trackintel staypoints)` and thus can rely that we get the right data shape.
In all other places `as_xyz` works as intended, since it is always applied to newly created objects and thus is not yet cached.
However, I would like to make this a bit clearer with a proper class hierarchy (which is backwards compatible with our current `as_xyz` approach), but we should discuss that elsewhere.
