### PR TITLE
ENH: remove warning suppression

### DIFF
--- a/.github/envs/39-latest-conda-forge.yaml
+++ b/.github/envs/39-latest-conda-forge.yaml
@@ -18,7 +18,7 @@ dependencies:
 - tqdm
 - similaritymeasures
 - jupyter
-- geopandas>=0.10.0
+- geopandas>=0.12.0
 
 # tests
 - pytest

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
 # - python=3.8
-- geopandas>=0.9.0
+- geopandas>=0.12.0
 - pip:
   - numpy
   - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - python
 - numpy
 - matplotlib
-- geopandas>=0.10.0
+- geopandas>=0.12.0
 - scikit-learn
 - networkx 
 - pint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 matplotlib
-geopandas>=0.10.0
+geopandas>=0.12.0
 scikit-learn
 networkx 
 pint 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ LICENSE = "MIT"
 # What packages are required for this module to be executed?
 REQUIRED = [
     "pandas",
-    "geopandas>=0.9.0",
+    "geopandas>=0.12.0",
     "matplotlib",
     "numpy",
     "pint",
@@ -40,13 +40,13 @@ install_requires = [
     "matplotlib",
     "numpy",
     "pint",
-    "shapely<=1.8.5",
+    "shapely",
     "networkx",
     "geoalchemy2",
     "osmnx",
     "scikit-learn",
     "tqdm",
-    "geopandas>=0.10.0",
+    "geopandas>=0.12.0",
     "similaritymeasures",
 ]
 

--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -33,10 +33,7 @@ def get_speed_positionfixes(positionfixes):
     g = pfs.geometry
     # get distance and time difference
     if is_planar_crs:
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="CRS not set for some of the concatenation inputs.*")
-
-            dist = g.distance(g.shift(1)).to_numpy()
+        dist = g.distance(g.shift(1)).to_numpy()
     else:
         x = g.x.to_numpy()
         y = g.y.to_numpy()

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -271,6 +271,7 @@ def merge_staypoints(staypoints, triplegs, max_time_gap="10min", agg={}):
     # a joined dataframe sp_tpls is constructed to add the columns 'type' and 'next_type' to the 'sp_merge' table
     # concat and sort by time
     sp_tpls = pd.concat([sp_merge, tpls_merge]).sort_values(by=["user_id", "started_at"])
+    # TODO: we want to make tpls as argumtent optional and adapt this logic here. See issue #463.
     sp_tpls.index.rename(index_name, inplace=True)
     # get information whether the there is a tripleg after a staypoint
     sp_tpls["next_type"] = sp_tpls["type"].shift(-1)

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -270,12 +270,7 @@ def merge_staypoints(staypoints, triplegs, max_time_gap="10min", agg={}):
 
     # a joined dataframe sp_tpls is constructed to add the columns 'type' and 'next_type' to the 'sp_merge' table
     # concat and sort by time
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="CRS not set for some of the concatenation inputs.*")
-
-        # TODO: the warning relates to how we process when no triplegs is provided. In future versions,
-        # we want to seperate the two scenarios. See issue #463.
-        sp_tpls = pd.concat([sp_merge, tpls_merge]).sort_values(by=["user_id", "started_at"])
+    sp_tpls = pd.concat([sp_merge, tpls_merge]).sort_values(by=["user_id", "started_at"])
     sp_tpls.index.rename(index_name, inplace=True)
     # get information whether the there is a tripleg after a staypoint
     sp_tpls["next_type"] = sp_tpls["type"].shift(-1)

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -132,12 +132,7 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
     trips.drop(columns=["type", "sp_tpls_id"], inplace=True)  # make space so no overlap with activity "sp_tpls_id"
     # Inserting `gaps` and `user_change` into the dataframe creates buffers that catch shifted
     # "staypoint_id" and "trip_id" from corrupting staypoints/trips.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="CRS not set for some of the concatenation inputs.*")
-
-        # TODO: the warning might be caused from process within geopandas. Remember to check
-        # if the warning persists in later versions.
-        trips_with_act = pd.concat((trips, sp_tpls_only_act, gaps, user_change), axis=0, ignore_index=True)
+    trips_with_act = pd.concat((trips, sp_tpls_only_act, gaps, user_change), axis=0, ignore_index=True)
     trips_with_act.sort_values(["user_id", "started_at"], inplace=True)
 
     # ID assignment #
@@ -147,11 +142,8 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
 
     # add geometry for start and end points
     if add_geometry:
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="CRS not set for some of the concatenation inputs.*")
-
-            trips_with_act["origin_geom"] = trips_with_act["geom"].shift(1)
-            trips_with_act["destination_geom"] = trips_with_act["geom"].shift(-1)
+        trips_with_act["origin_geom"] = trips_with_act["geom"].shift(1)
+        trips_with_act["destination_geom"] = trips_with_act["geom"].shift(-1)
 
     # add prev_trip_id and next_trip_id for is_activity staypoints
     trips_with_act["prev_trip_id"] = trips_with_act["trip_id"].shift(1)


### PR DESCRIPTION
As of geopandas 0.12.0, these warnings have been fixed and should no longer be suppressed.
Further should close #463 as the discussed problem does not occur anymore, can be tested with this code:
````python
import geopandas as gpd
import pandas as pd
from shapely.geometry import Point

gdf = gpd.GeoDataFrame([{"a":1, "g": Point(1, 2)}], geometry="g", crs=4326)
gdf_empty = gpd.GeoDataFrame()
gdf_concat = pd.concat([gdf, gdf_empty])
assert gdf.crs == gdf_concat.crs
````