### PR TITLE
DOC: change contributing file for performance benchmarking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,15 +82,15 @@ See [issue 117](https://github.com/mie-lab/trackintel/issues/117)
 - We use [airspeed velocity](https://asv.readthedocs.io/en/stable/) to benchmark key trackintel functions. 
 - Benchmarks are written in the airspeed velocity format. 
 - Three types of benchmarks exist (sample at [benchmarks](https://github.com/mie-lab/trackintel/tree/master/benchmarks) folder))
-  - _mem__ which measures the memory of the data structure returned:
+  - _mem_ which measures the memory of the data structure returned:
     https://github.com/mie-lab/trackintel/blob/19fcf965fce4a2bca2032f72b2759c7625c02b2f/benchmarks/preprocessing_benchmarks.py#L24
 
   - _peakmem_ which measure the peak memory usage:
     https://github.com/mie-lab/trackintel/blob/19fcf965fce4a2bca2032f72b2759c7625c02b2f/benchmarks/preprocessing_benchmarks.py#L27
   
-  - _time__ which measure run time:
+  - _time_ which measure run time:
     https://github.com/mie-lab/trackintel/blob/19fcf965fce4a2bca2032f72b2759c7625c02b2f/benchmarks/preprocessing_benchmarks.py#L21
-- Detailed instructions for re-running existing benchmarks can be found in the ASV-BENCHMARKS.MD file [here](https://github.com/abcnishant007/trackintel/blob/clean-asv-documentation/benchmarks/ASV-BENCHMARKING.md). 
+- We store the benchmark html files in the `gh-pages` branch for hosting them on the server. Detailed instructions for re-running existing benchmarks can be found in the ASV-BENCHMARKS.MD file [here](https://github.com/mie-lab/trackintel/blob/master/benchmarks/ASV-BENCHMARKING.md). 
 
 ### Others
 - We limit all lines to a maximum of 120 characters.


### PR DESCRIPTION
Update the instructions on Performance benchmarking and the usage of the `gh-pages` branch.