### PR TITLE
ENH: separate read_gpd kwargs into own variable

### DIFF
--- a/tests/io/test_postgis.py
+++ b/tests/io/test_postgis.py
@@ -312,7 +312,7 @@ class TestPositionfixes:
         try:
             pfs.as_positionfixes.to_postgis(table, conn_string)
             with pytest.warns(UserWarning):
-                pfs_db = ti.io.read_positionfixes_postgis(sql, conn, geom_col, index_col="id", **rename_dict)
+                pfs_db = ti.io.read_positionfixes_postgis(sql, conn, geom_col, index_col="id", read_gpd_kws=rename_dict)
             assert_geodataframe_equal(example_positionfixes, pfs_db)
         finally:
             del_table(conn, table)
@@ -406,7 +406,7 @@ class TestTriplegs:
         try:
             tpls.as_triplegs.to_postgis(table, conn_string)
             with pytest.warns(UserWarning):
-                tpls_db = ti.io.read_triplegs_postgis(sql, conn, geom_col, index_col="id", **rename_dict)
+                tpls_db = ti.io.read_triplegs_postgis(sql, conn, geom_col, index_col="id", read_gpd_kws=rename_dict)
             assert_geodataframe_equal(example_triplegs, tpls_db)
         finally:
             del_table(conn, table)
@@ -571,7 +571,7 @@ class TestLocations:
         try:
             locs.as_locations.to_postgis(table, conn_string)
             with pytest.warns(UserWarning):
-                tpls_db = ti.io.read_locations_postgis(sql, conn, geom_col, index_col="id", **rename_dict)
+                tpls_db = ti.io.read_locations_postgis(sql, conn, geom_col, index_col="id", read_gpd_kws=rename_dict)
             assert_geodataframe_equal(example_locations, tpls_db)
         finally:
             del_table(conn, table)
@@ -624,7 +624,7 @@ class TestTrips:
         try:
             trips.as_trips.to_postgis(table, create_engine(conn_string))
             with pytest.warns(UserWarning):
-                tpls_db = ti.io.read_trips_postgis(sql, conn, index_col="id", **rename_dict)
+                tpls_db = ti.io.read_trips_postgis(sql, conn, index_col="id", read_gpd_kws=rename_dict)
             assert_frame_equal(example_trips, tpls_db)
         finally:
             del_table(conn, table)

--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -50,7 +50,7 @@ def read_positionfixes_postgis(
     parse_dates=None,
     params=None,
     chunksize=None,
-    **kwargs
+    read_gpd_kws=None,
 ):
     """Reads positionfixes from a PostGIS database.
 
@@ -92,7 +92,7 @@ def read_positionfixes_postgis(
         If specified, return an iterator where chunksize is the number
         of rows to include in each chunk.
 
-    **kwargs
+    read_gpd_kws : dict, default None
         Further keyword arguments as available in trackintels trackintel.io.read_positionfixes_gpd().
         Especially useful to rename column names from the SQL table to trackintel conform column names.
         See second example how to use it in code.
@@ -106,7 +106,7 @@ def read_positionfixes_postgis(
     --------
     >>> pfs = ti.io.read_positionfixes_postgis("SELECT * FROM positionfixes", con, geom_col="geom")
     >>> pfs = ti.io.read_positionfixes_postgis("SELECT * FROM positionfixes", con, geom_col="geom",
-    ...                                        index_col="id", user_id="USER", tracked_at="time")
+    ...                                        index_col="id", user_id="USER", {tracked_at: "time"})
     """
     pfs = gpd.GeoDataFrame.from_postgis(
         sql,
@@ -119,7 +119,7 @@ def read_positionfixes_postgis(
         params=params,
         chunksize=chunksize,
     )
-    return ti.io.read_positionfixes_gpd(pfs, **kwargs)
+    return ti.io.read_positionfixes_gpd(pfs, **(read_gpd_kws or {}))
 
 
 @_handle_con_string
@@ -149,7 +149,7 @@ def read_triplegs_postgis(
     parse_dates=None,
     params=None,
     chunksize=None,
-    **kwargs
+    read_gpd_kws=None,
 ):
     """Reads triplegs from a PostGIS database.
 
@@ -191,7 +191,7 @@ def read_triplegs_postgis(
         If specified, return an iterator where chunksize is the number
         of rows to include in each chunk.
 
-    **kwargs
+    read_gpd_kws : dict, default None
         Further keyword arguments as available in trackintels trackintel.io.read_triplegs_gpd().
         Especially useful to rename column names from the SQL table to trackintel conform column names.
         See second example how to use it in code.
@@ -205,7 +205,7 @@ def read_triplegs_postgis(
     --------
     >>> tpls = ti.io.read_triplegs_postgis("SELECT * FROM triplegs", con, geom_col="geom")
     >>> tpls = ti.io.read_triplegs_postgis("SELECT * FROM triplegs", con, geom_col="geom", index_col="id",
-    ...                                    started_at="start_time", finished_at="end_time", user_id="USER")
+    ...                                    {started_at: "start_time", finished_at: "end_time", user_id: "USER"})
     """
     tpls = gpd.GeoDataFrame.from_postgis(
         sql,
@@ -218,7 +218,7 @@ def read_triplegs_postgis(
         params=params,
         chunksize=chunksize,
     )
-    return ti.io.read_triplegs_gpd(tpls, **kwargs)
+    return ti.io.read_triplegs_gpd(tpls, **(read_gpd_kws or {}))
 
 
 @_handle_con_string
@@ -248,7 +248,7 @@ def read_staypoints_postgis(
     parse_dates=None,
     params=None,
     chunksize=None,
-    **kwargs
+    read_gpd_kws=None,
 ):
     """Read staypoints from a PostGIS database.
 
@@ -290,7 +290,7 @@ def read_staypoints_postgis(
         If specified, return an iterator where chunksize is the number
         of rows to include in each chunk.
 
-    **kwargs
+    read_gpd_kws : dict, default None
         Further keyword arguments as available in trackintels trackintel.io.read_staypoints_gpd().
         Especially useful to rename column names from the SQL table to trackintel conform column names.
         See second example how to use it in code.
@@ -305,7 +305,7 @@ def read_staypoints_postgis(
     --------
     >>> sp = ti.io.read_staypoints_postgis("SELECT * FROM staypoints", con, geom_col="geom")
     >>> sp = ti.io.read_staypoints_postgis("SELECT * FROM staypoints", con, geom_col="geom", index_col="id",
-    ...                                      started_at="start_time", finished_at="end_time", user_id="USER")
+    ...                                      {started_at: "start_time", finished_at: "end_time", user_id: "USER"})
     """
     sp = gpd.GeoDataFrame.from_postgis(
         sql,
@@ -319,7 +319,7 @@ def read_staypoints_postgis(
         chunksize=chunksize,
     )
 
-    return ti.io.read_staypoints_gpd(sp, **kwargs)
+    return ti.io.read_staypoints_gpd(sp, **(read_gpd_kws or {}))
 
 
 @_handle_con_string
@@ -349,7 +349,8 @@ def read_locations_postgis(
     parse_dates=None,
     params=None,
     chunksize=None,
-    **kwargs
+    extent=None,
+    read_gpd_kws=None,
 ):
     """Reads locations from a PostGIS database.
 
@@ -391,7 +392,10 @@ def read_locations_postgis(
         If specified, return an iterator where chunksize is the number
         of rows to include in each chunk.
 
-    **kwargs
+    extent : string, default None
+        If specified read the extent column as geometry column.
+
+    read_gpd_kws : dict, default None
         Further keyword arguments as available in trackintels trackintel.io.read_locations_gpd().
         Especially useful to rename column names from the SQL table to trackintel conform column names.
         See second example how to use it in code.
@@ -405,7 +409,7 @@ def read_locations_postgis(
     --------
     >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, center="center")
     >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, center="geom", index_col="id",
-    ...                                     user_id="USER", extent="extent")
+    ...                                     extent="extent, {user_id: "USER"})
     )
     """
     locs = gpd.GeoDataFrame.from_postgis(
@@ -419,10 +423,10 @@ def read_locations_postgis(
         params=params,
         chunksize=chunksize,
     )
-    if "extent" in kwargs:
-        locs[kwargs["extent"]] = gpd.GeoSeries.from_wkb(locs[kwargs["extent"]])
+    if extent is not None:
+        locs[extent] = gpd.GeoSeries.from_wkb(locs[extent])
 
-    return ti.io.read_locations_gpd(locs, center=center, **kwargs)
+    return ti.io.read_locations_gpd(locs, center=center, **(read_gpd_kws or {}))
 
 
 @_handle_con_string
@@ -466,7 +470,7 @@ def read_trips_postgis(
     parse_dates=None,
     params=None,
     chunksize=None,
-    **kwargs
+    read_gpd_kws=None,
 ):
     """Read trips from a PostGIS database.
 
@@ -508,7 +512,7 @@ def read_trips_postgis(
         If specified, return an iterator where chunksize is the number
         of rows to include in each chunk.
 
-    **kwargs
+    read_gpd_kws : dict, default None
         Further keyword arguments as available in trackintels trackintel.io.read_trips_gpd().
         Especially useful to rename column names from the SQL table to trackintel conform column names.
         See second example how to use it in code.
@@ -523,8 +527,8 @@ def read_trips_postgis(
     --------
     >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con)
     >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con, geom_col="geom", index_col="id",
-    ...                                  started_at="start_time", finished_at="end_time", user_id="USER",
-    ...                                  origin_staypoint_id="ORIGIN", destination_staypoint_id="DEST")
+    ...                                  {started_at: "start_time", finished_at: "end_time", user_id: "USER",
+    ...                                  origin_staypoint_id: "ORIGIN", destination_staypoint_id: "DEST"})
 
     """
     if geom_col is None:
@@ -550,7 +554,7 @@ def read_trips_postgis(
             chunksize=chunksize,
         )
 
-    return ti.io.read_trips_gpd(trips, **kwargs)
+    return ti.io.read_trips_gpd(trips, **(read_gpd_kws or {}))
 
 
 @_handle_con_string
@@ -592,7 +596,7 @@ def read_tours_postgis(
     parse_dates=None,
     params=None,
     chunksize=None,
-    **kwargs
+    read_gpd_kws=None,
 ):
     """Read tours from a PostGIS database.
 
@@ -634,7 +638,7 @@ def read_tours_postgis(
         If specified, return an iterator where chunksize is the number
         of rows to include in each chunk.
 
-    **kwargs
+    read_gpd_kws : dict, default None
         Further keyword arguments as available in trackintels trackintel.io.read_tours_gpd().
         Especially useful to rename column names from the SQL table to trackintel conform column names.
         See second example how to use it in code.
@@ -647,8 +651,8 @@ def read_tours_postgis(
     Examples
     --------
     >>> tours = ti.io.read_tours_postgis("SELECT * FROM tours", con)
-    >>> tours = ti.io.read_tours_postgis("SELECT * FROM tours", con, index_col="id", started_at="start_time",
-    ...                                  finished_at="end_time", user_id="USER")
+    >>> tours = ti.io.read_tours_postgis("SELECT * FROM tours", con, index_col="id",
+                                         {started_at: "start_time", finished_at: "end_time", user_id: "USER"})
     """
     if geom_col is None:
         tours = pd.read_sql(
@@ -673,7 +677,7 @@ def read_tours_postgis(
             chunksize=chunksize,
         )
 
-    return ti.io.read_tours_gpd(tours, **kwargs)
+    return ti.io.read_tours_gpd(tours, **(read_gpd_kws or {}))
 
 
 @_handle_con_string

--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -106,8 +106,8 @@ def read_positionfixes_postgis(
     --------
     >>> pfs = ti.io.read_positionfixes_postgis("SELECT * FROM positionfixes", con, geom_col="geom")
     >>> pfs = ti.io.read_positionfixes_postgis("SELECT * FROM positionfixes", con, geom_col="geom",
-    ...                                        index_col="id", user_id="USER",
-                                               read_gpd_kws={tracked_at: "time"})
+    ...                                        index_col="id",
+                                               read_gpd_kws={"user_id"="USER", "tracked_at": "time"})
     """
     pfs = gpd.GeoDataFrame.from_postgis(
         sql,
@@ -206,7 +206,7 @@ def read_triplegs_postgis(
     --------
     >>> tpls = ti.io.read_triplegs_postgis("SELECT * FROM triplegs", con, geom_col="geom")
     >>> tpls = ti.io.read_triplegs_postgis("SELECT * FROM triplegs", con, geom_col="geom", index_col="id",
-    ...                                    read_gpd_kws={user_id: "USER"})
+    ...                                    read_gpd_kws={"user_id": "USER"})
     """
     tpls = gpd.GeoDataFrame.from_postgis(
         sql,
@@ -306,7 +306,7 @@ def read_staypoints_postgis(
     --------
     >>> sp = ti.io.read_staypoints_postgis("SELECT * FROM staypoints", con, geom_col="geom")
     >>> sp = ti.io.read_staypoints_postgis("SELECT * FROM staypoints", con, geom_col="geom", index_col="id",
-    ...                                    read_gpd_kws={user_id: "USER"})
+    ...                                    read_gpd_kws={"user_id": "USER"})
     """
     sp = gpd.GeoDataFrame.from_postgis(
         sql,
@@ -410,7 +410,7 @@ def read_locations_postgis(
     --------
     >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, center="center")
     >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, center="geom", index_col="id",
-    ...                                     extent="extent, read_gpd_kws={user_id: "USER"})
+    ...                                     extent="extent, read_gpd_kws={"user_id": "USER"})
     )
     """
     locs = gpd.GeoDataFrame.from_postgis(
@@ -528,8 +528,8 @@ def read_trips_postgis(
     --------
     >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con)
     >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con, geom_col="geom", index_col="id",
-    ...                                  read_gpd_kws={user_id: "USER", origin_staypoint_id: "ORIGIN",
-                                                       destination_staypoint_id: "DEST"})
+    ...                                  read_gpd_kws={"user_id": "USER", "origin_staypoint_id": "ORIGIN",
+                                                       "destination_staypoint_id": "DEST"})
 
     """
     if geom_col is None:
@@ -653,7 +653,7 @@ def read_tours_postgis(
     --------
     >>> tours = ti.io.read_tours_postgis("SELECT * FROM tours", con)
     >>> tours = ti.io.read_tours_postgis("SELECT * FROM tours", con, index_col="id",
-                                         read_gpd_kws={user_id: "USER"})
+                                         read_gpd_kws={"user_id": "USER"})
     """
     if geom_col is None:
         tours = pd.read_sql(

--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -106,7 +106,8 @@ def read_positionfixes_postgis(
     --------
     >>> pfs = ti.io.read_positionfixes_postgis("SELECT * FROM positionfixes", con, geom_col="geom")
     >>> pfs = ti.io.read_positionfixes_postgis("SELECT * FROM positionfixes", con, geom_col="geom",
-    ...                                        index_col="id", user_id="USER", {tracked_at: "time"})
+    ...                                        index_col="id", user_id="USER",
+                                               read_gpd_kws={tracked_at: "time"})
     """
     pfs = gpd.GeoDataFrame.from_postgis(
         sql,
@@ -205,7 +206,7 @@ def read_triplegs_postgis(
     --------
     >>> tpls = ti.io.read_triplegs_postgis("SELECT * FROM triplegs", con, geom_col="geom")
     >>> tpls = ti.io.read_triplegs_postgis("SELECT * FROM triplegs", con, geom_col="geom", index_col="id",
-    ...                                    {started_at: "start_time", finished_at: "end_time", user_id: "USER"})
+    ...                                    read_gpd_kws={user_id: "USER"})
     """
     tpls = gpd.GeoDataFrame.from_postgis(
         sql,
@@ -305,7 +306,7 @@ def read_staypoints_postgis(
     --------
     >>> sp = ti.io.read_staypoints_postgis("SELECT * FROM staypoints", con, geom_col="geom")
     >>> sp = ti.io.read_staypoints_postgis("SELECT * FROM staypoints", con, geom_col="geom", index_col="id",
-    ...                                      {started_at: "start_time", finished_at: "end_time", user_id: "USER"})
+    ...                                    read_gpd_kws={user_id: "USER"})
     """
     sp = gpd.GeoDataFrame.from_postgis(
         sql,
@@ -409,7 +410,7 @@ def read_locations_postgis(
     --------
     >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, center="center")
     >>> locs = ti.io.read_locations_postgis("SELECT * FROM locations", con, center="geom", index_col="id",
-    ...                                     extent="extent, {user_id: "USER"})
+    ...                                     extent="extent, read_gpd_kws={user_id: "USER"})
     )
     """
     locs = gpd.GeoDataFrame.from_postgis(
@@ -527,8 +528,8 @@ def read_trips_postgis(
     --------
     >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con)
     >>> trips = ti.io.read_trips_postgis("SELECT * FROM trips", con, geom_col="geom", index_col="id",
-    ...                                  {started_at: "start_time", finished_at: "end_time", user_id: "USER",
-    ...                                  origin_staypoint_id: "ORIGIN", destination_staypoint_id: "DEST"})
+    ...                                  read_gpd_kws={user_id: "USER", origin_staypoint_id: "ORIGIN",
+                                                       destination_staypoint_id: "DEST"})
 
     """
     if geom_col is None:
@@ -652,7 +653,7 @@ def read_tours_postgis(
     --------
     >>> tours = ti.io.read_tours_postgis("SELECT * FROM tours", con)
     >>> tours = ti.io.read_tours_postgis("SELECT * FROM tours", con, index_col="id",
-                                         {started_at: "start_time", finished_at: "end_time", user_id: "USER"})
+                                         read_gpd_kws={user_id: "USER"})
     """
     if geom_col is None:
         tours = pd.read_sql(


### PR DESCRIPTION
closes #409 

Split up kwargs into own variable.
Test already existed for this.