### PR TITLE
BLD: increase geopandas version

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,7 +6,7 @@ dependencies:
 - python
 - numpy
 - matplotlib
-- geopandas>=0.10.0
+- geopandas>=0.12.0
 - scikit-learn
 - networkx
 - pint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 numpy
 matplotlib
-geopandas>=0.10.0
+geopandas>=0.12.0
 scikit-learn
 networkx 
 pint 


### PR DESCRIPTION
Due to overlapping PR, the version of geopandas wasn't increased for the dev requirements.