### PR TITLE
TST: remove unnecessary assert statements from tests

### DIFF
--- a/tests/analysis/test_location_identification.py
+++ b/tests/analysis/test_location_identification.py
@@ -39,7 +39,7 @@ def example_staypoints():
     ]
     sp = gpd.GeoDataFrame(data=list_dict, geometry="geometry", crs="EPSG:4326")
     sp.index.name = "id"
-    assert sp.as_staypoints
+    sp.as_staypoints
     assert "location_id" in sp.columns
     return sp
 
@@ -145,7 +145,7 @@ def example_freq():
     sp = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
     sp.index.name = "id"
     assert "location_id" in sp.columns
-    assert sp.as_staypoints
+    sp.as_staypoints
     return sp
 
 
@@ -297,7 +297,7 @@ def example_osna():
     sp = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
     sp.index.name = "id"
     assert "location_id" in sp.columns
-    assert sp.as_staypoints
+    sp.as_staypoints
     return sp
 
 

--- a/tests/analysis/test_modal_split.py
+++ b/tests/analysis/test_modal_split.py
@@ -127,17 +127,11 @@ class TestModalSplit:
                     for norm in norm_list:
                         calculate_modal_split(tpls, metric=metric, freq=freq, per_user=per_user, norm=norm)
 
-        # we only check if it runs through successfully
-        assert True
-
     def test_run_modal_split_with_geolife_accessors(self, read_geolife_with_modes):
         """check if we can access `calculate_modal_split` via the tripelg accessor"""
 
         tpls = read_geolife_with_modes
         tpls.as_triplegs.calculate_modal_split(metric="count", freq="D")
-
-        # we only check if it runs through successfully
-        assert True
 
     def test_modal_split_total_count(self, test_triplegs_modal_split):
         """Check counts per user and mode without temporal binning"""

--- a/tests/io/test_postgis.py
+++ b/tests/io/test_postgis.py
@@ -66,7 +66,7 @@ def example_positionfixes():
     ]
     pfs = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
     pfs.index.name = "id"
-    assert pfs.as_positionfixes
+    pfs.as_positionfixes
     return pfs
 
 
@@ -89,7 +89,7 @@ def example_staypoints():
     ]
     sp = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
     sp.index.name = "id"
-    assert sp.as_staypoints
+    sp.as_staypoints
     return sp
 
 
@@ -115,7 +115,7 @@ def example_triplegs():
     tpls = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
     tpls.set_index("id", inplace=True)
 
-    assert tpls.as_triplegs
+    tpls.as_triplegs
     return tpls
 
 
@@ -133,7 +133,7 @@ def example_locations():
     ]
     locs = gpd.GeoDataFrame(data=list_dict, geometry="center", crs="EPSG:4326")
     locs.index.name = "id"
-    assert locs.as_locations
+    locs.as_locations
     return locs
 
 
@@ -158,7 +158,7 @@ def example_trips():
     ]
     trips = pd.DataFrame(data=list_dict)
     trips.index.name = "id"
-    assert trips.as_trips
+    trips.as_trips
     return trips
 
 
@@ -177,7 +177,7 @@ def example_tours():
     ]
     tours = pd.DataFrame(data=list_dict)
     tours.index.name = "id"
-    assert tours.as_tours
+    tours.as_tours
     return tours
 
 

--- a/tests/model/test_positionfixes.py
+++ b/tests/model/test_positionfixes.py
@@ -20,7 +20,7 @@ class TestPositionfixes:
     def test_accessor_column(self, testdata_geolife):
         """Test if the as_positionfixes accessor checks the required column for positionfixes."""
         pfs = testdata_geolife.copy()
-        assert pfs.as_positionfixes
+        pfs.as_positionfixes
 
         # check user_id
         with pytest.raises(AttributeError, match="To process a DataFrame as a collection of positionfixes"):

--- a/tests/model/test_staypoints.py
+++ b/tests/model/test_staypoints.py
@@ -21,7 +21,7 @@ class TestStaypoints:
     def test_accessor_columns(self, testdata_sp):
         """Test if the as_staypoints accessor checks the required column for staypoints."""
         sp = testdata_sp.copy()
-        assert sp.as_staypoints
+        sp.as_staypoints
 
         with pytest.raises(AttributeError, match="To process a DataFrame as a collection of staypoints"):
             sp.drop(["user_id"], axis=1).as_staypoints

--- a/tests/model/test_triplegs.py
+++ b/tests/model/test_triplegs.py
@@ -23,7 +23,7 @@ class TestTriplegs:
         """Test if the as_triplegs accessor checks the required column for triplegs."""
         tpls = testdata_tpls.copy()
 
-        assert tpls.as_triplegs
+        tpls.as_triplegs
 
         # check user_id
         with pytest.raises(AttributeError):

--- a/tests/model/test_trips.py
+++ b/tests/model/test_trips.py
@@ -19,7 +19,7 @@ class TestTrips:
     def test_accessor(self, testdata_trips):
         """Test if the as_trips accessor checks the required column for trips."""
         trips = testdata_trips.copy()
-        assert trips.as_trips
+        trips.as_trips
 
         # user_id
         with pytest.raises(AttributeError):

--- a/tests/preprocessing/test_staypoints.py
+++ b/tests/preprocessing/test_staypoints.py
@@ -86,7 +86,7 @@ def example_staypoints_merge():
     ]
     sp = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
     sp = sp.set_index("id")
-    assert sp.as_staypoints
+    sp.as_staypoints
 
     # generate empty triplegs for the merge function
     tpls = pd.DataFrame([], columns=["user_id", "started_at", "finished_at"])


### PR DESCRIPTION
In #498 I copied `assert locs.as_locations` from another test. But we decided in #215 to use `locs.as_locations` to check validity.
To never copy the old style again, this PR removes all of it from the tests (and in addition I removed some `assert True`).
As a sidenote, I think some validity checks don`t work, as discussed in #476, but most are fine.