### PR TITLE
ENH: warn in `read_postgis_` functions if no index column is provided

### DIFF
--- a/tests/io/test_util.py
+++ b/tests/io/test_util.py
@@ -1,0 +1,23 @@
+import pytest
+from trackintel.io.util import _index_warning_default_none
+
+
+class Test_index_warning_default_none:
+    def test_index_set(self):
+        """Test if a set index creates no warning."""
+
+        @_index_warning_default_none
+        def foo(index_col=None):
+            return
+
+        foo(index_col=None)
+
+    def test_index_default(self):
+        """Test if default index creates a warning."""
+
+        @_index_warning_default_none
+        def foo(index_col=None):
+            return
+
+        with pytest.warns(UserWarning):
+            foo()

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -1,7 +1,4 @@
 import ast
-import warnings
-from functools import wraps
-from inspect import signature
 
 import geopandas as gpd
 import pandas as pd
@@ -15,22 +12,7 @@ from trackintel.io.from_geopandas import (
     read_triplegs_gpd,
     read_trips_gpd,
 )
-
-
-def _index_warning_default_none(func):
-    """Decorator function that warns if index_col None is not set explicit."""
-
-    @wraps(func)  # copy all metadata
-    def wrapper(*args, **kwargs):
-        bound_values = signature(func).bind(*args, **kwargs)  # binds only available args and kwargs
-        if "index_col" not in bound_values.arguments:
-            warnings.warn(
-                "Assuming default index as unique identifier. "
-                "Pass 'index_col=None' as explicit argument to avoid a warning when reading csv files."
-            )
-        return func(*args, **kwargs)
-
-    return wrapper
+from trackintel.io.util import _index_warning_default_none
 
 
 @_index_warning_default_none

--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -10,6 +10,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.types import JSON
 
 import trackintel as ti
+from trackintel.io.util import _index_warning_default_none
 
 
 def _handle_con_string(func):
@@ -40,6 +41,7 @@ def _handle_con_string(func):
     return wrapper
 
 
+@_index_warning_default_none
 @_handle_con_string
 def read_positionfixes_postgis(
     sql,
@@ -140,6 +142,7 @@ def write_positionfixes_postgis(
     )
 
 
+@_index_warning_default_none
 @_handle_con_string
 def read_triplegs_postgis(
     sql,
@@ -239,6 +242,7 @@ def write_triplegs_postgis(
     )
 
 
+@_index_warning_default_none
 @_handle_con_string
 def read_staypoints_postgis(
     sql,
@@ -340,6 +344,7 @@ def write_staypoints_postgis(
     )
 
 
+@_index_warning_default_none
 @_handle_con_string
 def read_locations_postgis(
     sql,
@@ -461,6 +466,7 @@ def write_locations_postgis(
     )
 
 
+@_index_warning_default_none
 @_handle_con_string
 def read_trips_postgis(
     sql,
@@ -590,6 +596,7 @@ def write_trips_postgis(
         )
 
 
+@_index_warning_default_none
 @_handle_con_string
 def read_tours_postgis(
     sql,

--- a/trackintel/io/util.py
+++ b/trackintel/io/util.py
@@ -1,0 +1,19 @@
+import warnings
+from functools import wraps
+from inspect import signature
+
+
+def _index_warning_default_none(func):
+    """Decorator function that warns if index_col None is not set explicit."""
+
+    @wraps(func)  # copy all metadata
+    def wrapper(*args, **kwargs):
+        bound_values = signature(func).bind(*args, **kwargs)  # binds only available args and kwargs
+        if "index_col" not in bound_values.arguments:
+            warnings.warn(
+                "Assuming default index as unique identifier. "
+                "Pass 'index_col=None' as explicit argument to avoid a warning."
+            )
+        return func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
closes #330 
I moved the decorator for the `read_csv` function to `io/util.py` to make it accessible, and then used it for the postgis functions as well.
Alternatively, we could move it to `io/from_geopandas.py` to avoid creating a new file.