### PR TITLE
CLN: replace `%s` and `.format` with fstrings

### DIFF
--- a/trackintel/analysis/tracking_quality.py
+++ b/trackintel/analysis/tracking_quality.py
@@ -72,8 +72,7 @@ def temporal_tracking_quality(source, granularity="all"):
     if any([c not in source.columns for c in required_columns]):
         raise KeyError(
             "To successfully calculate the user-level tracking quality, "
-            + "the source dataframe must have the columns [%s], but it has [%s]."
-            % (", ".join(required_columns), ", ".join(source.columns))
+            f"the source dataframe must have the columns {required_columns}, but it has [{', '.join(source.columns)}]."
         )
 
     df = source.copy()

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -64,9 +64,9 @@ def calculate_distance_matrix(X, Y=None, dist_metric="haversine", n_jobs=0, **kw
     geom_type = X.geometry.iat[0].geom_type
     if Y is None:
         Y = X
-    assert Y.geometry.iat[0].geom_type == Y.geometry.iat[0].geom_type, (
-        "x and y need same geometry type " "(only first column checked)"
-    )
+    assert (
+        Y.geometry.iat[0].geom_type == Y.geometry.iat[0].geom_type
+    ), "x and y need same geometry type (only first column checked)"
 
     if geom_type == "Point":
         x1 = X.geometry.x.values

--- a/trackintel/io/dataset_reader.py
+++ b/trackintel/io/dataset_reader.py
@@ -98,15 +98,15 @@ def read_geolife(geolife_path, print_progress=False):
     uids = [u for u in os.listdir(geolife_path) if os.path.isdir(os.path.join(geolife_path, u))]
 
     if len(uids) == 0:
-        raise FileNotFoundError("No user folders found at path {}".format(geolife_path))
+        raise FileNotFoundError(f"No user folders found at path {geolife_path}")
 
     for user_id in uids:
         try:
             int(user_id)
         except ValueError as err:
             errmsg = (
-                "Invalid user_id '{}' found in geolife path '{}'. The geolife path can only contain folders"
-                " named with integers that represent the user id.".format(user_id, os.path.join(geolife_path, user_id))
+                f"Invalid user_id '{user_id}' found in geolife path '{os.path.join(geolife_path, user_id)}'."
+                "The geolife path can only contain folders named with integers that represent the user id."
             )
             raise ValueError(errmsg) from err
 

--- a/trackintel/io/from_geopandas.py
+++ b/trackintel/io/from_geopandas.py
@@ -448,7 +448,7 @@ def _localize_timestamp(dt_series, pytz_tzinfo, col_name):
         a timezone aware pandas datetime series
     """
     if pytz_tzinfo is None:
-        warnings.warn("Assuming UTC timezone for column {}".format(col_name))
+        warnings.warn(f"Assuming UTC timezone for column {col_name}")
         pytz_tzinfo = "utc"
 
     timezone = pytz.timezone(pytz_tzinfo)

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -39,9 +39,8 @@ class LocationsAccessor(object):
     def _validate(obj):
         if any([c not in obj.columns for c in LocationsAccessor.required_columns]):
             raise AttributeError(
-                "To process a DataFrame as a collection of locations, "
-                + "it must have the properties [%s], but it has [%s]."
-                % (", ".join(LocationsAccessor.required_columns), ", ".join(obj.columns))
+                "To process a DataFrame as a collection of locations, it must have the properties"
+                f" {LocationsAccessor.required_columns}, but it has [{', '.join(obj.columns)}]."
             )
 
         if not (obj.shape[0] > 0 and obj["center"].iloc[0].geom_type == "Point"):

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -45,19 +45,18 @@ class PositionfixesAccessor(object):
 
     @staticmethod
     def _validate(obj):
-        assert obj.shape[0] > 0, "Geodataframe is empty with shape: {}".format(obj.shape)
+        assert obj.shape[0] > 0, f"Geodataframe is empty with shape: {obj.shape}"
         # check columns
         if any([c not in obj.columns for c in PositionfixesAccessor.required_columns]):
             raise AttributeError(
-                "To process a DataFrame as a collection of positionfixes, "
-                + "it must have the properties [%s], but it has [%s]."
-                % (", ".join(PositionfixesAccessor.required_columns), ", ".join(obj.columns))
+                "To process a DataFrame as a collection of positionfixes, it must have the properties"
+                f" {PositionfixesAccessor.required_columns}, but it has [{', '.join(obj.columns)}]."
             )
 
         # check geometry
-        assert obj.geometry.is_valid.all(), (
-            "Not all geometries are valid. Try x[~ x.geometry.is_valid] " "where x is you GeoDataFrame"
-        )
+        assert (
+            obj.geometry.is_valid.all()
+        ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
 
         if obj.geometry.iloc[0].geom_type != "Point":
             raise AttributeError("The geometry must be a Point (only first checked).")
@@ -65,7 +64,7 @@ class PositionfixesAccessor(object):
         # check timestamp dtypes
         assert pd.api.types.is_datetime64tz_dtype(
             obj["tracked_at"]
-        ), "dtype of tracked_at is {} but has to be datetime64 and timezone aware".format(obj["tracked_at"].dtype)
+        ), f"dtype of tracked_at is {obj['tracked_at'].dtype} but has to be datetime64 and timezone aware"
 
     @property
     def center(self):

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -52,24 +52,23 @@ class StaypointsAccessor(object):
         # check columns
         if any([c not in obj.columns for c in StaypointsAccessor.required_columns]):
             raise AttributeError(
-                "To process a DataFrame as a collection of staypoints, "
-                + "it must have the properties [%s], but it has [%s]."
-                % (", ".join(StaypointsAccessor.required_columns), ", ".join(obj.columns))
+                "To process a DataFrame as a collection of staypoints, it must have the properties"
+                f" {StaypointsAccessor.required_columns}, but it has {', '.join(obj.columns)}."
             )
         # check geometry
-        assert obj.geometry.is_valid.all(), (
-            "Not all geometries are valid. Try x[~ x.geometry.is_valid] " "where x is you GeoDataFrame"
-        )
+        assert (
+            obj.geometry.is_valid.all()
+        ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
         if obj.geometry.iloc[0].geom_type != "Point":
             raise AttributeError("The geometry must be a Point (only first checked).")
 
         # check timestamp dtypes
         assert pd.api.types.is_datetime64tz_dtype(
             obj["started_at"]
-        ), "dtype of started_at is {} but has to be tz aware datetime64".format(obj["started_at"].dtype)
+        ), f"dtype of started_at is {obj['started_at'].dtype} but has to be tz aware datetime64"
         assert pd.api.types.is_datetime64tz_dtype(
             obj["finished_at"]
-        ), "dtype of finished_at is {} but has to be tz aware datetime64".format(obj["finished_at"].dtype)
+        ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be tz aware datetime64"
 
     @property
     def center(self):

--- a/trackintel/model/tours.py
+++ b/trackintel/model/tours.py
@@ -37,18 +37,17 @@ class ToursAccessor(object):
     def _validate(obj):
         if any([c not in obj.columns for c in ToursAccessor.required_columns]):
             raise AttributeError(
-                "To process a DataFrame as a collection of tours, "
-                + "it must have the properties [%s], but it has [%s]."
-                % (", ".join(ToursAccessor.required_columns), ", ".join(obj.columns))
+                "To process a DataFrame as a collection of tours, it must have the properties"
+                f" {ToursAccessor.required_columns}, but it has {', '.join(obj.columns)}."
             )
 
         # check timestamp dtypes
         assert pd.api.types.is_datetime64tz_dtype(
             obj["started_at"]
-        ), "dtype of started_at is {} but has to be datetime64 and timezone aware".format(obj["started_at"].dtype)
+        ), f"dtype of started_at is {obj['started_at'].dtype} but has to be datetime64 and timezone aware"
         assert pd.api.types.is_datetime64tz_dtype(
             obj["finished_at"]
-        ), "dtype of finished_at is {} but has to be datetime64 and timezone aware".format(obj["finished_at"].dtype)
+        ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be datetime64 and timezone aware"
 
     def to_csv(self, filename, *args, **kwargs):
         """

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -48,28 +48,27 @@ class TriplegsAccessor(object):
 
     @staticmethod
     def _validate(obj):
-        assert obj.shape[0] > 0, "Geodataframe is empty with shape: {}".format(obj.shape)
+        assert obj.shape[0] > 0, f"Geodataframe is empty with shape: {obj.shape}"
         # check columns
         if any([c not in obj.columns for c in TriplegsAccessor.required_columns]):
             raise AttributeError(
-                "To process a DataFrame as a collection of triplegs, "
-                + "it must have the properties [%s], but it has [%s]."
-                % (", ".join(TriplegsAccessor.required_columns), ", ".join(obj.columns))
+                "To process a DataFrame as a collection of triplegs, it must have the properties"
+                f" {TriplegsAccessor.required_columns}, but it has [{', '.join(obj.columns)}]."
             )
         # check geometry
-        assert obj.geometry.is_valid.all(), (
-            "Not all geometries are valid. Try x[~ x.geometry.is_valid] " "where x is you GeoDataFrame"
-        )
+        assert (
+            obj.geometry.is_valid.all()
+        ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
         if obj.geometry.iloc[0].geom_type != "LineString":
             raise AttributeError("The geometry must be a LineString (only first checked).")
 
         # check timestamp dtypes
         assert pd.api.types.is_datetime64tz_dtype(
             obj["started_at"]
-        ), "dtype of started_at is {} but has to be datetime64 and timezone aware".format(obj["started_at"].dtype)
+        ), f"dtype of started_at is {obj['started_at'].dtype} but has to be datetime64 and timezone aware"
         assert pd.api.types.is_datetime64tz_dtype(
             obj["finished_at"]
-        ), "dtype of finished_at is {} but has to be datetime64 and timezone aware".format(obj["finished_at"].dtype)
+        ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be datetime64 and timezone aware"
 
     @_copy_docstring(plot_triplegs)
     def plot(self, *args, **kwargs):

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -53,25 +53,24 @@ class TripsAccessor(object):
     def _validate(obj):
         if any([c not in obj.columns for c in TripsAccessor.required_columns]):
             raise AttributeError(
-                "To process a DataFrame as a collection of trips, "
-                + "it must have the properties [%s], but it has [%s]."
-                % (", ".join(TripsAccessor.required_columns), ", ".join(obj.columns))
+                "To process a DataFrame as a collection of trips, it must have the properties"
+                f" {TripsAccessor.required_columns}, but it has [{', '.join(obj.columns)}]."
             )
 
         # check timestamp dtypes
         assert pd.api.types.is_datetime64tz_dtype(
             obj["started_at"]
-        ), "dtype of started_at is {} but has to be datetime64 and timezone aware".format(obj["started_at"].dtype)
+        ), f"dtype of started_at is {obj['started_at'].dtype} but has to be datetime64 and timezone aware"
         assert pd.api.types.is_datetime64tz_dtype(
             obj["finished_at"]
-        ), "dtype of finished_at is {} but has to be datetime64 and timezone aware".format(obj["finished_at"].dtype)
+        ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be datetime64 and timezone aware"
 
         # Check geometry if Trips is a GeoDataFrame
         if isinstance(obj, gpd.GeoDataFrame):
             # check geometry
-            assert obj.geometry.is_valid.all(), (
-                "Not all geometries are valid. Try x[~ x.geometry.is_valid] " "where x is you GeoDataFrame"
-            )
+            assert (
+                obj.geometry.is_valid.all()
+            ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
             if obj.geometry.iloc[0].geom_type != "MultiPoint":
                 raise AttributeError("The geometry must be a MultiPoint (only first checked).")
 

--- a/trackintel/visualization/osm.py
+++ b/trackintel/visualization/osm.py
@@ -46,4 +46,4 @@ def plot_osm_streets(north, south, east, west, ax):
         lc = LineCollection(lines, colors="#999999", linewidths=0.5, alpha=1, zorder=0)
         ax.add_collection(lc)
     except NetworkXPointlessConcept as e:
-        logging.warn("Plotting of OSM graph failed: %s", e)
+        logging.warn(f"Plotting of OSM graph failed: {e}")

--- a/trackintel/visualization/util.py
+++ b/trackintel/visualization/util.py
@@ -47,7 +47,7 @@ def a4_figsize(fig_height_mm=None, columns=2):
 
     max_figh_height_mm = 234.0
     if fig_height_mm > max_figh_height_mm:
-        logging.warning("fig_height too large: %s, so will reduce to %s." % (fig_height_mm, fig_height_mm))
+        logging.warning(f"fig_height too large: {fig_height_mm}, so will reduce to {max_figh_height_mm}.")
         fig_height_mm = max_figh_height_mm
 
     fig_height_mm *= ureg.millimeter
@@ -56,7 +56,7 @@ def a4_figsize(fig_height_mm=None, columns=2):
     fig_width = fig_width_mm.to(ureg.inch).magnitude
     fig_height = fig_height_mm.to(ureg.inch).magnitude
 
-    logging.info("Creating figure of %sx%s." % (fig_width_mm, fig_height_mm))
+    logging.info(f"Creating figure of {fig_width_mm}x{fig_height_mm}.")
     return fig_width, fig_height
 
 
@@ -113,11 +113,11 @@ def save_fig(out_filename, tight="tight", formats=["png", "pdf"]):
         logging.info("Creating png...")
         ts = time.time()
         plt.savefig(outpath, dpi=600, bbox_inches=tight, pad_inches=0)
-        logging.info("...took {} s!".format(round(time.time() - ts, 2)))
+        logging.info(f"...took {round(time.time() - ts, 2)} s!")
     if "pdf" in formats:
         logging.info("Creating pdf...")
         ts = time.time()
         plt.savefig(outpath.replace(".png", ".pdf"), bbox_inches=tight, pad_inches=0)
-        logging.info("...took {} s!".format(round(time.time() - ts, 2)))
+        logging.info(f"...took {round(time.time() - ts, 2)} s!")
     plt.close()
     logging.info("Finished!")


### PR DESCRIPTION
Small cleanup PR that converts all `%s` strings and `format` functions into fstrings. This should prevent me from fixing small problems in other PRs where they are not relevant.