### PR TITLE
BUG: enable non-numeric dtypes in generate_triplegs

### DIFF
--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -552,5 +552,5 @@ class TestGenerate_triplegs:
         # remove isolated - not needed for this test
         pfs = pfs[~pfs.index.isin([1, 2])].copy()
         # set user ID to string
-        pfs["user_id"] = pfs["user_id"].astype(str)
-        pfs, tpls = pfs.as_positionfixes.generate_triplegs()
+        pfs["user_id"] = pfs["user_id"].astype(str) + "not_numerical_interpretable_str"
+        pfs, _ = pfs.as_positionfixes.generate_triplegs()

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -362,7 +362,7 @@ def generate_triplegs(
         posfix_grouper = pfs.groupby("tripleg_id")
 
         tpls = posfix_grouper.agg(
-            {"user_id": ["mean"], "tracked_at": [min, max], pfs.geometry.name: list}
+            {"user_id": ["first"], "tracked_at": [min, max], pfs.geometry.name: list}
         )  # could add a "number of pfs": can be any column "count"
 
         # prepare dataframe: Rename columns; read/set geometry/crs;


### PR DESCRIPTION
closes #514 
Changed `mean` function to `first`. Bug wasn't detected as pandas `mean` interprets strings like `"0"` as numbers for `mean` if necessary. 