### PR TITLE
ENH: remove `is_datetime64tz_type`

### DIFF
--- a/tests/io/test_file.py
+++ b/tests/io/test_file.py
@@ -47,7 +47,7 @@ class TestPositionfixes:
         # check if tz is added to the datatime column
         file = os.path.join("tests", "data", "positionfixes.csv")
         pfs = ti.read_positionfixes_csv(file, sep=";", index_col="id")
-        assert pd.api.types.is_datetime64tz_dtype(pfs["tracked_at"])
+        assert isinstance(pfs["tracked_at"].dtype, pd.DatetimeTZDtype)
 
         # check if a timezone will be set without storing the timezone
         date_format = "%Y-%m-%d %H:%M:%S"
@@ -55,7 +55,7 @@ class TestPositionfixes:
         pfs.as_positionfixes.to_csv(tmp_file, sep=";", date_format=date_format)
         pfs = ti.read_positionfixes_csv(tmp_file, sep=";", index_col="id", tz="utc")
 
-        assert pd.api.types.is_datetime64tz_dtype(pfs["tracked_at"])
+        assert isinstance(pfs["tracked_at"].dtype, pd.DatetimeTZDtype)
 
         # check if a warning is raised if 'tz' is not provided
         with pytest.warns(UserWarning):
@@ -115,7 +115,7 @@ class TestTriplegs:
         # check if tz is added to the datatime column
         file = os.path.join("tests", "data", "triplegs.csv")
         tpls = ti.read_triplegs_csv(file, sep=";", index_col="id")
-        assert pd.api.types.is_datetime64tz_dtype(tpls["started_at"])
+        assert isinstance(tpls["started_at"].dtype, pd.DatetimeTZDtype)
 
         # check if a timezone will be set without storing the timezone
         tmp_file = os.path.join("tests", "data", "triplegs_test_2.csv")
@@ -123,7 +123,7 @@ class TestTriplegs:
         tpls.as_triplegs.to_csv(tmp_file, sep=";", date_format=date_format)
         tpls = ti.read_triplegs_csv(tmp_file, sep=";", index_col="id", tz="utc")
 
-        assert pd.api.types.is_datetime64tz_dtype(tpls["started_at"])
+        assert isinstance(tpls["started_at"].dtype, pd.DatetimeTZDtype)
 
         # check if a warning is raised if 'tz' is not provided
         with pytest.warns(UserWarning):
@@ -180,7 +180,7 @@ class TestStaypoints:
         # check if tz is added to the datatime column
         file = os.path.join("tests", "data", "staypoints.csv")
         sp = ti.read_staypoints_csv(file, sep=";", index_col="id")
-        assert pd.api.types.is_datetime64tz_dtype(sp["started_at"])
+        assert isinstance(sp["started_at"].dtype, pd.DatetimeTZDtype)
 
         # check if a timezone will be without storing the timezone
         tmp_file = os.path.join("tests", "data", "staypoints_test_2.csv")
@@ -188,7 +188,7 @@ class TestStaypoints:
         sp.as_staypoints.to_csv(tmp_file, sep=";", date_format=date_format)
         sp = ti.read_staypoints_csv(tmp_file, sep=";", index_col="id", tz="utc")
 
-        assert pd.api.types.is_datetime64tz_dtype(sp["started_at"])
+        assert isinstance(sp["started_at"].dtype, pd.DatetimeTZDtype)
 
         # check if a warning is raised if 'tz' is not provided
         with pytest.warns(UserWarning):
@@ -305,7 +305,7 @@ class TestTrips:
         # check if tz is added to the datatime column
         file = os.path.join("tests", "data", "trips.csv")
         trips = ti.read_trips_csv(file, sep=";", index_col="id")
-        assert pd.api.types.is_datetime64tz_dtype(trips["started_at"])
+        assert isinstance(trips["started_at"].dtype, pd.DatetimeTZDtype)
 
         # check if a timezone will be set without storing the timezone
         tmp_file = os.path.join("tests", "data", "trips_test_2.csv")
@@ -313,7 +313,7 @@ class TestTrips:
         trips.as_trips.to_csv(tmp_file, sep=";", date_format=date_format)
         trips = ti.read_trips_csv(tmp_file, sep=";", index_col="id", tz="utc")
 
-        assert pd.api.types.is_datetime64tz_dtype(trips["started_at"])
+        assert isinstance(trips["started_at"].dtype, pd.DatetimeTZDtype)
 
         # check if a warning is raised if 'tz' is not provided
         with pytest.warns(UserWarning):

--- a/trackintel/io/from_geopandas.py
+++ b/trackintel/io/from_geopandas.py
@@ -400,7 +400,7 @@ def _trackintel_model(gdf, set_names=None, geom_col=None, crs=None, tz_cols=None
 
     if tz_cols is not None:
         for col in tz_cols:
-            if not pd.api.types.is_datetime64tz_dtype(gdf[col]):
+            if not isinstance(gdf[col].dtype, pd.DatetimeTZDtype):
                 try:
                     gdf[col] = _localize_timestamp(dt_series=gdf[col], pytz_tzinfo=tz, col_name=col)
                 except ValueError:

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -66,8 +66,8 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
                 f" {_required_columns}, but it has [{', '.join(obj.columns)}]."
             )
         # check timestamp dtypes
-        assert pd.api.types.is_datetime64tz_dtype(
-            obj["tracked_at"]
+        assert isinstance(
+            obj["tracked_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of tracked_at is {obj['tracked_at'].dtype} but has to be datetime64 and timezone aware"
 
         # check geometry
@@ -86,7 +86,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
             return False
         if obj.shape[0] <= 0:
             return False
-        if not pd.api.types.is_datetime64tz_dtype(obj["tracked_at"]):
+        if not isinstance(obj["tracked_at"].dtype, pd.DatetimeTZDtype):
             return False
         if validate_geometry:
             return obj.geometry.is_valid.all() and obj.geometry.iloc[0].geom_type == "Point"

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -66,11 +66,11 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
                 f" {_required_columns}, but it has {', '.join(obj.columns)}."
             )
         # check timestamp dtypes
-        assert pd.api.types.is_datetime64tz_dtype(
-            obj["started_at"]
+        assert isinstance(
+            obj["started_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of started_at is {obj['started_at'].dtype} but has to be tz aware datetime64"
-        assert pd.api.types.is_datetime64tz_dtype(
-            obj["finished_at"]
+        assert isinstance(
+            obj["finished_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be tz aware datetime64"
 
         if validate_geometry:
@@ -86,9 +86,9 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
         """Check does the same as _validate but returns bool instead of potentially raising an error."""
         if any([c not in obj.columns for c in _required_columns]):
             return False
-        if not pd.api.types.is_datetime64tz_dtype(obj["started_at"]):
+        if not isinstance(obj["started_at"].dtype, pd.DatetimeTZDtype):
             return False
-        if not pd.api.types.is_datetime64tz_dtype(obj["finished_at"]):
+        if not isinstance(obj["finished_at"].dtype, pd.DatetimeTZDtype):
             return False
         if validate_geometry:
             return obj.geometry.is_valid.all() and obj.geometry.iloc[0].geom_type == "Point"

--- a/trackintel/model/tours.py
+++ b/trackintel/model/tours.py
@@ -42,11 +42,11 @@ class ToursAccessor(object):
             )
 
         # check timestamp dtypes
-        assert pd.api.types.is_datetime64tz_dtype(
-            obj["started_at"]
+        assert isinstance(
+            obj["started_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of started_at is {obj['started_at'].dtype} but has to be datetime64 and timezone aware"
-        assert pd.api.types.is_datetime64tz_dtype(
-            obj["finished_at"]
+        assert isinstance(
+            obj["finished_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be datetime64 and timezone aware"
 
     def to_csv(self, filename, *args, **kwargs):

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -67,11 +67,11 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
             )
 
         # check timestamp dtypes
-        assert pd.api.types.is_datetime64tz_dtype(
-            obj["started_at"]
+        assert isinstance(
+            obj["started_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of started_at is {obj['started_at'].dtype} but has to be datetime64 and timezone aware"
-        assert pd.api.types.is_datetime64tz_dtype(
-            obj["finished_at"]
+        assert isinstance(
+            obj["finished_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be datetime64 and timezone aware"
 
         # check geometry
@@ -89,9 +89,9 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
             return False
         if obj.shape[0] <= 0:
             return False
-        if not pd.api.types.is_datetime64tz_dtype(obj["started_at"]):
+        if not isinstance(obj["started_at"].dtype, pd.DatetimeTZDtype):
             return False
-        if not pd.api.types.is_datetime64tz_dtype(obj["finished_at"]):
+        if not isinstance(obj["finished_at"].dtype, pd.DatetimeTZDtype):
             return False
         if validate_geometry:
             return obj.geometry.is_valid.all() and obj.geometry.iloc[0].geom_type == "LineString"

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -58,11 +58,11 @@ class TripsAccessor(object):
             )
 
         # check timestamp dtypes
-        assert pd.api.types.is_datetime64tz_dtype(
-            obj["started_at"]
+        assert isinstance(
+            obj["started_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of started_at is {obj['started_at'].dtype} but has to be datetime64 and timezone aware"
-        assert pd.api.types.is_datetime64tz_dtype(
-            obj["finished_at"]
+        assert isinstance(
+            obj["finished_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be datetime64 and timezone aware"
 
         # Check geometry if Trips is a GeoDataFrame


### PR DESCRIPTION
Replaces all calls of `is_datetime64tz_type(obj)` with `isinstance(obj.dtype, pd.DatetimeTZDtype)`, because it is deprecated in pandas `2.1.0`.
Personally I don't understand why they changed that, but apparently it creates some minor performance increase.

 