### PR TITLE
CLN: fix deprecation warnings for `fillna` and `.agg`

### DIFF
--- a/trackintel/analysis/location_identification.py
+++ b/trackintel/analysis/location_identification.py
@@ -143,7 +143,7 @@ def pre_filter_locations(
         groupby_loc = ["location_id"]
     else:
         raise ValueError(f"Unknown agg_level '{agg_level}' use instead {{'user', 'dataset'}}.")
-    loc = sp.groupby(groupby_loc).agg({"started_at": [min, "count"], "finished_at": max, "duration": sum})
+    loc = sp.groupby(groupby_loc).agg({"started_at": ["min", "count"], "finished_at": "max", "duration": "sum"})
     loc.columns = loc.columns.droplevel(0)  # remove possible multi-index
     loc.rename(columns={"min": "started_at", "max": "finished_at", "sum": "duration"}, inplace=True)
     # period for maximal time span first visit - last visit.
@@ -214,7 +214,7 @@ def _freq_transform(group, *labels):
     pd.Series
         dtype : object
     """
-    group_agg = group.groupby("location_id").agg({"duration": sum})
+    group_agg = group.groupby("location_id").agg({"duration": "sum"})
     group_agg["purpose"] = _freq_assign(group_agg["duration"], *labels)
     group_merge = pd.merge(
         group["location_id"], group_agg["purpose"], how="left", left_on="location_id", right_index=True

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -355,7 +355,7 @@ def generate_triplegs(
 
         # fill the pd.NAs with the previously observed tripleg_id
         # pfs not belonging to tripleg are also propagated (with -1)
-        pfs["tripleg_id"] = pfs["tripleg_id"].fillna(method="ffill")
+        pfs["tripleg_id"] = pfs["tripleg_id"].ffill()
         # assign back pd.NA to -1
         pfs.loc[pfs["tripleg_id"] == -1, "tripleg_id"] = pd.NA
 

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -362,7 +362,7 @@ def generate_triplegs(
         posfix_grouper = pfs.groupby("tripleg_id")
 
         tpls = posfix_grouper.agg(
-            {"user_id": ["first"], "tracked_at": [min, max], pfs.geometry.name: list}
+            {"user_id": ["first"], "tracked_at": ["min", "max"], pfs.geometry.name: list}
         )  # could add a "number of pfs": can be any column "count"
 
         # prepare dataframe: Rename columns; read/set geometry/crs;

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -86,7 +86,8 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
     # assign an incrementing id to all triplegs that start a trip
     # temporary as empty trips are not filtered out yet.
     sp_tpls.loc[new_trip, "temp_trip_id"] = np.arange(new_trip.sum())
-    sp_tpls["temp_trip_id"].fillna(method="ffill", inplace=True)
+    # fill NA with previous entry
+    sp_tpls["temp_trip_id"].ffill(inplace=True)
 
     # exclude activities to aggregate trips together.
     # activity can be thought of as the same aggregation level as trips.

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -96,7 +96,7 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
 
     trips_grouper = sp_tpls_no_act.groupby("temp_trip_id")
     trips = trips_grouper.agg(
-        {"user_id": "first", "started_at": min, "finished_at": max, "type": list, "sp_tpls_id": list}
+        {"user_id": "first", "started_at": "min", "finished_at": "max", "type": list, "sp_tpls_id": list}
     )
 
     def _seperate_ids(row):


### PR DESCRIPTION
Replace `fillna(method="ffill")` with `.ffill()` and replace built-in functions in `.agg` with strings.