### PR TITLE
CLN: fix deprecation warnings for `.idxmax` and `.loc[]`

### DIFF
--- a/tests/analysis/test_location_identification.py
+++ b/tests/analysis/test_location_identification.py
@@ -307,6 +307,7 @@ class TestOsna_Method:
     def test_default(self, example_osna):
         """Test with no changes to test data."""
         osna = osna_method(example_osna)
+        example_osna["purpose"] = None
         example_osna.loc[example_osna["location_id"] == 0, "purpose"] = "home"
         example_osna.loc[example_osna["location_id"] == 1, "purpose"] = "work"
         assert_geodataframe_equal(example_osna, osna)
@@ -327,6 +328,7 @@ class TestOsna_Method:
         sp = pd.concat((example_osna, sp))
 
         result = osna_method(sp).iloc[:-2]
+        example_osna["purpose"] = None
         example_osna.loc[example_osna["location_id"] == 0, "purpose"] = "home"
         example_osna.loc[example_osna["location_id"] == 1, "purpose"] = "work"
         assert_geodataframe_equal(result, example_osna)
@@ -358,6 +360,7 @@ class TestOsna_Method:
         two_user = pd.concat((example_osna, example_osna))
         two_user.iloc[len(example_osna) :, 0] = 1  # second user gets id 1
         result = osna_method(two_user)
+        two_user["purpose"] = None
         two_user.loc[two_user["location_id"] == 0, "purpose"] = "home"
         two_user.loc[two_user["location_id"] == 1, "purpose"] = "work"
         assert_geodataframe_equal(result, two_user)
@@ -385,6 +388,7 @@ class TestOsna_Method:
         sp = gpd.GeoDataFrame(data=list_dict, geometry="geom", crs="EPSG:4326")
         sp.index.name = "id"
         result = osna_method(sp)
+        sp["purpose"] = None
         sp.loc[sp["location_id"] == 1, "purpose"] = "home"
         sp.loc[sp["location_id"] == 2, "purpose"] = "work"
         assert_geodataframe_equal(sp, result)
@@ -429,7 +433,7 @@ class TestOsna_Method:
         """Test that prior purpose column does not corrupt output."""
         example_osna["purpose"] = np.arange(len(example_osna))
         result = osna_method(example_osna)
-        del example_osna["purpose"]
+        example_osna["purpose"] = None
         example_osna.loc[example_osna["location_id"] == 0, "purpose"] = "home"
         example_osna.loc[example_osna["location_id"] == 1, "purpose"] = "work"
         assert_geodataframe_equal(example_osna, result)

--- a/trackintel/analysis/location_identification.py
+++ b/trackintel/analysis/location_identification.py
@@ -143,7 +143,7 @@ def pre_filter_locations(
         groupby_loc = ["location_id"]
     else:
         raise ValueError(f"Unknown agg_level '{agg_level}' use instead {{'user', 'dataset'}}.")
-    loc = sp.groupby(groupby_loc).agg({"started_at": ["min", "count"], "finished_at": "max", "duration": "sum"})
+    loc = sp.groupby(groupby_loc).agg({"started_at": [min, "count"], "finished_at": max, "duration": sum})
     loc.columns = loc.columns.droplevel(0)  # remove possible multi-index
     loc.rename(columns={"min": "started_at", "max": "finished_at", "sum": "duration"}, inplace=True)
     # period for maximal time span first visit - last visit.
@@ -214,7 +214,7 @@ def _freq_transform(group, *labels):
     pd.Series
         dtype : object
     """
-    group_agg = group.groupby("location_id").agg({"duration": "sum"})
+    group_agg = group.groupby("location_id").agg({"duration": sum})
     group_agg["purpose"] = _freq_assign(group_agg["duration"], *labels)
     group_merge = pd.merge(
         group["location_id"], group_agg["purpose"], how="left", left_on="location_id", right_index=True

--- a/trackintel/analysis/location_identification.py
+++ b/trackintel/analysis/location_identification.py
@@ -303,12 +303,12 @@ def osna_method(staypoints):
     sp_pivot = sp_agg.unstack()
     # get index of maximum for columns "work" and "home"
     # looks over locations to find maximum for columns
-    # use fillna to such that idxmax works on columns with only NaT
+    # use fillna such that idxmax raises no error on columns with only NaT
     sp_idxmax = sp_pivot.fillna(pd.Timedelta(0)).groupby(["user_id"]).idxmax()
 
     # preset dtype to avoid upcast (float64 -> object) in pandas (and the corresponding error)
     sp_pivot["purpose"] = None
-    # assign empty index without any overlap
+    # assign empty index to idx_work/idx_home to have a default behavior for the intersection later
     idx_work = idx_home = sp_pivot.iloc[0:0].index
     if "work" in sp_pivot.columns:
         # first get all index of max entries (of work) that are not NaT

--- a/trackintel/analysis/location_identification.py
+++ b/trackintel/analysis/location_identification.py
@@ -309,7 +309,7 @@ def osna_method(staypoints):
     # preset dtype to avoid upcast (float64 -> object) in pandas (and the corresponding error)
     sp_pivot["purpose"] = None
     # assign empty index to idx_work/idx_home to have a default behavior for the intersection later
-    idx_work = idx_home = sp_pivot.iloc[0:0].index
+    idx_work = idx_home = pd.Index([])
     if "work" in sp_pivot.columns:
         # first get all index of max entries (of work) that are not NaT
         idx_work = sp_pivot.loc[sp_idxmax["work"], "work"].dropna().index

--- a/trackintel/analysis/location_identification.py
+++ b/trackintel/analysis/location_identification.py
@@ -308,26 +308,24 @@ def osna_method(staypoints):
 
     # preset dtype to avoid upcast (float64 -> object) in pandas (and the corresponding error)
     sp_pivot["purpose"] = None
+    # assign empty index without any overlap
+    idx_work = idx_home = sp_pivot.iloc[0:0].index
     if "work" in sp_pivot.columns:
         # first get all index of max entries (of work) that are not NaT
         idx_work = sp_pivot.loc[sp_idxmax["work"], "work"].dropna().index
         # set them to the corresponding purpose (work)
         sp_pivot.loc[idx_work, "purpose"] = "work"
-    else:
-        # assign empty index to see if overlap happened
-        idx_work = sp_pivot.iloc[0:0].index
 
     if "home" in sp_pivot.columns:
         # get all index of max entries (of home) that are not NaT
         idx_home = sp_pivot.loc[sp_idxmax["home"], "home"].dropna().index
         # set them to the corresponding purpose (home overrides work!)
         sp_pivot.loc[idx_home, "purpose"] = "home"
-    else:
-        idx_home = sp_pivot.iloc[0:0].index
 
     # if override happened recalculate work
     overlap = idx_home.intersection(idx_work)
     if not overlap.empty:
+        # remove overlap -> must take another location as everything is NaT on maximum
         sp_pivot.loc[overlap, "work"] = pd.NaT
         sp_idxmax = sp_pivot["work"].fillna(pd.Timedelta(0)).groupby(["user_id"]).idxmax()
         idx_work = sp_pivot.loc[sp_idxmax, "work"].dropna().index


### PR DESCRIPTION
For `idxmax` two things got deprecated.
1. the `axis` keyword, this was an easy fix
2. support of columns with only NaT, we relied on this behavior. Thus I needed to rewrite code to handle this.

Further deprecated is `df.loc[idx, "col"] = "string"`; it creates a new column that defaults to `float64`, that type then gets upcasted to `object` when `"string"` gets filled into the dataframe. To avoid this we have to create the column beforehand with `df["col"] = None`. 