### PR TITLE
TST: remove debug print statements

### DIFF
--- a/tests/io/test_postgis.py
+++ b/tests/io/test_postgis.py
@@ -276,7 +276,6 @@ class TestPositionfixes:
             with pytest.warns(UserWarning):
                 pfs_db = ti.io.read_positionfixes_postgis(sql, conn, geom_col)
             pfs_db = pfs_db.set_index("id")
-            print(pfs_db)
             assert_geodataframe_equal(pfs, pfs_db)
         finally:
             del_table(conn, table)

--- a/tests/model/test_util.py
+++ b/tests/model/test_util.py
@@ -232,8 +232,6 @@ class Test_copy_docstring:
             pass
 
         old_docs = """Old docstring."""
-        print(type(old_docs))
-
         for wa in WRAPPER_ASSIGNMENTS:
             attr_foo = getattr(read_trips_postgis, wa)
             attr_bar = getattr(bar, wa)

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -672,7 +672,6 @@ def _generate_trips_user(df, gap_threshold):
             )
         )
 
-    # print(trip_ls)
     trips = pd.DataFrame(trip_ls)
     return trips
 


### PR DESCRIPTION
Small PR that removes `print` statements that weren't removed after debugging.