### PR TITLE
ENH: clean up __init__ files

### DIFF
--- a/trackintel/__init__.py
+++ b/trackintel/__init__.py
@@ -1,15 +1,3 @@
-import trackintel.model
-import trackintel.analysis
-import trackintel.geogr
-import trackintel.preprocessing
-
-from trackintel.io.file import read_positionfixes_csv
-from trackintel.io.file import read_triplegs_csv
-from trackintel.io.file import read_staypoints_csv
-from trackintel.io.file import read_locations_csv
-from trackintel.io.file import read_trips_csv
-from trackintel.io.file import read_tours_csv
-
 from trackintel.model.positionfixes import Positionfixes
 from trackintel.model.locations import Locations
 from trackintel.model.triplegs import Triplegs
@@ -19,7 +7,34 @@ from trackintel.model.trips import TripsDataFrame
 from trackintel.model.trips import TripsGeoDataFrame
 from trackintel.model.tours import Tours
 
+from trackintel.io.file import read_positionfixes_csv
+from trackintel.io.file import read_triplegs_csv
+from trackintel.io.file import read_staypoints_csv
+from trackintel.io.file import read_locations_csv
+from trackintel.io.file import read_trips_csv
+from trackintel.io.file import read_tours_csv
+
 from trackintel.visualization import plot, plot_modal_split
 
 from trackintel.__version__ import __version__
 from .core import print_version
+
+__all__ = [
+    "Positionfixes",
+    "Locations",
+    "Triplegs",
+    "Staypoints",
+    "Trips",
+    "TripsDataFrame",
+    "TripsGeoDataFrame",
+    "Tours",
+    "read_positionfixes_csv",
+    "read_triplegs_csv",
+    "read_staypoints_csv",
+    "read_locations_csv",
+    "read_trips_csv",
+    "read_tours_csv",
+    "plot",
+    "plot_modal_split",
+    "print_version",
+]

--- a/trackintel/io/__init__.py
+++ b/trackintel/io/__init__.py
@@ -35,4 +35,48 @@ from .postgis import write_tours_postgis
 from .from_geopandas import read_tours_gpd
 
 from .dataset_reader import read_geolife
+from .dataset_reader import read_mzmv
 from .dataset_reader import geolife_add_modes_to_triplegs
+
+__all__ = [
+    # positionfixes
+    "read_positionfixes_csv",
+    "write_positionfixes_csv",
+    "read_positionfixes_postgis",
+    "write_positionfixes_postgis",
+    "read_positionfixes_gpd",
+    # triplegs
+    "read_triplegs_csv",
+    "write_triplegs_csv",
+    "read_triplegs_postgis",
+    "write_triplegs_postgis",
+    "read_triplegs_gpd",
+    # staypoints
+    "read_staypoints_csv",
+    "write_staypoints_csv",
+    "read_staypoints_postgis",
+    "write_staypoints_postgis",
+    "read_staypoints_gpd",
+    # locations
+    "read_locations_csv",
+    "write_locations_csv",
+    "read_locations_postgis",
+    "write_locations_postgis",
+    "read_locations_gpd",
+    # trips
+    "read_trips_csv",
+    "write_trips_csv",
+    "read_trips_postgis",
+    "write_trips_postgis",
+    "read_trips_gpd",
+    # tours
+    "read_tours_csv",
+    "write_tours_csv",
+    "read_tours_postgis",
+    "write_tours_postgis",
+    "read_tours_gpd",
+    # rest
+    "read_geolife",
+    "read_mzmv",
+    "geolife_add_modes_to_triplegs",
+]

--- a/trackintel/model/__init__.py
+++ b/trackintel/model/__init__.py
@@ -1,6 +1,0 @@
-from .positionfixes import Positionfixes
-from .locations import Locations
-from .triplegs import Triplegs
-from .staypoints import Staypoints
-from .trips import Trips
-from .tours import Tours


### PR DESCRIPTION
I wanted to work on #535 but there is an issue with circular imports. This PR is a cleanup step before that, updating `__init__` files with adding new functions, changing orders such that the trackintel classes are the first things that are imported, and deleting imports that I think are not necessary.