### PR TITLE
ENH: remove all potential circular imports from Postfixes

### DIFF
--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -284,11 +284,7 @@ def calculate_haversine_length(gdf):
 
 @doc(
     Positionfixes.get_speed,
-    first_arg="""
-Parameters
-----------
-positionfixes : GeoDataFrame (as trackintel positionfixes)
-""",
+    first_arg="\nParameters\n----------\npositionfixes : GeoDataFrame (as trackintel positionfixes)",
 )
 def get_speed_positionfixes(positionfixes):
     pfs = positionfixes.copy()

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -11,6 +11,9 @@ import similaritymeasures
 from scipy.spatial.distance import cdist
 from sklearn.metrics import pairwise_distances
 
+from trackintel import Positionfixes
+from trackintel.model.util import doc
+
 
 def point_haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_flag=False):
     """
@@ -80,54 +83,8 @@ def point_haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_flag=False
     return r * np.arccos(cos_lat_d - cos_lat1 * cos_lat2 * (1 - cos_lon_d))
 
 
+@doc(Positionfixes.calculate_distance_matrix, first_arg="\nX : GeoDataFrame (as trackintel staypoints or triplegs)\n")
 def calculate_distance_matrix(X, Y=None, dist_metric="haversine", n_jobs=0, **kwds):
-    """
-    Calculate a distance matrix based on a specific distance metric.
-
-    If only X is given, the pair-wise distances between all elements in X are calculated. If X and Y are given, the
-    distances between all combinations of X and Y are calculated. Distances between elements of X and X, and distances
-    between elements of Y and Y are not calculated.
-
-    Parameters
-    ----------
-    X : GeoDataFrame (as trackintel staypoints or triplegs)
-
-    Y : GeoDataFrame (as trackintel staypoints or triplegs), optional
-
-    dist_metric: {'haversine', 'euclidean', 'dtw', 'frechet'}
-        The distance metric to be used for calculating the matrix.
-
-        For staypoints, common choice is 'haversine' or 'euclidean'. This function wraps around
-        the ``pairwise_distance`` function from scikit-learn if only `X` is given and wraps around the
-        ``scipy.spatial.distance.cdist`` function if X and Y are given.
-        Therefore the following metrics are also accepted:
-
-        via ``scikit-learn``: `[‘cityblock’, ‘cosine’, ‘euclidean’, ‘l1’, ‘l2’, ‘manhattan’]`
-
-        via ``scipy.spatial.distance``: `[‘braycurtis’, ‘canberra’, ‘chebyshev’, ‘correlation’, ‘dice’, ‘hamming’, ‘jaccard’,
-        ‘kulsinski’, ‘mahalanobis’, ‘minkowski’, ‘rogerstanimoto’, ‘russellrao’, ‘seuclidean’, ‘sokalmichener’,
-        ‘sokalsneath’, ‘sqeuclidean’, ‘yule’]`
-
-        For triplegs, common choice is 'dtw' or 'frechet'. This function uses the implementation
-        from similaritymeasures.
-
-    n_jobs: int
-        Number of cores to use: 'dtw', 'frechet' and all distance metrics from `pairwise_distance` (only available
-        if only X is given) are parallelized.
-
-    **kwds:
-        optional keywords passed to the distance functions.
-
-    Returns
-    -------
-    D: np.array
-        matrix of shape (len(X), len(X)) or of shape (len(X), len(Y)) if Y is provided.
-
-    Examples
-    --------
-    >>> calculate_distance_matrix(staypoints, dist_metric="haversine")
-    >>> calculate_distance_matrix(triplegs_1, triplegs_2, dist_metric="dtw")
-    """
     geom_type = X.geometry.iat[0].geom_type
     if Y is None:
         Y = X
@@ -325,25 +282,15 @@ def calculate_haversine_length(gdf):
     return np.bincount((index[:-1])[no_mix], weights=dist[no_mix])
 
 
+@doc(
+    Positionfixes.get_speed,
+    first_arg="""
+Parameters
+----------
+positionfixes : GeoDataFrame (as trackintel positionfixes)
+""",
+)
 def get_speed_positionfixes(positionfixes):
-    """
-    Compute speed per positionfix (in m/s)
-
-    Parameters
-    ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
-        The positionfixes have to follow the standard definition for positionfixes DataFrames.
-
-    Returns
-    -------
-    pfs: GeoDataFrame (as trackintel positionfixes)
-        The original positionfixes with a new column ``[`speed`]``. The speed is given in m/s
-
-    Notes
-    -----
-    The speed at one positionfix is computed from the distance and time since the previous positionfix. For the first
-    positionfix, the speed is set to the same value as for the second one.
-    """
     pfs = positionfixes.copy()
     is_planar_crs = check_gdf_planar(pfs)
 

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -13,6 +13,8 @@ from trackintel.io.from_geopandas import (
     read_trips_gpd,
 )
 from trackintel.io.util import _index_warning_default_none
+from trackintel.model.util import doc
+from trackintel import Positionfixes
 
 
 @_index_warning_default_none
@@ -88,36 +90,14 @@ def read_positionfixes_csv(*args, columns=None, tz=None, index_col=None, geom_co
     return read_positionfixes_gpd(df, geom_col=geom_col, crs=crs, tz=tz)
 
 
+@doc(
+    Positionfixes.to_csv,
+    first_arg="""
+positionfixes : GeoDataFrame (as trackintel positionfixes)
+    The positionfixes to store to the CSV file.
+""",
+)
 def write_positionfixes_csv(positionfixes, filename, *args, **kwargs):
-    """
-    Write positionfixes to csv file.
-
-    Wraps the pandas to_csv function, but strips the geometry column and
-    stores the longitude and latitude in respective columns.
-
-    Parameters
-    ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
-        The positionfixes to store to the CSV file.
-
-    filename : str
-        The file to write to.
-
-    args
-        Additional arguments passed to pd.DataFrame.to_csv().
-
-    kwargs
-        Additional keyword arguments passed to pd.DataFrame.to_csv().
-
-    Notes
-    -----
-    "longitude" and "latitude" is extracted from the geometry column and the orignal
-    geometry column is dropped.
-
-    Examples
-    ---------
-    >>> ps.as_positionfixes.to_csv("export_pfs.csv")
-    """
     gdf = positionfixes.copy()
     gdf["longitude"] = positionfixes.geometry.x
     gdf["latitude"] = positionfixes.geometry.y

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -92,10 +92,7 @@ def read_positionfixes_csv(*args, columns=None, tz=None, index_col=None, geom_co
 
 @doc(
     Positionfixes.to_csv,
-    first_arg="""
-positionfixes : GeoDataFrame (as trackintel positionfixes)
-    The positionfixes to store to the CSV file.
-""",
+    first_arg="\npositionfixes : GeoDataFrame (as trackintel positionfixes)\n    The positionfixes to store to the CSV file.",
 )
 def write_positionfixes_csv(positionfixes, filename, *args, **kwargs):
     gdf = positionfixes.copy()

--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -127,7 +127,12 @@ def read_positionfixes_postgis(
     return ti.io.read_positionfixes_gpd(pfs, **(read_gpd_kws or {}))
 
 
-@doc(_shared_docs["write_postgis"], long="positionfixes", short="pfs")
+@doc(
+    _shared_docs["write_postgis"],
+    first_arg="\npositionfixes : GeoDataFrame (as trackintel positionfixes)\n    The positionfixes to store to the database.\n",
+    long="positionfixes",
+    short="pfs",
+)
 @_handle_con_string
 def write_positionfixes_postgis(
     positionfixes, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
@@ -219,7 +224,12 @@ def read_triplegs_postgis(
     return ti.io.read_triplegs_gpd(tpls, **(read_gpd_kws or {}))
 
 
-@doc(_shared_docs["write_postgis"], long="triplegs", short="tpls")
+@doc(
+    _shared_docs["write_postgis"],
+    first_arg="\ntriplegs : GeoDataFrame (as trackintel triplegs)\n    The triplegs to store to the database.\n",
+    long="triplegs",
+    short="tpls",
+)
 @_handle_con_string
 def write_triplegs_postgis(
     triplegs, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
@@ -323,7 +333,12 @@ def read_staypoints_postgis(
     return ti.io.read_staypoints_gpd(sp, **(read_gpd_kws or {}))
 
 
-@doc(_shared_docs["write_postgis"], long="staypoints", short="sp")
+@doc(
+    _shared_docs["write_postgis"],
+    first_arg="\nstaypoints : GeoDataFrame (as trackintel staypoints)\n    The staypoints to store to the database.\n",
+    long="staypoints",
+    short="sp",
+)
 @_handle_con_string
 def write_staypoints_postgis(
     staypoints, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
@@ -433,7 +448,12 @@ def read_locations_postgis(
     return ti.io.read_locations_gpd(locs, center=center, **(read_gpd_kws or {}))
 
 
-@doc(_shared_docs["write_postgis"], long="locations", short="locs")
+@doc(
+    _shared_docs["write_postgis"],
+    first_arg="\nlocations : GeoDataFrame (as trackintel locations)\n    The locations to store to the database.\n",
+    long="locations",
+    short="locs",
+)
 @_handle_con_string
 def write_locations_postgis(
     locations, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
@@ -564,7 +584,12 @@ def read_trips_postgis(
     return ti.io.read_trips_gpd(trips, **(read_gpd_kws or {}))
 
 
-@doc(_shared_docs["write_postgis"], long="trips", short="trips")
+@doc(
+    _shared_docs["write_postgis"],
+    first_arg="\ntrips : GeoDataFrame (as trackintel trips)\n    The trips to store to the database.\n",
+    long="trips",
+    short="trips",
+)
 @_handle_con_string
 def write_trips_postgis(
     trips, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
@@ -690,7 +715,12 @@ def read_tours_postgis(
     return ti.io.read_tours_gpd(tours, **(read_gpd_kws or {}))
 
 
-@doc(_shared_docs["write_postgis"], long="tours", short="tours")
+@doc(
+    _shared_docs["write_postgis"],
+    first_arg="\ntours : GeoDataFrame (as trackintel tours)\n    The tours to store to the database.\n",
+    long="tours",
+    short="tours",
+)
 @_handle_con_string
 def write_tours_postgis(
     tours, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -1,16 +1,19 @@
-import pandas as pd
 import geopandas as gpd
+import pandas as pd
+
 import trackintel as ti
 from trackintel.geogr import calculate_distance_matrix, get_speed_positionfixes
 from trackintel.io.file import write_positionfixes_csv
 from trackintel.io.postgis import write_positionfixes_postgis
-from trackintel.model.util import _copy_docstring
-from trackintel.preprocessing.positionfixes import generate_staypoints, generate_triplegs
 from trackintel.model.util import (
     TrackintelBase,
     TrackintelGeoDataFrame,
+    _copy_docstring,
     _register_trackintel_accessor,
+    _shared_docs,
+    doc,
 )
+from trackintel.preprocessing.positionfixes import generate_staypoints, generate_triplegs
 
 _required_columns = ["user_id", "tracked_at"]
 
@@ -125,15 +128,10 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         """
         ti.io.file.write_positionfixes_csv(self, filename, *args, **kwargs)
 
-    @_copy_docstring(write_positionfixes_postgis)
+    @doc(_shared_docs["write_postgis"], first_arg="", long="positionfixes", short="pfs")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        """
-        Store this collection of positionfixes to PostGIS.
-
-        See :func:`trackintel.io.postgis.write_positionfixes_postgis`.
-        """
         ti.io.postgis.write_positionfixes_postgis(
             self, name, con, schema, if_exists, index, index_label, chunksize, dtype
         )

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -193,7 +193,6 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
             n_jobs=n_jobs,
         )
 
-    # @_copy_docstring(generate_triplegs)
     @doc(first_arg="")
     def generate_triplegs(
         self,
@@ -342,7 +341,6 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         """
         return ti.geogr.distances.calculate_distance_matrix(self, Y=Y, dist_metric=dist_metric, n_jobs=n_jobs, **kwds)
 
-    # @_copy_docstring(get_speed_positionfixes)
     @doc(first_arg="")
     def get_speed(self):
         """

--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -194,10 +194,7 @@ Stores {long} to PostGIS. Usually, this is directly called on a {long}
 DataFrame (see example below).
 
 Parameters
-----------
-{long} : GeoDataFrame (as trackintel {long})
-        The {long} to store to the database.
-
+----------{first_arg}
 name : str
     The name of the table to write to.
 

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -4,13 +4,16 @@ import warnings
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
 from shapely.geometry import LineString
+from tqdm import tqdm
 
+from trackintel import Positionfixes
 from trackintel.geogr import check_gdf_planar, point_haversine_dist
+from trackintel.model.util import doc
 from trackintel.preprocessing.util import _explode_agg, angle_centroid_multipoints, applyParallel
 
 
+@doc(Positionfixes.generate_staypoints, first_arg="\npositionfixes : GeoDataFrame (as trackintel positionfixes)\n")
 def generate_staypoints(
     positionfixes,
     method="sliding",
@@ -23,80 +26,6 @@ def generate_staypoints(
     exclude_duplicate_pfs=True,
     n_jobs=1,
 ):
-    """
-    Generate staypoints from positionfixes.
-
-    Parameters
-    ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
-        The positionfixes have to follow the standard definition for positionfixes DataFrames.
-
-    method : {'sliding'}
-        Method to create staypoints. 'sliding' applies a sliding window over the data.
-
-    distance_metric : {'haversine'}
-        The distance metric used by the applied method.
-
-    dist_threshold : float, default 100
-        The distance threshold for the 'sliding' method, i.e., how far someone has to travel to
-        generate a new staypoint. Units depend on the dist_func parameter. If 'distance_metric' is 'haversine' the
-        unit is in meters
-
-    time_threshold : float, default 5.0 (minutes)
-        The time threshold for the 'sliding' method in minutes.
-
-    gap_threshold : float, default 15.0 (minutes)
-        The time threshold of determine whether a gap exists between consecutive pfs. Consecutive pfs with
-        temporal gaps larger than 'gap_threshold' will be excluded from staypoints generation.
-        Only valid in 'sliding' method.
-
-    include_last: boolean, default False
-        The algorithm in Li et al. (2008) only detects staypoint if the user steps out
-        of that staypoint. This will omit the last staypoint (if any). Set 'include_last'
-        to True to include this last staypoint.
-
-    print_progress: boolean, default False
-        Show per-user progress if set to True.
-
-    exclude_duplicate_pfs: boolean, default True
-        Filters duplicate positionfixes before generating staypoints. Duplicates can lead to problems in later
-        processing steps (e.g., when generating triplegs). It is not recommended to set this to False.
-
-    n_jobs: int, default 1
-        The maximum number of concurrently running jobs. If -1 all CPUs are used. If 1 is given, no parallel
-        computing code is used at all, which is useful for debugging. See
-        https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation
-        for a detailed description
-
-    Returns
-    -------
-    pfs: GeoDataFrame (as trackintel positionfixes)
-        The original positionfixes with a new column ``[`staypoint_id`]``.
-
-    sp: GeoDataFrame (as trackintel staypoints)
-        The generated staypoints.
-
-    Notes
-    -----
-    The 'sliding' method is adapted from Li et al. (2008). In the original algorithm, the 'finished_at'
-    time for the current staypoint lasts until the 'tracked_at' time of the first positionfix outside
-    this staypoint. Users are assumed to be stationary during this missing period and potential tracking
-    gaps may be included in staypoints. To avoid including too large missing signal gaps, set 'gap_threshold'
-    to a small value, e.g., 15 min.
-
-    Examples
-    --------
-    >>> pfs.as_positionfixes.generate_staypoints('sliding', dist_threshold=100)
-
-    References
-    ----------
-    Zheng, Y. (2015). Trajectory data mining: an overview. ACM Transactions on Intelligent Systems
-    and Technology (TIST), 6(3), 29.
-
-    Li, Q., Zheng, Y., Xie, X., Chen, Y., Liu, W., & Ma, W. Y. (2008, November). Mining user
-    similarity based on location history. In Proceedings of the 16th ACM SIGSPATIAL international
-    conference on Advances in geographic information systems (p. 34). ACM.
-    """
     # copy the original pfs for adding 'staypoint_id' column
     pfs = positionfixes.copy()
 
@@ -166,6 +95,13 @@ def generate_staypoints(
     return pfs, sp
 
 
+@doc(
+    Positionfixes.generate_triplegs,
+    first_arg="""
+positionfixes : GeoDataFrame (as trackintel positionfixes)
+    If 'staypoint_id' column is not found, 'staypoints' needs to be provided.
+""",
+)
 def generate_triplegs(
     positionfixes,
     staypoints=None,
@@ -173,54 +109,6 @@ def generate_triplegs(
     gap_threshold=15,
     print_progress=False,
 ):
-    """Generate triplegs from positionfixes.
-
-    Parameters
-    ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
-        The positionfixes have to follow the standard definition for positionfixes DataFrames.
-        If 'staypoint_id' column is not found, 'staypoints' needs to be given.
-
-    staypoints : GeoDataFrame (as trackintel staypoints), optional
-        The staypoints (corresponding to the positionfixes). If this is not passed, the
-        positionfixes need 'staypoint_id' associated with them.
-
-    method: {'between_staypoints'}
-        Method to create triplegs. 'between_staypoints' method defines a tripleg as all positionfixes
-        between two staypoints (no overlap). This method requires either a column 'staypoint_id' on
-        the positionfixes or passing staypoints as an input.
-
-    gap_threshold: float, default 15 (minutes)
-        Maximum allowed temporal gap size in minutes. If tracking data is missing for more than
-        `gap_threshold` minutes, a new tripleg will be generated.
-
-    print_progress: boolean, default False
-        Show the progress bar for assigning staypoints to positionfixes if set to True.
-
-    Returns
-    -------
-    pfs: GeoDataFrame (as trackintel positionfixes)
-        The original positionfixes with a new column ``[`tripleg_id`]``.
-
-    tpls: GeoDataFrame (as trackintel triplegs)
-        The generated triplegs.
-
-    Notes
-    -----
-    Methods 'between_staypoints' requires either a column 'staypoint_id' on the
-    positionfixes or passing some staypoints that correspond to the positionfixes!
-    This means you usually should call ``generate_staypoints()`` first.
-
-    The first positionfix after a staypoint is regarded as the first positionfix of the
-    generated tripleg. The generated tripleg will not have overlapping positionfix with
-    the existing staypoints. This means a small temporal gap in user's trace will occur
-    between the first positionfix of staypoint and the last positionfix of tripleg:
-    pfs_stp_first['tracked_at'] - pfs_tpl_last['tracked_at'].
-
-    Examples
-    --------
-    >>> pfs.as_positionfixes.generate_triplegs('between_staypoints', gap_threshold=15)
-    """
     # copy the original pfs for adding 'tripleg_id' column
     pfs = positionfixes.copy()
 


### PR DESCRIPTION
This PR removes all imports that were necessary to copy docstrings to the Positionfixes class. 
The docstrings are still copied, but now in the other direction. 
On some level, I dislike this change, as it removes documentation from the code that relies on it, thus making the source code harder to read. On the other hand `@doc` enables to omit the first argument for all the class methods.
If you find the loss of readability worse than the `@doc` tricks, I would also be happy to simply duplicate the docstrings and add comments as a reminder that dependent docstrings should be updated accordingly