### PR TITLE
ENH: Remove all potential import circles by copying docstrings

### DIFF
--- a/tests/model/test_util.py
+++ b/tests/model/test_util.py
@@ -1,15 +1,11 @@
-from functools import WRAPPER_ASSIGNMENTS
-
 import pandas as pd
 import pytest
 from geopandas import GeoDataFrame
 from shapely.geometry import Point
 
 import trackintel as ti
-from trackintel.io.postgis import read_trips_postgis
 from trackintel.model.util import (
     NonCachedAccessor,
-    _copy_docstring,
     doc,
     _register_trackintel_accessor,
     _wrapped_gdf_method,
@@ -40,24 +36,6 @@ def example_positionfixes():
     # assert validity of positionfixes.
     pfs.as_positionfixes
     return pfs
-
-
-class Test_copy_docstring:
-    def test_default(self):
-        @_copy_docstring(read_trips_postgis)
-        def bar(b: int) -> int:
-            """Old docstring."""
-            pass
-
-        old_docs = """Old docstring."""
-        for wa in WRAPPER_ASSIGNMENTS:
-            attr_foo = getattr(read_trips_postgis, wa)
-            attr_bar = getattr(bar, wa)
-            if wa == "__doc__":
-                assert attr_foo == attr_bar
-                assert attr_bar != old_docs
-            else:
-                assert attr_foo != attr_bar
 
 
 class Test_wrapped_gdf_method:

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -137,25 +137,6 @@ class TestGenerate_trips:
         assert_geodataframe_equal(sp_expl, sp_acc)
         assert_geodataframe_equal(tpls_acc, tpls_expl)
 
-    def test_accessor_arguments(self, example_triplegs):
-        """Test if the accessor is robust to different ways to receive arguments"""
-        sp, tpls = example_triplegs
-
-        # accessor with only arguments (not allowed)
-        with pytest.raises(AssertionError):
-            _, _, _ = tpls.as_triplegs.generate_trips(sp, 15)
-
-        # accessor with only keywords
-        sp_1, tpls_1, trips_1 = tpls.as_triplegs.generate_trips(staypoints=sp, gap_threshold=15)
-
-        # accessor with mixed arguments/keywords
-        sp_2, tpls_2, trips_2 = tpls.as_triplegs.generate_trips(staypoints=sp, gap_threshold=15)
-
-        # test if generated trips are equal (1,2)
-        assert_geodataframe_equal(sp_1, sp_2)
-        assert_geodataframe_equal(tpls_1, tpls_2)
-        assert_geodataframe_equal(trips_1, trips_2)
-
     def test_generate_trips_missing_link(self, example_triplegs):
         """Test nan is assigned for missing link between sp and trips, and tpls and trips."""
         sp, tpls = example_triplegs

--- a/trackintel/__init__.py
+++ b/trackintel/__init__.py
@@ -16,6 +16,11 @@ from trackintel.io.file import read_tours_csv
 
 from trackintel.visualization import plot, plot_modal_split
 
+# why is this import needed?
+# as trackintel.analysis is never imported somewhere python does not realize that it is a module during the set-up period.
+# with adding it here, we avoid this and make analysis importable.
+import trackintel.analysis
+
 from trackintel.__version__ import __version__
 from .core import print_version
 

--- a/trackintel/analysis/labelling.py
+++ b/trackintel/analysis/labelling.py
@@ -6,16 +6,15 @@ from trackintel.geogr import get_speed_triplegs
 
 
 def create_activity_flag(staypoints, method="time_threshold", time_threshold=15.0, activity_column_name="is_activity"):
+    # if you update this docstring update ti.Staypoints.create_activity_flag as well.
     """
-    Add a flag whether or not a staypoint is considered an activity.
+    Add a flag whether or not a staypoint is considered an activity based on a time threshold.
 
     Parameters
     ----------
     staypoints: GeoDataFrame (as trackintel staypoints)
-        The original input staypoints
 
     method: {'time_threshold'}, default = 'time_threshold'
-
         - 'time_threshold' : All staypoints with a duration greater than the time_threshold are considered an activity.
 
     time_threshold : float, default = 15 (minutes)
@@ -32,7 +31,7 @@ def create_activity_flag(staypoints, method="time_threshold", time_threshold=15.
     Examples
     --------
     >>> sp  = sp.as_staypoints.create_activity_flag(method='time_threshold', time_threshold=15)
-    >>> print(sp['activity'])
+    >>> print(sp['is_activity'])
     """
     if method == "time_threshold":
         staypoints[activity_column_name] = staypoints["finished_at"] - staypoints["started_at"] > datetime.timedelta(
@@ -45,6 +44,7 @@ def create_activity_flag(staypoints, method="time_threshold", time_threshold=15.
 
 
 def predict_transport_mode(triplegs, method="simple-coarse", **kwargs):
+    # if you update this docstring update Triplegs.predict_transport_mode as well
     """
     Predict the transport mode of triplegs.
 
@@ -54,11 +54,9 @@ def predict_transport_mode(triplegs, method="simple-coarse", **kwargs):
     Parameters
     ----------
     triplegs: GeoDataFrame (as trackintel triplegs)
-        The original input triplegs.
 
-    method: {'simple-coarse'}
+    method: {'simple-coarse'}, default 'simple-coarse'
         The following methods are available for transport mode inference/prediction:
-
         - 'simple-coarse' : Uses simple heuristics to predict coarse transport classes.
 
     Returns

--- a/trackintel/analysis/modal_split.py
+++ b/trackintel/analysis/modal_split.py
@@ -4,7 +4,9 @@ from trackintel.geogr.distances import check_gdf_planar, calculate_haversine_len
 
 
 def calculate_modal_split(tpls, freq=None, metric="count", per_user=False, norm=False):
-    """Calculate the modal split of triplegs
+    # if you update this docstring update Triplegs.calculate_modal_split as well.
+    """
+    Calculate the modal split of triplegs
 
     Parameters
     ----------
@@ -32,16 +34,13 @@ def calculate_modal_split(tpls, freq=None, metric="count", per_user=False, norm=
     Notes
     ------
         `freq='W-MON'` is used for a weekly aggregation that starts on mondays.
-
         If `freq=None` and `per_user=False` are passed the modal split collapses to a single column.
-
         The modal split can be visualized using :func:`trackintel.visualization.plot_modal_split`
 
     Examples
     --------
     >>> triplegs.calculate_modal_split()
     >>> tripleg.calculate_modal_split(freq='W-MON', metric='distance')
-
     """
     tpls = tpls.copy()  # copy as we add additional columns on tpls
 

--- a/trackintel/analysis/tracking_quality.py
+++ b/trackintel/analysis/tracking_quality.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 
 def temporal_tracking_quality(source, granularity="all"):
+    # if you update this docstring update all class method that rely on this method as well.
     """
     Calculate per-user temporal tracking quality (temporal coverage).
 
@@ -35,27 +36,22 @@ def temporal_tracking_quality(source, granularity="all"):
     and the columns for the returned ``quality`` df for different ``granularity`` are:
 
     - ``all``:
-
         - time extent: between the latest "finished_at" and the earliest "started_at" for each user.
         - columns: ``['user_id', 'quality']``.
 
     - ``week``:
-
         - time extent: the whole week (604800 sec) for each user.
         - columns: ``['user_id', 'week_monday', 'quality']``.
 
     - ``day``:
-
         - time extent: the whole day (86400 sec) for each user
         - columns: ``['user_id', 'day', 'quality']``
 
     - ``weekday``
-
         - time extent: the whole day (86400 sec) * number of tracked weeks for each user for each user
         - columns: ``['user_id', 'weekday', 'quality']``
 
     - ``hour``:
-
         - time extent: the whole hour (3600 sec) * number of tracked days for each user
         - columns: ``['user_id', 'hour', 'quality']``
 

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -12,7 +12,7 @@ from scipy.spatial.distance import cdist
 from sklearn.metrics import pairwise_distances
 
 from trackintel import Positionfixes
-from trackintel.model.util import doc
+from trackintel.model.util import doc, _shared_docs
 
 
 def point_haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_flag=False):
@@ -83,8 +83,57 @@ def point_haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_flag=False
     return r * np.arccos(cos_lat_d - cos_lat1 * cos_lat2 * (1 - cos_lon_d))
 
 
-@doc(Positionfixes.calculate_distance_matrix, first_arg="\nX : GeoDataFrame (as trackintel staypoints or triplegs)\n")
 def calculate_distance_matrix(X, Y=None, dist_metric="haversine", n_jobs=0, **kwds):
+    # if you update this docstring update all class methods that rely on it as well.
+    """
+    Calculate a distance matrix based on a specific distance metric.
+
+    If only X is given, the pair-wise distances between all elements in X are calculated.
+    If X and Y are given, the distances between all combinations of X and Y are calculated.
+    Distances between elements of X and X, and distances between elements of Y and Y are not calculated.
+
+    Parameters
+    ----------
+    X : GeoDataFrame (as trackintel model)
+
+    Y : GeoDataFrame (as trackintel model), optional
+        Should be of the same type as X
+
+    dist_metric: {{'haversine', 'euclidean', 'dtw', 'frechet'}}, optional
+        The distance metric to be used for calculating the matrix. By default 'haversine.
+
+        For staypoints or positionfixes, a common choice is 'haversine' or 'euclidean'. This function wraps around
+        the ``pairwise_distance`` function from scikit-learn if only `X` is given and wraps around the
+        ``scipy.spatial.distance.cdist`` function if X and Y are given.
+        Therefore the following metrics are also accepted:
+
+        via ``scikit-learn``: `['cityblock', 'cosine', 'euclidean', 'l1', 'l2', 'manhattan']`
+
+        via ``scipy.spatial.distance``: `['braycurtis', 'canberra', 'chebyshev', 'correlation', 'dice', 'hamming', 'jaccard',
+        'kulsinski', 'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean', 'sokalmichener',
+        'sokalsneath', 'sqeuclidean', 'yule']`
+
+        For triplegs, common choice is 'dtw' or 'frechet'. This function uses the implementation
+        from similaritymeasures.
+
+    n_jobs: int, optional
+        Number of cores to use: 'dtw', 'frechet' and all distance metrics from `pairwise_distance` (only available
+        if only X is given) are parallelized. By default 1.
+
+    **kwds:
+        optional keywords passed to the distance functions.
+
+    Returns
+    -------
+    D: np.array
+        matrix of shape (len(X), len(X)) or of shape (len(X), len(Y)) if Y is provided.
+
+    Examples
+    --------
+    >>> calculate_distance_matrix(staypoints, dist_metric="haversine")
+    >>> calculate_distance_matrix(triplegs_1, triplegs_2, dist_metric="dtw")
+    >>> pfs.as_positionfixes.calculate_distance_matrix(dist_metric="haversine")
+    """
     geom_type = X.geometry.iat[0].geom_type
     if Y is None:
         Y = X
@@ -282,11 +331,25 @@ def calculate_haversine_length(gdf):
     return np.bincount((index[:-1])[no_mix], weights=dist[no_mix])
 
 
-@doc(
-    Positionfixes.get_speed,
-    first_arg="\nParameters\n----------\npositionfixes : GeoDataFrame (as trackintel positionfixes)",
-)
 def get_speed_positionfixes(positionfixes):
+    # if you update this docstring update ti.Positionfixes.get_speed as well
+    """
+    Compute speed per positionfix (in m/s)
+
+    Parameters
+    ----------
+    positionfixes : GeoDataFrame (as trackintel positionfixes)
+
+    Returns
+    -------
+    pfs: GeoDataFrame (as trackintel positionfixes)
+        Copy of the original positionfixes with a new column ``[`speed`]``. The speed is given in m/s
+
+    Notes
+    -----
+    The speed at one positionfix is computed from the distance and time since the previous positionfix.
+    For the first positionfix, the speed is set to the same value as for the second one.
+    """
     pfs = positionfixes.copy()
     is_planar_crs = check_gdf_planar(pfs)
 
@@ -309,21 +372,22 @@ def get_speed_positionfixes(positionfixes):
 
 
 def get_speed_triplegs(triplegs, positionfixes=None, method="tpls_speed"):
+    # if you update this docstring update Triplegs.get_speed as well
     """
     Compute the average speed per positionfix for each tripleg (in m/s)
 
     Parameters
     ----------
     triplegs: GeoDataFrame (as trackintel triplegs)
-        The generated triplegs as returned by ti.preprocessing.positionfixes.generate_triplegs
 
-    positionfixes (Optional): GeoDataFrame (as trackintel positionfixes)
-        The positionfixes as returned by ti.preprocessing.positionfixes.generate_triplegs. Only required if the method
-        is 'pfs_mean_speed'. In addition the standard columns it must include the column ``[`tripleg_id`]``.
+    positionfixes: GeoDataFrame (as trackintel positionfixes), optional
+        Only required if the method is 'pfs_mean_speed'.
+        In addition to the standard columns positionfixes must include the column ``[`tripleg_id`]``.
 
-    method: str
-        Method how the speed is computed, one of {tpls_speed, pfs_mean_speed}. The 'tpls_speed' method simply divides
-        the overall tripleg distance by its duration, while the 'pfs_mean_speed' method is the mean pfs speed.
+    method: {'tpls_speed', 'pfs_mean_speed'}, optional
+        Method how of speed calculation, default is "tpls_speed"
+        The 'tpls_speed' method divides the tripleg distance by its duration,
+        the 'pfs_mean_speed' method calculates the speed via the mean speed of the positionfixes of a tripleg.
 
     Returns
     -------

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -13,7 +13,7 @@ from trackintel.io.from_geopandas import (
     read_trips_gpd,
 )
 from trackintel.io.util import _index_warning_default_none
-from trackintel.model.util import doc
+from trackintel.model.util import doc, _shared_docs
 from trackintel import Positionfixes
 
 
@@ -90,11 +90,37 @@ def read_positionfixes_csv(*args, columns=None, tz=None, index_col=None, geom_co
     return read_positionfixes_gpd(df, geom_col=geom_col, crs=crs, tz=tz)
 
 
-@doc(
-    Positionfixes.to_csv,
-    first_arg="\npositionfixes : GeoDataFrame (as trackintel positionfixes)\n    The positionfixes to store to the CSV file.",
-)
 def write_positionfixes_csv(positionfixes, filename, *args, **kwargs):
+    # if you update this docstring update ti.Positionfixes.to_csv as well
+    """
+    Write positionfixes to csv file.
+
+    Wraps the pandas to_csv function, but strips the geometry column and
+    stores the longitude and latitude in respective columns.
+
+    Parameters
+    ----------
+    positionfixes : GeoDataFrame (as trackintel positionfixes)
+
+    filename : str
+        The file to write to.
+
+    args
+        Additional arguments passed to pd.DataFrame.to_csv().
+
+    kwargs
+        Additional keyword arguments passed to pd.DataFrame.to_csv().
+
+    Notes
+    -----
+    "longitude" and "latitude" is extracted from the geometry column and the orignal
+    geometry column is dropped.
+
+    Examples
+    ---------
+    >>> pfs.as_positionfixes.to_csv("export_pfs.csv")
+    >>> ti.io.write_positionfixes_csv(pfs, "export_pfs.csv")
+    """
     gdf = positionfixes.copy()
     gdf["longitude"] = positionfixes.geometry.x
     gdf["latitude"] = positionfixes.geometry.y
@@ -163,31 +189,13 @@ def read_triplegs_csv(*args, columns=None, tz=None, index_col=None, geom_col="ge
     return read_triplegs_gpd(df, geom_col=geom_col, crs=crs, tz=tz, mapper=columns)
 
 
+@doc(
+    _shared_docs["write_csv"],
+    first_arg="\ntriplegs : GeoDataFrame (as trackintel triplegs)\n",
+    long="triplegs",
+    short="tpls",
+)
 def write_triplegs_csv(triplegs, filename, *args, **kwargs):
-    """
-    Write triplegs to csv file.
-
-    Wraps the pandas to_csv function, but transforms the geometry into WKT
-    before writing.
-
-    Parameters
-    ----------
-    triplegs : GeoDataFrame (as trackintel triplegs)
-        The triplegs to store to the CSV file.
-
-    filename : str
-        The file to write to.
-
-    args
-        Additional arguments passed to pd.DataFrame.to_csv().
-
-    kwargs
-        Additional keyword arguments passed to pd.DataFrame.to_csv().
-
-    Examples
-    --------
-    >>> tpls.as_triplegs.to_csv("export_tpls.csv")
-    """
     geo_col_name = triplegs.geometry.name
     df = pd.DataFrame(triplegs, copy=True)
     df[geo_col_name] = triplegs.geometry.apply(wkt.dumps)
@@ -255,31 +263,13 @@ def read_staypoints_csv(*args, columns=None, tz=None, index_col=None, geom_col="
     return read_staypoints_gpd(df, geom_col=geom_col, crs=crs, tz=tz)
 
 
+@doc(
+    _shared_docs["write_csv"],
+    first_arg="\nstaypoints : GeoDataFrame (as trackintel staypoints)\n",
+    long="staypoints",
+    short="sp",
+)
 def write_staypoints_csv(staypoints, filename, *args, **kwargs):
-    """
-    Write staypoints to csv file.
-
-    Wraps the pandas to_csv function, but transforms the geometry into WKT
-    before writing.
-
-    Parameters
-    ----------
-    staypoints : GeoDataFrame (as trackintel staypoints)
-        The staypoints to store to the CSV file.
-
-    filename : str
-        The file to write to.
-
-    args
-        Additional arguments passed to pd.DataFrame.to_csv().
-
-    kwargs
-        Additional keyword arguments passed to pd.DataFrame.to_csv().
-
-    Examples
-    --------
-    >>> tpls.as_triplegs.to_csv("export_tpls.csv")
-    """
     geo_col_name = staypoints.geometry.name
     df = pd.DataFrame(staypoints, copy=True)
     df[geo_col_name] = staypoints.geometry.apply(wkt.dumps)
@@ -341,31 +331,13 @@ def read_locations_csv(*args, columns=None, index_col=None, crs=None, **kwargs):
     return read_locations_gpd(df, crs=crs)
 
 
+@doc(
+    _shared_docs["write_csv"],
+    first_arg="\nlocations : GeoDataFrame (as trackintel locations)\n",
+    long="locations",
+    short="locs",
+)
 def write_locations_csv(locations, filename, *args, **kwargs):
-    """
-    Write locations to csv file.
-
-    Wraps the pandas to_csv function, but transforms the center (and
-    extent) into WKT before writing.
-
-    Parameters
-    ----------
-    locations : GeoDataFrame (as trackintel locations)
-        The locations to store to the CSV file.
-
-    filename : str
-        The file to write to.
-
-    args
-        Additional arguments passed to pd.DataFrame.to_csv().
-
-    kwargs
-        Additional keyword arguments passed to pd.DataFrame.to_csv().
-
-    Examples
-    --------
-    >>> locs.as_locations.to_csv("export_locs.csv")
-    """
     df = pd.DataFrame(locations, copy=True)
     df["center"] = locations["center"].apply(wkt.dumps)
     if "extent" in df.columns:
@@ -447,31 +419,10 @@ def read_trips_csv(*args, columns=None, tz=None, index_col=None, geom_col=None, 
     return read_trips_gpd(trips, geom_col=geom_col, crs=crs, tz=tz)
 
 
+@doc(
+    _shared_docs["write_csv"], first_arg="\ntrips : (Geo)DataFrame (as trackintel trips)\n", long="trips", short="trips"
+)
 def write_trips_csv(trips, filename, *args, **kwargs):
-    """
-    Write trips to csv file.
-
-    Wraps the pandas to_csv function.
-    Geometry get transformed to WKT before writing.
-
-    Parameters
-    ----------
-    trips : (Geo)DataFrame (as trackintel trips)
-        The trips to store to the CSV file.
-
-    filename : str
-        The file to write to.
-
-    args
-        Additional arguments passed to pd.DataFrame.to_csv().
-
-    kwargs
-        Additional keyword arguments passed to pd.DataFrame.to_csv().
-
-    Examples
-    --------
-    >>> trips.as_trips.to_csv("export_trips.csv")
-    """
     df = trips.copy()
     if isinstance(df, GeoDataFrame):
         geom_col_name = df.geometry.name
@@ -526,28 +477,6 @@ def read_tours_csv(*args, columns=None, index_col=None, tz=None, **kwargs):
     return read_tours_gpd(tours, tz=tz)
 
 
+@doc(_shared_docs["write_csv"], first_arg="\ntours : DataFrame (as trackintel tours)\n", long="tours", short="tours")
 def write_tours_csv(tours, filename, *args, **kwargs):
-    """
-    Write tours to csv file.
-
-    Wraps the pandas to_csv function.
-
-    Parameters
-    ----------
-    tours : DataFrame (as trackintel tours)
-        The tours to store to the CSV file.
-
-    filename : str
-        The file to write to.
-
-    args
-        Additional arguments passed to pd.DataFrame.to_csv().
-
-    kwargs
-        Additional keyword arguments passed to pd.DataFrame.to_csv().
-
-    Examples
-    --------
-    >>> tours.as_tours.to_csv("export_tours.csv")
-    """
     pd.DataFrame.to_csv(tours, filename, index=True, *args, **kwargs)

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -1,13 +1,11 @@
 import trackintel as ti
-from trackintel.io.file import write_locations_csv
-from trackintel.io.postgis import write_locations_postgis
 from trackintel.model.util import (
     TrackintelBase,
     TrackintelGeoDataFrame,
-    _copy_docstring,
     _register_trackintel_accessor,
+    _shared_docs,
+    doc,
 )
-from trackintel.preprocessing.filter import spatial_filter
 
 _required_columns = ["user_id", "center"]
 
@@ -68,31 +66,48 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
             return obj.geometry.iloc[0].geom_type == "Point"
         return True
 
-    @_copy_docstring(write_locations_csv)
+    @doc(_shared_docs["write_csv"], first_arg="", long="locations", short="locs")
     def to_csv(self, filename, *args, **kwargs):
-        """
-        Store this collection of locations as a CSV file.
-
-        See :func:`trackintel.io.file.write_locations_csv`.
-        """
         ti.io.file.write_locations_csv(self, filename, *args, **kwargs)
 
-    @_copy_docstring(write_locations_postgis)
+    @doc(_shared_docs["write_postgis"], first_arg="", long="locations", short="locs")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        """
-        Store this collection of locations to PostGIS.
-
-        See :func:`trackintel.io.postgis.write_locations_postgis`.
-        """
         ti.io.postgis.write_locations_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
-    @_copy_docstring(spatial_filter)
-    def spatial_filter(self, *args, **kwargs):
+    def spatial_filter(self, areas, method="within", re_project=False):
+        # if you update this docstring update ti.preprocessing.filter.spatial_filter as well.
         """
-        Filter locations with a geo extent.
+        Filter Locations on a geo extent.
 
-        See :func:`trackintel.preprocessing.filter.spatial_filter`.
+        Parameters
+        ----------
+        areas : GeoDataFrame
+            The areas used to perform the spatial filtering. Note, you can have multiple Polygons
+            and it will return all the features intersect with ANY of those geometries.
+
+        method : {'within', 'intersects', 'crosses'}, optional
+            The method to filter the 'source' GeoDataFrame, by default 'within'
+            - 'within'    : return instances in 'source' where no points of these instances lies in the
+                exterior of the 'areas' and at least one point of the interior of these instances lies
+                in the interior of 'areas'.
+            - 'intersects': return instances in 'source' where the boundary or interior of these instances
+                intersect in any way with those of the 'areas'
+            - 'crosses'   : return instances in 'source' where the interior of these instances intersects
+                the interior of the 'areas' but does not contain it, and the dimension of the intersection
+                is less than the dimension of the one of the 'areas'.
+
+        re_project : bool, default False
+            If this is set to True, the 'source' will be projected to the coordinate reference system of 'areas'
+
+        Returns
+        -------
+        GeoDataFrame (as trackintel locations)
+            GeoDataFrame containing the features after the spatial filtering.
+
+        Examples
+        --------
+        >>> locs.as_locations.spatial_filter(areas, method="within", re_project=False)
         """
-        return ti.preprocessing.filter.spatial_filter(self, *args, **kwargs)
+        return ti.preprocessing.filter.spatial_filter(self, areas, method=method, re_project=re_project)

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -96,7 +96,6 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         lon = self.geometry.x
         return (float(lon.mean()), float(lat.mean()))
 
-    @doc(first_arg="")
     def generate_staypoints(
         self,
         method="sliding",
@@ -109,15 +108,16 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         exclude_duplicate_pfs=True,
         n_jobs=1,
     ):
+        # if you update this docstring update ti.preprocessing.generate_staypoints as well
         """
         Generate staypoints from positionfixes.
 
         Parameters
-        ----------{first_arg}
-        method : {{'sliding'}}
+        ----------
+        method : {'sliding'}
             Method to create staypoints. 'sliding' applies a sliding window over the data.
 
-        distance_metric : {{'haversine'}}
+        distance_metric : {'haversine'}
             The distance metric used by the applied method.
 
         dist_threshold : float, default 100
@@ -193,7 +193,6 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
             n_jobs=n_jobs,
         )
 
-    @doc(first_arg="")
     def generate_triplegs(
         self,
         staypoints=None,
@@ -201,16 +200,17 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         gap_threshold=15,
         print_progress=False,
     ):
+        # if you update this docstring update ti.preprocessing.generate_triplegs as well
         """
         Generate triplegs from positionfixes.
 
         Parameters
-        ----------{first_arg}
+        ----------
         staypoints : GeoDataFrame (as trackintel staypoints), optional
             The staypoints (corresponding to the positionfixes). If this is not passed, the
             positionfixes need 'staypoint_id' associated with them.
 
-        method: {{'between_staypoints'}}
+        method: {'between_staypoints'}
             Method to create triplegs. 'between_staypoints' method defines a tripleg as all positionfixes
             between two staypoints (no overlap). This method requires either a column 'staypoint_id' on
             the positionfixes or passing staypoints as an input.
@@ -254,8 +254,8 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
             print_progress=print_progress,
         )
 
-    @doc(first_arg="")
     def to_csv(self, filename, *args, **kwargs):
+        # if you update this docstring update ti.io.file.write_positionfixex_csv as well
         """
         Write positionfixes to csv file.
 
@@ -263,7 +263,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         stores the longitude and latitude in respective columns.
 
         Parameters
-        ----------{first_arg}
+        ----------
         filename : str
             The file to write to.
 
@@ -280,7 +280,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
 
         Examples
         ---------
-        >>> ps.as_positionfixes.to_csv("export_pfs.csv")
+        >>> pfs.as_positionfixes.to_csv("export_pfs.csv")
         """
         ti.io.file.write_positionfixes_csv(self, filename, *args, **kwargs)
 
@@ -292,23 +292,24 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
             self, name, con, schema, if_exists, index, index_label, chunksize, dtype
         )
 
-    @doc(first_arg="")
     def calculate_distance_matrix(self, Y=None, dist_metric="haversine", n_jobs=0, **kwds):
+        # if you update this docstring update ti.geogr.calculate_distance_matrix as well.
         """
         Calculate a distance matrix based on a specific distance metric.
 
-        If only X is given, the pair-wise distances between all elements in X are calculated. If X and Y are given, the
-        distances between all combinations of X and Y are calculated. Distances between elements of X and X, and distances
-        between elements of Y and Y are not calculated.
+        If no Y is given, the pair-wise distances between all elements in self are calculated.
+        If Y is given, the distances between all combinations of self and Y are calculated.
+        Distances between elements of self and self, and distances between elements of Y and Y are not calculated.
 
         Parameters
-        ----------{first_arg}
-        Y : GeoDataFrame (as trackintel staypoints or triplegs), optional
+        ----------
+        Y : GeoDataFrame (as trackintel positionfixes), optional
+            Should be of the same type as self
 
-        dist_metric: {{'haversine', 'euclidean', 'dtw', 'frechet'}}, optional
+        dist_metric: {'haversine', 'euclidean', 'dtw', 'frechet'}, optional
             The distance metric to be used for calculating the matrix. By default 'haversine.
 
-            For staypoints, common choice is 'haversine' or 'euclidean'. This function wraps around
+            For staypoints or positionfixes, a common choice is 'haversine' or 'euclidean'. This function wraps around
             the ``pairwise_distance`` function from scikit-learn if only `X` is given and wraps around the
             ``scipy.spatial.distance.cdist`` function if X and Y are given.
             Therefore the following metrics are also accepted:
@@ -338,14 +339,15 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         --------
         >>> calculate_distance_matrix(staypoints, dist_metric="haversine")
         >>> calculate_distance_matrix(triplegs_1, triplegs_2, dist_metric="dtw")
+        >>> pfs.as_positionfixes.calculate_distance_matrix(dist_metric="haversine")
         """
         return ti.geogr.distances.calculate_distance_matrix(self, Y=Y, dist_metric=dist_metric, n_jobs=n_jobs, **kwds)
 
-    @doc(first_arg="")
     def get_speed(self):
+        # if you update this docstring update ti.geogr.get_speed_positionfixes as well
         """
         Compute speed per positionfix (in m/s)
-        {first_arg}
+
         Returns
         -------
         pfs: GeoDataFrame (as trackintel positionfixes)

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -1,18 +1,13 @@
 import pandas as pd
 
 import trackintel as ti
-from trackintel.analysis.labelling import create_activity_flag
-from trackintel.analysis.tracking_quality import temporal_tracking_quality
-from trackintel.io.file import write_staypoints_csv
-from trackintel.io.postgis import write_staypoints_postgis
 from trackintel.model.util import (
     TrackintelBase,
     TrackintelGeoDataFrame,
-    _copy_docstring,
     _register_trackintel_accessor,
+    doc,
+    _shared_docs,
 )
-from trackintel.preprocessing.filter import spatial_filter
-from trackintel.preprocessing.staypoints import generate_locations, merge_staypoints
 
 _required_columns = ["user_id", "started_at", "finished_at"]
 
@@ -101,67 +96,259 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
         lon = self.geometry.x
         return (float(lon.mean()), float(lat.mean()))
 
-    @_copy_docstring(generate_locations)
-    def generate_locations(self, *args, **kwargs):
+    def generate_locations(
+        self,
+        method="dbscan",
+        epsilon=100,
+        num_samples=1,
+        distance_metric="haversine",
+        agg_level="user",
+        activities_only=False,
+        print_progress=False,
+        n_jobs=1,
+    ):
+        # if you update this docstring update ti.preprocessing.generate_locations as well
         """
-        Generate locations from this collection of staypoints.
+        Generate locations from the staypoints.
 
-        See :func:`trackintel.preprocessing.staypoints.generate_locations`.
+        Parameters
+        ----------
+        method : {'dbscan'}
+            Method to create locations.
+            - 'dbscan' : Uses the DBSCAN algorithm to cluster staypoints.
+
+        epsilon : float, default 100
+            The epsilon for the 'dbscan' method. if 'distance_metric' is 'haversine'
+            or 'euclidean', the unit is in meters.
+
+        num_samples : int, default 1
+            The minimal number of samples in a cluster.
+
+        distance_metric: {'haversine', 'euclidean'}
+            The distance metric used by the applied method. Any mentioned below are possible:
+            https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html
+
+        agg_level: {'user','dataset'}
+            The level of aggregation when generating locations:
+            - 'user'      : locations are generated independently per-user.
+            - 'dataset'   : shared locations are generated for all users.
+
+        activities_only: bool, default False (requires "activity" column)
+            Flag to set if locations should be generated only from staypoints on which the value for "activity" is True.
+            Useful if activites represent more significant places.
+
+        print_progress : bool, default False
+            If print_progress is True, the progress bar is displayed
+
+        n_jobs: int, default 1
+            The maximum number of concurrently running jobs. If -1 all CPUs are used. If 1 is given, no parallel
+            computing code is used at all, which is useful for debugging. See
+            https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation
+            for a detailed description
+
+        Returns
+        -------
+        sp: GeoDataFrame (as trackintel staypoints)
+            The original staypoints with a new column ``[`location_id`]``.
+
+        locs: GeoDataFrame (as trackintel locations)
+            The generated locations.
+
+        Examples
+        --------
+        >>> sp.as_staypoints.generate_locations(method='dbscan', epsilon=100, num_samples=1)
         """
-        return ti.preprocessing.staypoints.generate_locations(self, *args, **kwargs)
+        return ti.preprocessing.staypoints.generate_locations(
+            self,
+            method=method,
+            epsilon=epsilon,
+            num_samples=num_samples,
+            distance_metric=distance_metric,
+            agg_level=agg_level,
+            activities_only=activities_only,
+            print_progress=print_progress,
+            n_jobs=n_jobs,
+        )
 
-    @_copy_docstring(merge_staypoints)
-    def merge_staypoints(self, *args, **kwargs):
+    def merge_staypoints(self, triplegs, max_time_gap="10min", agg={}):
+        # if you update this docstring update ti.preprocessing.staypoints.merge_staypoints as well
         """
         Aggregate staypoints horizontally via time threshold.
 
-        See :func:`trackintel.preprocessing.staypoints.merge_staypoints`.
-        """
-        return ti.preprocessing.staypoints.merge_staypoints(self, *args, **kwargs)
+        Staypoints must contain a column `location_id` (see `generate_locations` function)
 
-    @_copy_docstring(create_activity_flag)
-    def create_activity_flag(self, *args, **kwargs):
-        """
-        Set a flag if a staypoint is also an activity.
+        Parameters
+        ----------
+        triplegs: GeoDataFrame (as trackintel triplegs)
 
-        See :func:`trackintel.analysis.labelling.create_activity_flag`.
-        """
-        return ti.analysis.labelling.create_activity_flag(self, *args, **kwargs)
+        max_time_gap : str or pd.Timedelta, default "10min"
+            Maximum duration between staypoints to still be merged.
+            If str must be parsable by pd.to_timedelta.
 
-    @_copy_docstring(spatial_filter)
-    def spatial_filter(self, *args, **kwargs):
-        """
-        Filter staypoints with a geo extent.
+        agg: dict, optional
+            Dictionary to aggregate the rows after merging staypoints. This dictionary is used as input to the pandas
+            aggregate function: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.agg.html
+            If empty, only the required columns of staypoints (which are ['user_id', 'started_at', 'finished_at']) are
+            aggregated and returned. In order to return for example also the geometry column of the merged staypoints, set
+            'agg={"geom":"first"}' to return the first geometry of the merged staypoints, or 'agg={"geom":"last"}' to use
+            the last one.
 
-        See :func:`trackintel.preprocessing.filter.spatial_filter`.
-        """
-        return ti.preprocessing.filter.spatial_filter(self, *args, **kwargs)
+        Returns
+        -------
+        sp: DataFrame
+            The new staypoints with the default columns and columns in `agg`, where staypoints at same location and close in
+            time are aggregated.
 
-    @_copy_docstring(write_staypoints_csv)
+        Notes
+        -----
+        - Due to the modification of the staypoint index, the relation between the staypoints and the corresponding
+        positionfixes **is broken** after execution of this function! In explanation, the staypoint_id column of pfs does
+        not necessarily correspond to an id in the new sp table that is returned from this function. The same holds for
+        trips (if generated yet) where the staypoints contained in a trip might be merged in this function.
+        - If there is a tripleg between two staypoints, the staypoints are not merged. If you for some reason want to merge
+        such staypoints, simply pass an empty DataFrame for the tpls argument.
+
+        Examples
+        --------
+        >>> # direct function call
+        >>> ti.preprocessing.staypoints.merge_staypoints(staypoints=sp, triplegs=tpls)
+        >>> # or using the trackintel datamodel
+        >>> sp.as_staypoints.merge_staypoints(triplegs, max_time_gap="1h", agg={"geom":"first"})
+        """
+        return ti.preprocessing.staypoints.merge_staypoints(self, triplegs, max_time_gap=max_time_gap, agg=agg)
+
+    def create_activity_flag(self, method="time_threshold", time_threshold=15.0, activity_column_name="is_activity"):
+        # if you update this docstring update ti.analysis.labelling.create_activity_flag as well.
+        """
+        Add a flag whether or not a staypoint is considered an activity based on a time threshold.
+
+        Parameters
+        ----------
+        staypoints: GeoDataFrame (as trackintel staypoints)
+
+        method: {'time_threshold'}, default = 'time_threshold'
+            - 'time_threshold' : All staypoints with a duration greater than the time_threshold are considered an activity.
+
+        time_threshold : float, default = 15 (minutes)
+            The time threshold for which a staypoint is considered an activity in minutes. Used by method 'time_threshold'
+
+        activity_column_name : str , default = 'is_activity'
+            The name of the newly created column that holds the activity flag.
+
+        Returns
+        -------
+        staypoints : GeoDataFrame (as trackintel staypoints)
+            Original staypoints with the additional activity column
+
+        Examples
+        --------
+        >>> sp  = sp.as_staypoints.create_activity_flag(method='time_threshold', time_threshold=15)
+        >>> print(sp['is_activity'])
+        """
+        return ti.analysis.labelling.create_activity_flag(
+            self, method=method, time_threshold=time_threshold, activity_column_name=activity_column_name
+        )
+
+    def spatial_filter(self, areas, method="within", re_project=False):
+        # if you update this docstring update ti.preprocessing.filter.spatial_filter as well.
+        """
+        Filter Staypoints on a geo extent.
+
+        Parameters
+        ----------
+        areas : GeoDataFrame
+            The areas used to perform the spatial filtering. Note, you can have multiple Polygons
+            and it will return all the features intersect with ANY of those geometries.
+
+        method : {'within', 'intersects', 'crosses'}, optional
+            The method to filter the 'source' GeoDataFrame, by default 'within'
+            - 'within'    : return instances in 'source' where no points of these instances lies in the
+                exterior of the 'areas' and at least one point of the interior of these instances lies
+                in the interior of 'areas'.
+            - 'intersects': return instances in 'source' where the boundary or interior of these instances
+                intersect in any way with those of the 'areas'
+            - 'crosses'   : return instances in 'source' where the interior of these instances intersects
+                the interior of the 'areas' but does not contain it, and the dimension of the intersection
+                is less than the dimension of the one of the 'areas'.
+
+        re_project : bool, default False
+            If this is set to True, the 'source' will be projected to the coordinate reference system of 'areas'
+
+        Returns
+        -------
+        GeoDataFrame (as trackintel staypoints)
+            GeoDataFrame containing the features after the spatial filtering.
+
+        Examples
+        --------
+        >>> sp.as_staypoints.spatial_filter(areas, method="within", re_project=False)
+        """
+        return ti.preprocessing.filter.spatial_filter(self, areas, method=method, re_project=re_project)
+
+    @doc(_shared_docs["write_csv"], first_arg="", long="staypoints", short="sp")
     def to_csv(self, filename, *args, **kwargs):
-        """
-        Store this collection of staypoints as a CSV file.
-
-        See :func:`trackintel.io.file.write_staypoints_csv`.
-        """
         ti.io.file.write_staypoints_csv(self, filename, *args, **kwargs)
 
-    @_copy_docstring(write_staypoints_postgis)
+    @doc(_shared_docs["write_postgis"], first_arg="", long="staypoints", short="sp")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        """
-        Store this collection of staypoints to PostGIS.
-
-        See :func:`trackintel.io.postgis.write_staypoints_postgis`.
-        """
         ti.io.postgis.write_staypoints_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
-    @_copy_docstring(temporal_tracking_quality)
-    def temporal_tracking_quality(self, *args, **kwargs):
+    def temporal_tracking_quality(self, granularity="all"):
+        # if you update this docstring update ti.analysis.tracking_quality as well.
         """
         Calculate per-user temporal tracking quality (temporal coverage).
 
-        See :func:`trackintel.analysis.tracking_quality.temporal_tracking_quality`.
+        Parameters
+        ----------
+        granularity : {"all", "day", "week", "weekday", "hour"}
+            The level of which the tracking quality is calculated. The default "all" returns
+            the overall tracking quality; "day" the tracking quality by days; "week" the quality
+            by weeks; "weekday" the quality by day of the week (e.g, Mondays, Tuesdays, etc.) and
+            "hour" the quality by hours.
+
+        Returns
+        -------
+        quality: DataFrame
+            A per-user per-granularity temporal tracking quality dataframe.
+
+        Notes
+        -----
+        Requires at least the following columns:
+        ``['user_id', 'started_at', 'finished_at']``
+        which means the function supports trackintel ``staypoints``, ``triplegs``, ``trips`` and ``tours``
+        datamodels and their combinations (e.g., staypoints and triplegs sequence).
+
+        The temporal tracking quality is the ratio of tracking time and the total time extent. It is
+        calculated and returned per-user in the defined ``granularity``. The time extents
+        and the columns for the returned ``quality`` df for different ``granularity`` are:
+
+        - ``all``:
+            - time extent: between the latest "finished_at" and the earliest "started_at" for each user.
+            - columns: ``['user_id', 'quality']``.
+
+        - ``week``:
+            - time extent: the whole week (604800 sec) for each user.
+            - columns: ``['user_id', 'week_monday', 'quality']``.
+
+        - ``day``:
+            - time extent: the whole day (86400 sec) for each user
+            - columns: ``['user_id', 'day', 'quality']``
+
+        - ``weekday``
+            - time extent: the whole day (86400 sec) * number of tracked weeks for each user for each user
+            - columns: ``['user_id', 'weekday', 'quality']``
+
+        - ``hour``:
+            - time extent: the whole hour (3600 sec) * number of tracked days for each user
+            - columns: ``['user_id', 'hour', 'quality']``
+
+        Examples
+        --------
+        >>> # calculate overall tracking quality of staypoints
+        >>> temporal_tracking_quality(sp, granularity="all")
+        >>> # calculate per-day tracking quality of sp and tpls sequence
+        >>> temporal_tracking_quality(sp_tpls, granularity="day")
         """
-        return ti.analysis.tracking_quality.temporal_tracking_quality(self, *args, **kwargs)
+        return ti.analysis.tracking_quality.temporal_tracking_quality(self, granularity=granularity)

--- a/trackintel/model/tours.py
+++ b/trackintel/model/tours.py
@@ -1,9 +1,13 @@
 import pandas as pd
 
 import trackintel as ti
-from trackintel.io.file import write_tours_csv
-from trackintel.io.postgis import write_tours_postgis
-from trackintel.model.util import _register_trackintel_accessor, TrackintelBase, TrackintelDataFrame, _copy_docstring
+from trackintel.model.util import (
+    TrackintelBase,
+    TrackintelDataFrame,
+    _register_trackintel_accessor,
+    _shared_docs,
+    doc,
+)
 
 _required_columns = ["user_id", "started_at", "finished_at"]
 
@@ -68,22 +72,12 @@ class Tours(TrackintelBase, TrackintelDataFrame):
             return False
         return True
 
-    @_copy_docstring(write_tours_csv)
+    @doc(_shared_docs["write_csv"], first_arg="", long="tours", short="tours")
     def to_csv(self, filename, *args, **kwargs):
-        """
-        Store this collection of tours as a CSV file.
-
-        See :func:`trackintel.io.file.write_tours_csv`.
-        """
         ti.io.file.write_tours_csv(self, filename, *args, **kwargs)
 
-    @_copy_docstring(write_tours_postgis)
+    @doc(_shared_docs["write_postgis"], first_arg="", long="tours", short="tours")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        """
-        Store this collection of tours to PostGIS.
-
-        See :func:`trackintel.io.postgis.write_tours_postgis`.
-        """
         ti.io.postgis.write_tours_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -1,15 +1,13 @@
 import pandas as pd
 
 import trackintel as ti
-from trackintel.analysis.labelling import predict_transport_mode
-from trackintel.analysis.modal_split import calculate_modal_split
-from trackintel.analysis.tracking_quality import temporal_tracking_quality
-from trackintel.geogr import calculate_distance_matrix, get_speed_triplegs
-from trackintel.io.file import write_triplegs_csv
-from trackintel.io.postgis import write_triplegs_postgis
-from trackintel.model.util import TrackintelBase, TrackintelGeoDataFrame, _copy_docstring, _register_trackintel_accessor
-from trackintel.preprocessing.filter import spatial_filter
-from trackintel.preprocessing.triplegs import generate_trips
+from trackintel.model.util import (
+    TrackintelBase,
+    TrackintelGeoDataFrame,
+    _register_trackintel_accessor,
+    _shared_docs,
+    doc,
+)
 
 _required_columns = ["user_id", "started_at", "finished_at"]
 
@@ -91,94 +89,321 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
             return obj.geometry.is_valid.all() and obj.geometry.iloc[0].geom_type == "LineString"
         return True
 
-    @_copy_docstring(write_triplegs_csv)
+    @doc(_shared_docs["write_csv"], first_arg="", long="triplegs", short="tpls")
     def to_csv(self, filename, *args, **kwargs):
-        """
-        Store this collection of triplegs as a CSV file.
-
-        See :func:`trackintel.io.file.write_triplegs_csv`.
-        """
         ti.io.file.write_triplegs_csv(self, filename, *args, **kwargs)
 
-    @_copy_docstring(write_triplegs_postgis)
+    @doc(_shared_docs["write_postgis"], first_arg="", long="triplegs", short="tpls")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        """
-        Store this collection of triplegs to PostGIS.
-
-        See :func:`trackintel.io.postgis.store_positionfixes_postgis`.
-        """
         ti.io.postgis.write_triplegs_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
-    @_copy_docstring(calculate_distance_matrix)
-    def calculate_distance_matrix(self, *args, **kwargs):
+    def calculate_distance_matrix(self, Y=None, dist_metric="haversine", n_jobs=0, **kwds):
+        # if you update this docstring update ti.geogr.calculate_distance_matrix as well.
         """
-        Calculate pair-wise distance among triplegs or to other triplegs.
+        Calculate a distance matrix based on a specific distance metric.
 
-        See :func:`trackintel.geogr.distances.calculate_distance_matrix`.
+        If no Y is given, the pair-wise distances between all elements in self are calculated.
+        If Y is given, the distances between all combinations of self and Y are calculated.
+        Distances between elements of self and self, and distances between elements of Y and Y are not calculated.
+
+        Parameters
+        ----------
+        Y : GeoDataFrame (as trackintel triplegs), optional
+            Should be of the same type as self
+
+        dist_metric: {'haversine', 'euclidean', 'dtw', 'frechet'}, optional
+            The distance metric to be used for calculating the matrix. By default 'haversine.
+
+            For staypoints or positionfixes, a common choice is 'haversine' or 'euclidean'. This function wraps around
+            the ``pairwise_distance`` function from scikit-learn if only `X` is given and wraps around the
+            ``scipy.spatial.distance.cdist`` function if X and Y are given.
+            Therefore the following metrics are also accepted:
+
+            via ``scikit-learn``: `['cityblock', 'cosine', 'euclidean', 'l1', 'l2', 'manhattan']`
+
+            via ``scipy.spatial.distance``: `['braycurtis', 'canberra', 'chebyshev', 'correlation', 'dice', 'hamming', 'jaccard',
+            'kulsinski', 'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean', 'sokalmichener',
+            'sokalsneath', 'sqeuclidean', 'yule']`
+
+            For triplegs, common choice is 'dtw' or 'frechet'. This function uses the implementation
+            from similaritymeasures.
+
+        n_jobs: int, optional
+            Number of cores to use: 'dtw', 'frechet' and all distance metrics from `pairwise_distance` (only available
+            if only X is given) are parallelized. By default 1.
+
+        **kwds:
+            optional keywords passed to the distance functions.
+
+        Returns
+        -------
+        D: np.array
+            matrix of shape (len(X), len(X)) or of shape (len(X), len(Y)) if Y is provided.
+
+        Examples
+        --------
+        >>> calculate_distance_matrix(staypoints, dist_metric="haversine")
+        >>> calculate_distance_matrix(triplegs_1, triplegs_2, dist_metric="dtw")
+        >>> tpls.as_triplegs.calculate_distance_matrix(dist_metric="haversine")
         """
-        return ti.geogr.calculate_distance_matrix(self, *args, **kwargs)
+        return ti.geogr.calculate_distance_matrix(self, Y=Y, dist_metric=dist_metric, n_jobs=n_jobs, **kwds)
 
-    @_copy_docstring(spatial_filter)
-    def spatial_filter(self, *args, **kwargs):
+    def spatial_filter(self, areas, method="within", re_project=False):
+        # if you update this docstring update ti.preprocessing.filter.spatial_filter as well.
         """
-        Filter triplegs with a geo extent.
+        Filter Triplegs on a geo extent.
 
-        See :func:`trackintel.preprocessing.filter.spatial_filter`.
+        Parameters
+        ----------
+        areas : GeoDataFrame
+            The areas used to perform the spatial filtering. Note, you can have multiple Polygons
+            and it will return all the features intersect with ANY of those geometries.
+
+        method : {'within', 'intersects', 'crosses'}, optional
+            The method to filter the 'source' GeoDataFrame, by default 'within'
+            - 'within' : return instances in 'source' where no points of these instances lies in the
+                exterior of the 'areas' and at least one point of the interior of these instances lies
+                in the interior of 'areas'.
+            - 'intersects': return instances in 'source' where the boundary or interior of these instances
+                intersect in any way with those of the 'areas'
+            - 'crosses' : return instances in 'source' where the interior of these instances intersects
+                the interior of the 'areas' but does not contain it, and the dimension of the intersection
+                is less than the dimension of the one of the 'areas'.
+
+        re_project : bool, default False
+            If this is set to True, the 'source' will be projected to the coordinate reference system of 'areas'
+
+        Returns
+        -------
+        GeoDataFrame (as trackintel triplegs)
+            GeoDataFrame containing the features after the spatial filtering.
+
+        Examples
+        --------
+        >>> tpls.as_triplegs.spatial_filter(areas, method="within", re_project=False)
         """
-        return ti.preprocessing.filter.spatial_filter(self, *args, **kwargs)
+        return ti.preprocessing.filter.spatial_filter(self, areas, method=method, re_project=re_project)
 
-    @_copy_docstring(generate_trips)
-    def generate_trips(self, *args, **kwargs):
+    def generate_trips(self, staypoints, gap_threshold=15, add_geometry=True):
+        # if you update this docstring update ti.preprocessing.generate_triplegs as well
         """
         Generate trips based on staypoints and triplegs.
 
-        See :func:`trackintel.preprocessing.triplegs.generate_trips`.
-        """
-        # if staypoints in kwargs: 'staypoints' can not be in args as it would be the first argument
-        if "staypoints" in kwargs:
-            return ti.preprocessing.triplegs.generate_trips(triplegs=self, **kwargs)
-        # if 'staypoints' no in kwargs it has to be the first argument in 'args'
-        else:
-            assert len(args) <= 1, (
-                "All arguments except 'staypoints' have to be given as keyword arguments. You gave"
-                f" {args[1:]} as positional arguments."
-            )
-            return ti.preprocessing.triplegs.generate_trips(staypoints=args[0], triplegs=self, **kwargs)
+        Parameters
+        ----------
+        staypoints : GeoDataFrame (as trackintel staypoints)
 
-    @_copy_docstring(predict_transport_mode)
-    def predict_transport_mode(self, *args, **kwargs):
-        """
-        Predict/impute the transport mode with which each tripleg was likely covered.
+        gap_threshold : float, default 15 (minutes)
+            Maximum allowed temporal gap size in minutes. If tracking data is missing for more than
+            `gap_threshold` minutes, then a new trip begins after the gap.
 
-        See :func:`trackintel.analysis.labelling.predict_transport_mode`.
-        """
-        return ti.analysis.labelling.predict_transport_mode(self, *args, **kwargs)
+        add_geometry : bool default True
+            If True, the start and end coordinates of each trip are added to the output table in a geometry column "geom"
+            of type MultiPoint. Set `add_geometry=False` for better runtime performance (if coordinates are not required).
 
-    @_copy_docstring(calculate_modal_split)
-    def calculate_modal_split(self, *args, **kwargs):
-        """
-        Calculate the modal split of the triplegs.
+        print_progress : bool, default False
+            If print_progress is True, the progress bar is displayed
 
-        See :func:`trackintel.analysis.modal_split.calculate_modal_split`.
-        """
-        return ti.analysis.modal_split.calculate_modal_split(self, *args, **kwargs)
+        Returns
+        -------
+        sp: GeoDataFrame (as trackintel staypoints)
+            The original staypoints with new columns ``[`trip_id`, `prev_trip_id`, `next_trip_id`]``.
 
-    @_copy_docstring(temporal_tracking_quality)
-    def temporal_tracking_quality(self, *args, **kwargs):
+        tpls: GeoDataFrame (as trackintel triplegs)
+            The original triplegs with a new column ``[`trip_id`]``.
+
+        trips: (Geo)DataFrame (as trackintel trips)
+            The generated trips.
+
+        Notes
+        -----
+        Trips are an aggregation level in transport planning that summarize all movement and all non-essential actions
+        (e.g., waiting) between two relevant activities.
+        The function returns altered versions of the input staypoints and triplegs. Staypoints receive the fields
+        [`trip_id` `prev_trip_id` and `next_trip_id`], triplegs receive the field [`trip_id`].
+        The following assumptions are implemented
+
+            - If we do not record a person for more than `gap_threshold` minutes,
+            we assume that the person performed an activity in the recording gap and split the trip at the gap.
+            - Trips that start/end in a recording gap can have an unknown origin/destination
+            - There are no trips without a (recorded) tripleg
+            - Trips optionally have their start and end point as geometry of type MultiPoint, if `add_geometry==True`
+            - If the origin (or destination) staypoint is unknown, and `add_geometry==True`, the origin (and destination)
+            geometry is set as the first coordinate of the first tripleg (or the last coordinate of the last tripleg),
+            respectively. Trips with missing values can still be identified via col `origin_staypoint_id`.
+
+
+        Examples
+        --------
+        >>> from trackintel.preprocessing.triplegs import generate_trips
+        >>> staypoints, triplegs, trips = generate_trips(staypoints, triplegs)
+
+        trips can also be directly generated using the tripleg accessor
+        >>> staypoints, triplegs, trips = triplegs.as_triplegs.generate_trips(staypoints)
+        """
+        return ti.preprocessing.triplegs.generate_trips(
+            staypoints, self, gap_threshold=gap_threshold, add_geometry=add_geometry
+        )
+
+    def predict_transport_mode(self, method="simple-coarse", **kwargs):
+        # if you update this docstring update ti.analysis.labelling.predict_transport_mode as well
+        """
+        Predict the transport mode of triplegs.
+
+        Predict/impute the transport mode that was likely chosen to cover the given
+        tripleg, e.g., car, bicycle, or walk.
+
+        Parameters
+        ----------
+        method: {'simple-coarse'}, default 'simple-coarse'
+            The following methods are available for transport mode inference/prediction:
+            - 'simple-coarse' : Uses simple heuristics to predict coarse transport classes.
+
+        Returns
+        -------
+        triplegs : GeoDataFrame (as trackintel triplegs)
+            The triplegs with added column mode, containing the predicted transport modes.
+
+        Notes
+        -----
+        ``simple-coarse`` method includes ``{'slow_mobility', 'motorized_mobility', 'fast_mobility'}``.
+        In the default classification, ``slow_mobility`` (<15 km/h) includes transport modes such as
+        walking or cycling, ``motorized_mobility`` (<100 km/h) modes such as car or train, and
+        ``fast_mobility`` (>100 km/h) modes such as high-speed rail or airplanes.
+        These categories are default values and can be overwritten using the keyword argument categories.
+
+        Examples
+        --------
+        >>> tpls  = tpls.as_triplegs.predict_transport_mode()
+        >>> print(tpls["mode"])
+        """
+        return ti.analysis.labelling.predict_transport_mode(self, method=method, **kwargs)
+
+    def calculate_modal_split(self, freq=None, metric="count", per_user=False, norm=False):
+        # if you update this docstring update ti.analysis.modal_split.calculate_modal_split as well.
+        """
+        Calculate the modal split of triplegs.
+
+        Triplegs require column `mode` on which the modal split is calculated.
+
+        Parameters
+        ----------
+        freq : str
+            frequency string passed on as `freq` keyword to the pandas.Grouper class. If `freq=None` the modal split is
+            calculated on all data. A list of possible
+            values can be found `here <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset
+            -aliases>`_.
+        metric : {'count', 'distance', 'duration'}
+            Aggregation used to represent the modal split. 'distance' returns in the same unit as the crs. 'duration'
+            returns values in seconds.
+        per_user : bool, default: False
+            If True the modal split is calculated per user
+        norm : bool, default: False
+            If True every row of the modal split is normalized to 1
+
+        Returns
+        -------
+        modal_split : DataFrame
+            The modal split represented as pandas Dataframe with (optionally) a multi-index. The index can have the
+            levels: `('user_id', 'timestamp')` and every mode as a column.
+
+        Notes
+        ------
+            `freq='W-MON'` is used for a weekly aggregation that starts on mondays.
+
+            If `freq=None` and `per_user=False` are passed the modal split collapses to a single column.
+
+            The modal split can be visualized using :func:`trackintel.visualization.plot_modal_split`
+
+        Examples
+        --------
+        >>> assert "mode" is in triplegs.columns
+        >>> triplegs.calculate_modal_split()
+        >>> triplegs.calculate_modal_split(freq='W-MON', metric='distance')
+        """
+        return ti.analysis.modal_split.calculate_modal_split(
+            self, freq=freq, metric=metric, per_user=per_user, norm=norm
+        )
+
+    def temporal_tracking_quality(self, granularity="all"):
+        # if you update this docstring update ti.analysis.(...).temporal_tracking as well.
         """
         Calculate per-user temporal tracking quality (temporal coverage).
 
-        See :func:`trackintel.analysis.tracking_quality.temporal_tracking_quality`.
-        """
-        return ti.analysis.tracking_quality.temporal_tracking_quality(self, *args, **kwargs)
+        Parameters
+        ----------
+        granularity : {"all", "day", "week", "weekday", "hour"}
+            The level of which the tracking quality is calculated. The default "all" returns
+            the overall tracking quality; "day" the tracking quality by days; "week" the quality
+            by weeks; "weekday" the quality by day of the week (e.g, Mondays, Tuesdays, etc.) and
+            "hour" the quality by hours.
 
-    @_copy_docstring(get_speed_triplegs)
-    def get_speed(self, *args, **kwargs):
-        """
-        Compute the average speed for each tripleg, given by overall distance and duration (in m/s)
+        Returns
+        -------
+        quality: DataFrame
+            A per-user per-granularity temporal tracking quality dataframe.
 
-        See :func:`trackintel.model.util.get_speed_triplegs`.
+        Notes
+        -----
+        Requires at least the following columns:
+        ``['user_id', 'started_at', 'finished_at']``
+        which means the function supports trackintel ``staypoints``, ``triplegs``, ``trips`` and ``tours``
+        datamodels and their combinations (e.g., staypoints and triplegs sequence).
+
+        The temporal tracking quality is the ratio of tracking time and the total time extent. It is
+        calculated and returned per-user in the defined ``granularity``. The time extents
+        and the columns for the returned ``quality`` df for different ``granularity`` are:
+
+        - ``all``:
+            - time extent: between the latest "finished_at" and the earliest "started_at" for each user.
+            - columns: ``['user_id', 'quality']``.
+
+        - ``week``:
+            - time extent: the whole week (604800 sec) for each user.
+            - columns: ``['user_id', 'week_monday', 'quality']``.
+
+        - ``day``:
+            - time extent: the whole day (86400 sec) for each user
+            - columns: ``['user_id', 'day', 'quality']``
+
+        - ``weekday``
+            - time extent: the whole day (86400 sec) * number of tracked weeks for each user for each user
+            - columns: ``['user_id', 'weekday', 'quality']``
+
+        - ``hour``:
+            - time extent: the whole hour (3600 sec) * number of tracked days for each user
+            - columns: ``['user_id', 'hour', 'quality']``
+
+        Examples
+        --------
+        >>> # calculate overall tracking quality of staypoints
+        >>> temporal_tracking_quality(tpls, granularity="all")
+        >>> # calculate per-day tracking quality of sp and tpls sequence
+        >>> temporal_tracking_quality(sp_tpls, granularity="day")
         """
-        return ti.geogr.get_speed_triplegs(self, *args, **kwargs)
+        return ti.analysis.tracking_quality.temporal_tracking_quality(self, granularity=granularity)
+
+    def get_speed(self, positionfixes=None, method="tpls_speed"):
+        # if you update this docstring update ti.geogr.get_speed_triplegs as well
+        """
+        Compute the average speed per positionfix for each tripleg (in m/s)
+
+        Parameters
+        ----------
+        positionfixes: GeoDataFrame (as trackintel positionfixes), optional
+            Only required if the method is 'pfs_mean_speed'.
+            In addition to the standard columns positionfixes must include the column ``[`tripleg_id`]``.
+
+        method: {'tpls_speed', 'pfs_mean_speed'}, optional
+            Method how of speed calculation, default is "tpls_speed"
+            The 'tpls_speed' method divides the tripleg distance by its duration,
+            the 'pfs_mean_speed' method calculates the speed via the mean speed of the positionfixes of a tripleg.
+
+        Returns
+        -------
+        tpls: GeoDataFrame (as trackintel triplegs)
+            The original triplegs with a new column ``[`speed`]``. The speed is given in m/s.
+        """
+        return ti.geogr.get_speed_triplegs(self, positionfixes=positionfixes, method=method)

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -2,15 +2,13 @@ import geopandas as gpd
 import pandas as pd
 
 import trackintel as ti
-from trackintel.analysis.tracking_quality import temporal_tracking_quality
-from trackintel.io.file import write_trips_csv
-from trackintel.io.postgis import write_trips_postgis
 from trackintel.model.util import (
-    _copy_docstring,
-    _register_trackintel_accessor,
     TrackintelBase,
     TrackintelDataFrame,
     TrackintelGeoDataFrame,
+    _register_trackintel_accessor,
+    _shared_docs,
+    doc,
 )
 
 
@@ -121,40 +119,127 @@ class TripsDataFrame(TrackintelBase, TrackintelDataFrame):
             return False
         return True
 
-    @_copy_docstring(write_trips_csv)
+    @doc(_shared_docs["write_csv"], first_arg="", long="trips", short="trips")
     def to_csv(self, filename, *args, **kwargs):
-        """
-        Store this collection of trips as a CSV file.
-
-        See :func:`trackintel.io.file.write_trips_csv`.
-        """
         ti.io.file.write_trips_csv(self, filename, *args, **kwargs)
 
-    @_copy_docstring(write_trips_postgis)
+    @doc(_shared_docs["write_postgis"], first_arg="", long="trips", short="trips")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        """
-        Store this collection of trips to PostGIS.
-
-        See :func:`trackintel.io.postgis.write_trips_postgis`.
-        """
         ti.io.postgis.write_trips_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
-    @_copy_docstring(temporal_tracking_quality)
-    def temporal_tracking_quality(self, *args, **kwargs):
+    def temporal_tracking_quality(self, granularity="all"):
+        # if you update this docstring update ti.analysis.tracking_quality as well.
         """
         Calculate per-user temporal tracking quality (temporal coverage).
 
-        See :func:`trackintel.analysis.tracking_quality.temporal_tracking_quality`.
+        Parameters
+        ----------
+        granularity : {"all", "day", "week", "weekday", "hour"}
+            The level of which the tracking quality is calculated. The default "all" returns
+            the overall tracking quality; "day" the tracking quality by days; "week" the quality
+            by weeks; "weekday" the quality by day of the week (e.g, Mondays, Tuesdays, etc.) and
+            "hour" the quality by hours.
+
+        Returns
+        -------
+        quality: DataFrame
+            A per-user per-granularity temporal tracking quality dataframe.
+
+        Notes
+        -----
+        Requires at least the following columns:
+        ``['user_id', 'started_at', 'finished_at']``
+        which means the function supports trackintel ``staypoints``, ``triplegs``, ``trips`` and ``tours``
+        datamodels and their combinations (e.g., staypoints and triplegs sequence).
+
+        The temporal tracking quality is the ratio of tracking time and the total time extent. It is
+        calculated and returned per-user in the defined ``granularity``. The time extents
+        and the columns for the returned ``quality`` df for different ``granularity`` are:
+
+        - ``all``:
+            - time extent: between the latest "finished_at" and the earliest "started_at" for each user.
+            - columns: ``['user_id', 'quality']``.
+
+        - ``week``:
+            - time extent: the whole week (604800 sec) for each user.
+            - columns: ``['user_id', 'week_monday', 'quality']``.
+
+        - ``day``:
+            - time extent: the whole day (86400 sec) for each user
+            - columns: ``['user_id', 'day', 'quality']``
+
+        - ``weekday``
+            - time extent: the whole day (86400 sec) * number of tracked weeks for each user for each user
+            - columns: ``['user_id', 'weekday', 'quality']``
+
+        - ``hour``:
+            - time extent: the whole hour (3600 sec) * number of tracked days for each user
+            - columns: ``['user_id', 'hour', 'quality']``
+
+        Examples
+        --------
+        >>> # calculate overall tracking quality of staypoints
+        >>> temporal_tracking_quality(sp, granularity="all")
+        >>> # calculate per-day tracking quality of sp and tpls sequence
+        >>> temporal_tracking_quality(sp_tpls, granularity="day")
         """
-        return ti.analysis.tracking_quality.temporal_tracking_quality(self, *args, **kwargs)
+        return ti.analysis.tracking_quality.temporal_tracking_quality(self, granularity=granularity)
 
     def generate_tours(self, **kwargs):
+        # if you update this docstring update ti.preprocessing.generate_tours as well
         """
-        Generate tours based on trips (and optionally staypoint locations).
+        Generate trackintel-tours from trips
 
-        See :func:`trackintel.preprocessing.trips.generate_tours`.
+        Parameters
+        ----------
+        trips : GeoDataFrame (as trackintel trips)
+
+        staypoints : GeoDataFrame (as trackintel staypoints), default None
+            Must have `location_id` column to connect trips via locations to a tour.
+            If None, trips will be connected based only by the set distance threshold `max_dist`.
+
+        max_dist: float, default 100 (meters)
+            Maximum distance between the end point of one trip and the start point of the next trip within a tour.
+            This is parameter is only used if staypoints is `None`!
+            Also, if `max_nr_gaps > 0`, a tour can contain larger spatial gaps (see Notes below for more detail)
+
+        max_time: str or pd.Timedelta, default "1d" (1 day)
+            Maximum time that a tour is allowed to take
+
+        max_nr_gaps: int, default 0
+            Maximum number of spatial gaps on the tour. Use with caution - see notes below.
+
+        print_progress : bool, default False
+            If print_progress is True, the progress bar is displayed
+
+        Returns
+        -------
+        trips_with_tours: GeoDataFrame (as trackintel trips)
+            Same as `trips`, but with column `tour_id`, containing a list of the tours that the trip is part of (see notes).
+
+        tours: GeoDataFrame (as trackintel tours)
+            The generated tours
+
+        Examples
+        --------
+        >>> trips.as_trips.generate_tours(staypoints)
+
+        Notes
+        -------
+        - Tours are defined as a collection of trips in a certain time frame that start and end at the same point
+        - Tours and trips have an N:N relationship: One tour consists of multiple trips, but also one trip can be part of
+        multiple tours, due to nested tours or overlapping tours.
+        - This function implements two possibilities to generate tours of trips: Via the location ID in the `staypoints`
+        df, or via a maximum distance. Thus, note that only one of the parameters `staypoints` or `max_dist` is used!
+        - Nested tours are possible and will be regarded as 2 (or more tours).
+        - It is possible to allow spatial gaps to occur on the tour, which might be useful to deal with missing data.
+        Example: The two trips home-work, supermarket-home would still be detected as a tour when max_nr_gaps >= 1,
+        although the work-supermarket trip is missing.
+        Warning: This only counts the number of gaps, but neither temporal or spatial distance of gaps, nor the number
+        of missing trips in a gap are bounded. Thus, this parameter should be set with caution, because trips that are
+        hours apart might still be connected to a tour if `max_nr_gaps > 0`.
         """
         return ti.preprocessing.trips.generate_tours(trips=self, **kwargs)
 

--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -1,5 +1,5 @@
 import warnings
-from functools import partial, update_wrapper, wraps
+from functools import wraps
 from textwrap import dedent
 
 import pandas as pd
@@ -133,11 +133,6 @@ def _register_trackintel_accessor(name: str):
     return decorator
 
 
-def _copy_docstring(wrapped, assigned=("__doc__",), updated=[]):
-    """Thin wrapper for `functools.update_wrapper` to mimic `functools.wraps` but to only copy the docstring."""
-    return partial(update_wrapper, wrapped=wrapped, assigned=assigned, updated=updated)
-
-
 # doc is derived from pandas.util._decorators (2.1.0)
 # module https://github.com/pandas-dev/pandas/blob/main/LICENSE
 
@@ -228,4 +223,28 @@ Examples
 --------
 >>> {short}.as_{long}.to_postgis(conn_string, table_name)
 >>> ti.io.postgis.write_{long}_postgis({short}, conn_string, table_name)
+"""
+
+_shared_docs[
+    "write_csv"
+] = """
+Write {long} to csv file.
+
+Wraps the pandas to_csv function.
+Geometry get transformed to WKT before writing.
+
+Parameters
+----------{first_arg}
+filename : str
+    The file to write to.
+
+args
+    Additional arguments passed to pd.DataFrame.to_csv().
+
+kwargs
+    Additional keyword arguments passed to pd.DataFrame.to_csv().
+
+Examples
+--------
+>>> {short}.as_{long}.to_csv("export_{long}.csv")
 """

--- a/trackintel/preprocessing/filter.py
+++ b/trackintel/preprocessing/filter.py
@@ -1,26 +1,26 @@
 def spatial_filter(source, areas, method="within", re_project=False):
+    # if you update this docstring update all ti class methods that use this as well
     """
-    Filter staypoints, locations or triplegs with a geo extent.
+    Filter a GeoDataFrame on a geo extent.
 
     Parameters
     ----------
-    source : GeoDataFrame (as trackintel datamodels)
+    source : GeoDataFrame
         The source feature to perform the spatial filtering
 
     areas : GeoDataFrame
         The areas used to perform the spatial filtering. Note, you can have multiple Polygons
         and it will return all the features intersect with ANY of those geometries.
 
-    method : {'within', 'intersects', 'crosses'}
-        The method to filter the 'source' GeoDataFrame
-
-        - 'within'    : return instances in 'source' where no points of these instances lies in the \
-            exterior of the 'areas' and at least one point of the interior of these instances lies \
+    method : {'within', 'intersects', 'crosses'}, optional
+        The method to filter the 'source' GeoDataFrame, by default 'within'
+        - 'within'    : return instances in 'source' where no points of these instances lies in the
+            exterior of the 'areas' and at least one point of the interior of these instances lies
             in the interior of 'areas'.
-        - 'intersects': return instances in 'source' where the boundary or interior of these instances \
+        - 'intersects': return instances in 'source' where the boundary or interior of these instances
             intersect in any way with those of the 'areas'
-        - 'crosses'   : return instances in 'source' where the interior of these instances intersects \
-            the interior of the 'areas' but does not contain it, and the dimension of the intersection \
+        - 'crosses'   : return instances in 'source' where the interior of these instances intersects
+            the interior of the 'areas' but does not contain it, and the dimension of the intersection
             is less than the dimension of the one of the 'areas'.
 
     re_project : bool, default False
@@ -28,7 +28,7 @@ def spatial_filter(source, areas, method="within", re_project=False):
 
     Returns
     -------
-    ret_gdf: GeoDataFrame (as trackintel datamodels)
+    GeoDataFrame
         A new GeoDataFrame containing the features after the spatial filtering.
 
     Examples

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -13,7 +13,6 @@ from trackintel.model.util import doc
 from trackintel.preprocessing.util import _explode_agg, angle_centroid_multipoints, applyParallel
 
 
-@doc(Positionfixes.generate_staypoints, first_arg="\npositionfixes : GeoDataFrame (as trackintel positionfixes)\n")
 def generate_staypoints(
     positionfixes,
     method="sliding",
@@ -26,6 +25,80 @@ def generate_staypoints(
     exclude_duplicate_pfs=True,
     n_jobs=1,
 ):
+    # if you update this docstring update Positionfixes.generate_staypoints as well
+    """
+    Generate staypoints from positionfixes.
+
+    Parameters
+    ----------
+    positionfixes : GeoDataFrame (as trackintel positionfixes)
+
+    method : {'sliding'}
+        Method to create staypoints. 'sliding' applies a sliding window over the data.
+
+    distance_metric : {'haversine'}
+        The distance metric used by the applied method.
+
+    dist_threshold : float, default 100
+        The distance threshold for the 'sliding' method, i.e., how far someone has to travel to
+        generate a new staypoint. Units depend on the dist_func parameter. If 'distance_metric' is 'haversine' the
+        unit is in meters
+
+    time_threshold : float, default 5.0 (minutes)
+        The time threshold for the 'sliding' method in minutes.
+
+    gap_threshold : float, default 15.0 (minutes)
+        The time threshold of determine whether a gap exists between consecutive pfs. Consecutive pfs with
+        temporal gaps larger than 'gap_threshold' will be excluded from staypoints generation.
+        Only valid in 'sliding' method.
+
+    include_last: boolean, default False
+        The algorithm in Li et al. (2008) only detects staypoint if the user steps out
+        of that staypoint. This will omit the last staypoint (if any). Set 'include_last'
+        to True to include this last staypoint.
+
+    print_progress: boolean, default False
+        Show per-user progress if set to True.
+
+    exclude_duplicate_pfs: boolean, default True
+        Filters duplicate positionfixes before generating staypoints. Duplicates can lead to problems in later
+        processing steps (e.g., when generating triplegs). It is not recommended to set this to False.
+
+    n_jobs: int, default 1
+        The maximum number of concurrently running jobs. If -1 all CPUs are used. If 1 is given, no parallel
+        computing code is used at all, which is useful for debugging. See
+        https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation
+        for a detailed description
+
+    Returns
+    -------
+    pfs: GeoDataFrame (as trackintel positionfixes)
+        The original positionfixes with a new column ``[`staypoint_id`]``.
+
+    sp: GeoDataFrame (as trackintel staypoints)
+        The generated staypoints.
+
+    Notes
+    -----
+    The 'sliding' method is adapted from Li et al. (2008). In the original algorithm, the 'finished_at'
+    time for the current staypoint lasts until the 'tracked_at' time of the first positionfix outside
+    this staypoint. Users are assumed to be stationary during this missing period and potential tracking
+    gaps may be included in staypoints. To avoid including too large missing signal gaps, set 'gap_threshold'
+    to a small value, e.g., 15 min.
+
+    Examples
+    --------
+    >>> pfs.as_positionfixes.generate_staypoints('sliding', dist_threshold=100)
+
+    References
+    ----------
+    Zheng, Y. (2015). Trajectory data mining: an overview. ACM Transactions on Intelligent Systems
+    and Technology (TIST), 6(3), 29.
+
+    Li, Q., Zheng, Y., Xie, X., Chen, Y., Liu, W., & Ma, W. Y. (2008, November). Mining user
+    similarity based on location history. In Proceedings of the 16th ACM SIGSPATIAL international
+    conference on Advances in geographic information systems (p. 34). ACM.
+    """
     # copy the original pfs for adding 'staypoint_id' column
     pfs = positionfixes.copy()
 
@@ -95,13 +168,6 @@ def generate_staypoints(
     return pfs, sp
 
 
-@doc(
-    Positionfixes.generate_triplegs,
-    first_arg="""
-positionfixes : GeoDataFrame (as trackintel positionfixes)
-    If 'staypoint_id' column is not found, 'staypoints' needs to be provided.
-""",
-)
 def generate_triplegs(
     positionfixes,
     staypoints=None,
@@ -109,6 +175,55 @@ def generate_triplegs(
     gap_threshold=15,
     print_progress=False,
 ):
+    # if you update this docstring update ti.Positionfixes.generate_triplegs as well
+    """
+    Generate triplegs from positionfixes.
+
+    Parameters
+    ----------
+    positionfixes : GeoDataFrame (as trackintel positionfixes)
+        If 'staypoint_id' column is not found, 'staypoints' needs to be provided.
+
+    staypoints : GeoDataFrame (as trackintel staypoints), optional
+        The staypoints (corresponding to the positionfixes). If this is not passed, the
+        positionfixes need 'staypoint_id' associated with them.
+
+    method: {'between_staypoints'}
+        Method to create triplegs. 'between_staypoints' method defines a tripleg as all positionfixes
+        between two staypoints (no overlap). This method requires either a column 'staypoint_id' on
+        the positionfixes or passing staypoints as an input.
+
+    gap_threshold: float, default 15 (minutes)
+        Maximum allowed temporal gap size in minutes. If tracking data is missing for more than
+        `gap_threshold` minutes, a new tripleg will be generated.
+
+    print_progress: boolean, default False
+        Show the progress bar for assigning staypoints to positionfixes if set to True.
+
+    Returns
+    -------
+    pfs: GeoDataFrame (as trackintel positionfixes)
+        The original positionfixes with a new column ``[`tripleg_id`]``.
+
+    tpls: GeoDataFrame (as trackintel triplegs)
+        The generated triplegs.
+
+    Notes
+    -----
+    Methods 'between_staypoints' requires either a column 'staypoint_id' on the
+    positionfixes or passing some staypoints that correspond to the positionfixes!
+    This means you usually should call ``generate_staypoints()`` first.
+
+    The first positionfix after a staypoint is regarded as the first positionfix of the
+    generated tripleg. The generated tripleg will not have overlapping positionfix with
+    the existing staypoints. This means a small temporal gap in user's trace will occur
+    between the first positionfix of staypoint and the last positionfix of tripleg:
+    pfs_stp_first['tracked_at'] - pfs_tpl_last['tracked_at'].
+
+    Examples
+    --------
+    >>> pfs.as_positionfixes.generate_triplegs('between_staypoints', gap_threshold=15)
+    """
     # copy the original pfs for adding 'tripleg_id' column
     pfs = positionfixes.copy()
 

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -19,17 +19,16 @@ def generate_locations(
     print_progress=False,
     n_jobs=1,
 ):
+    # if you update this docstring update ti.Staypoints.generate_locations as well
     """
     Generate locations from the staypoints.
 
     Parameters
     ----------
     staypoints : GeoDataFrame (as trackintel staypoints)
-        The staypoints have to follow the standard definition for staypoints DataFrames.
 
     method : {'dbscan'}
         Method to create locations.
-
         - 'dbscan' : Uses the DBSCAN algorithm to cluster staypoints.
 
     epsilon : float, default 100
@@ -219,17 +218,16 @@ def _gen_locs_dbscan(sp, distance_metric, db):
 
 
 def merge_staypoints(staypoints, triplegs, max_time_gap="10min", agg={}):
+    # if you update this docstring update ti.Staypoints.merge_staypoints as well
     """
     Aggregate staypoints horizontally via time threshold.
 
     Parameters
     ----------
     staypoints : GeoDataFrame (as trackintel staypoints)
-        The staypoints must contain a column `location_id` (see `generate_locations` function) and have to follow the
-        standard trackintel definition for staypoints DataFrames.
+        The staypoints must contain a column `location_id` (see `generate_locations` function)
 
     triplegs: GeoDataFrame (as trackintel triplegs)
-        The triplegs have to follow the standard definition for triplegs DataFrames.
 
     max_time_gap : str or pd.Timedelta, default "10min"
         Maximum duration between staypoints to still be merged.

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -9,7 +9,9 @@ from trackintel.preprocessing.util import _explode_agg
 
 
 def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
-    """Generate trips based on staypoints and triplegs.
+    # if you update this docstring update Triplegs.generate_triplegs as well
+    """
+    Generate trips based on staypoints and triplegs.
 
     Parameters
     ----------
@@ -64,7 +66,6 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
 
     trips can also be directly generated using the tripleg accessor
     >>> staypoints, triplegs, trips = triplegs.as_triplegs.generate_trips(staypoints)
-
     """
     gap_threshold = pd.to_timedelta(gap_threshold, unit="min")
     sp_tpls = _concat_staypoints_triplegs(staypoints, triplegs, add_geometry)

--- a/trackintel/preprocessing/trips.py
+++ b/trackintel/preprocessing/trips.py
@@ -59,23 +59,22 @@ def generate_tours(
     max_nr_gaps=0,
     print_progress=False,
 ):
+    # if you update this docstring update Trips.generate_tours as well
     """
     Generate trackintel-tours from trips
 
     Parameters
     ----------
     trips : GeoDataFrame (as trackintel trips)
-        The trips have to follow the standard definition for trips DataFrames
 
-    staypoints : GeoDataFrame (as trackintel staypoints, preprocessed to contain location IDs), default None
-        The staypoints have to follow the standard definition for staypoints DataFrames. The location ID column
-        is necessary to connect trips via locations to a tour. If None, trips will be connected based only on a
-        distance threshold `max_dist`.
+    staypoints : GeoDataFrame (as trackintel staypoints), default None
+        Must have `location_id` column to connect trips via locations to a tour.
+        If None, trips will be connected based only by the set distance threshold `max_dist`.
 
     max_dist: float, default 100 (meters)
-        Maximum distance between the end point of one trip and the start point of the next trip on a tour.
-        This is parameter is only used if staypoints is None!
-        Also, if `max_nr_gaps > 0`, a tour can contain larger spatial gaps (see Notes below)
+        Maximum distance between the end point of one trip and the start point of the next trip within a tour.
+        This is parameter is only used if staypoints is `None`!
+        Also, if `max_nr_gaps > 0`, a tour can contain larger spatial gaps (see Notes below for more detail)
 
     max_time: str or pd.Timedelta, default "1d" (1 day)
         Maximum time that a tour is allowed to take
@@ -85,7 +84,6 @@ def generate_tours(
 
     print_progress : bool, default False
         If print_progress is True, the progress bar is displayed
-
 
     Returns
     -------


### PR DESCRIPTION
This PR removes all imports in the class files that will later lead to circular imports.
In #540 I often used the function `@doc` for this, in this PR that isn't the case. 
Why? Because removing the docstring from all functions makes the source code harder to read and the advantages that `@doc` gives can also be done easily with just adjusting the docstrings by hand. Also it was so much easier to do.
So what does this PR include?
- `@doc` usage for simple `to_csv` and `to_postgis` functions/methods. Here the functions are so simple that the docstring is not necessary, plus all classes share the same docstring anyway.
- Copying the docstring for all other methods/functions. Additionally, adding a comment at each docstring as a reminder which other docstrings should also be changed as well.
- Adding argument names instead of `*args, **kwargs`. Argument names are also documentation and should not be avoided.
- Small cleanups where certain things no longer work due to imports/changed argument names.

There is a lot of overlap in the documentation of certain methods, e.g. `spatial_filter`. We can move these documentations into the `TrackintelGeoDataFrame` and thus reduce the number of copies. However, this is not part of this PR, as this PR is already too large.