### PR TITLE
ENH: remove _check to do validation explicitly

### DIFF
--- a/tests/analysis/test_modal_split.py
+++ b/tests/analysis/test_modal_split.py
@@ -131,7 +131,6 @@ class TestModalSplit:
         """check if we can access `calculate_modal_split` via the tripelg accessor"""
 
         tpls = read_geolife_with_modes
-        print(tpls.columns)
         tpls.as_triplegs.calculate_modal_split(metric="count", freq="D")
 
     def test_modal_split_total_count(self, test_triplegs_modal_split):

--- a/tests/analysis/test_modal_split.py
+++ b/tests/analysis/test_modal_split.py
@@ -131,6 +131,7 @@ class TestModalSplit:
         """check if we can access `calculate_modal_split` via the tripelg accessor"""
 
         tpls = read_geolife_with_modes
+        print(tpls.columns)
         tpls.as_triplegs.calculate_modal_split(metric="count", freq="D")
 
     def test_modal_split_total_count(self, test_triplegs_modal_split):

--- a/tests/model/test_locations.py
+++ b/tests/model/test_locations.py
@@ -45,29 +45,3 @@ class TestLocations:
         locs = testdata_locs.as_locations
         assert type(locs) is Locations
         assert id(locs) == id(locs.as_locations)
-
-    def test_check_suceeding(self, testdata_locs):
-        """Test if check returns True on valid pfs"""
-        assert Locations._check(testdata_locs)
-
-    def test_check_missing_columns(self, testdata_locs):
-        """Test if check returns False if column is missing"""
-        assert not Locations._check(testdata_locs.drop(columns="user_id"))
-
-    def test_check_empty_df(self, testdata_locs):
-        """Test if check returns False if DataFrame is empty"""
-        assert not Locations._check(testdata_locs.drop(testdata_locs.index))
-
-    def test_check_false_geometry_type(self, testdata_locs):
-        """Test if check returns False if geometry type is wrong"""
-        testdata_locs["center"] = LineString(
-            [(13.476808430, 48.573711823), (13.506804, 48.939008), (13.4664690, 48.5706414)]
-        )
-        assert not Locations._check(testdata_locs)
-
-    def test_check_ignore_false_geometry_type(self, testdata_locs):
-        """Test if check returns True if geometry type is wrong but validate_geometry is set to False"""
-        testdata_locs["center"] = LineString(
-            [(13.476808430, 48.573711823), (13.506804, 48.939008), (13.4664690, 48.5706414)]
-        )
-        assert Locations._check(testdata_locs, validate_geometry=False)

--- a/tests/model/test_positionfixes.py
+++ b/tests/model/test_positionfixes.py
@@ -56,34 +56,3 @@ class TestPositionfixes:
         accessor_result = pfs.as_positionfixes.calculate_distance_matrix(dist_metric="haversine", n_jobs=1)
         function_result = ti.geogr.distances.calculate_distance_matrix(pfs, dist_metric="haversine", n_jobs=1)
         assert np.allclose(accessor_result, function_result)
-
-    def test_check_suceeding(self, testdata_geolife):
-        """Test if check returns True on valid pfs"""
-        assert Positionfixes._check(testdata_geolife)
-
-    def test_check_missing_columns(self, testdata_geolife):
-        """Test if check returns False if column is missing"""
-        assert not Positionfixes._check(testdata_geolife.drop(columns="user_id"))
-
-    def test_check_empty_df(self, testdata_geolife):
-        """Test if check returns False if DataFrame is empty"""
-        assert not Positionfixes._check(testdata_geolife.drop(testdata_geolife.index))
-
-    def test_check_no_tz(self, testdata_geolife):
-        """Test if check returns False if tracked at column has no tz"""
-        testdata_geolife["tracked_at"] = testdata_geolife["tracked_at"].dt.tz_localize(None)
-        assert not Positionfixes._check(testdata_geolife)
-
-    def test_check_false_geometry_type(self, testdata_geolife):
-        """Test if check returns False if geometry type is wrong"""
-        testdata_geolife["geom"] = LineString(
-            [(13.476808430, 48.573711823), (13.506804, 48.939008), (13.4664690, 48.5706414)]
-        )
-        assert not Positionfixes._check(testdata_geolife)
-
-    def test_check_ignore_false_geometry_type(self, testdata_geolife):
-        """Test if check returns True if geometry type is wrong but validate_geometry is set to False"""
-        testdata_geolife["geom"] = LineString(
-            [(13.476808430, 48.573711823), (13.506804, 48.939008), (13.4664690, 48.5706414)]
-        )
-        assert Positionfixes._check(testdata_geolife, validate_geometry=False)

--- a/tests/model/test_staypoints.py
+++ b/tests/model/test_staypoints.py
@@ -47,34 +47,3 @@ class TestStaypoints:
         """Check if sp has center method and returns (lat, lon) pairs as geometry."""
         sp = testdata_sp.copy()
         assert len(sp.as_staypoints.center) == 2
-
-    def test_check_suceeding(self, testdata_sp):
-        """Test if check returns True on valid sp"""
-        assert Staypoints._check(testdata_sp)
-
-    def test_check_missing_columns(self, testdata_sp):
-        """Test if check returns False if column is missing"""
-        assert not Staypoints._check(testdata_sp.drop(columns="user_id"))
-
-    def test_check_no_tz(self, testdata_sp):
-        """Test if check returns False if datetime columns have no tz"""
-        tmp = testdata_sp["started_at"]
-        testdata_sp["started_at"] = testdata_sp["started_at"].dt.tz_localize(None)
-        assert not Staypoints._check(testdata_sp)
-        testdata_sp["started_at"] = tmp
-        testdata_sp["finished_at"] = testdata_sp["finished_at"].dt.tz_localize(None)
-        assert not Staypoints._check(testdata_sp)
-
-    def test_check_false_geometry_type(self, testdata_sp):
-        """Test if check returns False if geometry type is wrong"""
-        testdata_sp["geom"] = LineString(
-            [(13.476808430, 48.573711823), (13.506804, 48.939008), (13.4664690, 48.5706414)]
-        )
-        assert not Staypoints._check(testdata_sp)
-
-    def test_check_ignore_false_geometry_type(self, testdata_sp):
-        """Test if check returns True if geometry type is wrong but validate_geometry is set to False"""
-        testdata_sp["geom"] = LineString(
-            [(13.476808430, 48.573711823), (13.506804, 48.939008), (13.4664690, 48.5706414)]
-        )
-        assert Staypoints._check(testdata_sp, validate_geometry=False)

--- a/tests/model/test_tours.py
+++ b/tests/model/test_tours.py
@@ -25,20 +25,3 @@ class TestTours:
         tours = test_tours.as_tours
         assert type(tours) is Tours
         assert id(tours) == id(tours.as_tours)
-
-    def test_check_succeeding(self, test_tours):
-        """Test if check returns True on valid tours"""
-        assert Tours._check(test_tours)
-
-    def test_check_missing_columns(self, test_tours):
-        """Test if check returns False if column is missing"""
-        assert not Tours._check(test_tours.drop(columns="user_id"))
-
-    def test_check_no_tz(self, test_tours):
-        """Test if check returns False if datetime columns have no tz"""
-        tmp = test_tours["started_at"]
-        test_tours["started_at"] = test_tours["started_at"].dt.tz_localize(None)
-        assert not Tours._check(test_tours)
-        test_tours["started_at"] = tmp
-        test_tours["finished_at"] = test_tours["finished_at"].dt.tz_localize(None)
-        assert not Tours._check(test_tours)

--- a/tests/model/test_triplegs.py
+++ b/tests/model/test_triplegs.py
@@ -51,34 +51,3 @@ class TestTriplegs:
         tpls = testdata_tpls.as_triplegs
         assert type(tpls) is Triplegs
         assert id(tpls) == id(tpls.as_triplegs)
-
-    def test_check_suceeding(self, testdata_tpls):
-        """Test if check returns True on valid pfs"""
-        assert Triplegs._check(testdata_tpls)
-
-    def test_check_missing_columns(self, testdata_tpls):
-        """Test if check returns False if column is missing"""
-        assert not Triplegs._check(testdata_tpls.drop(columns="user_id"))
-
-    def test_check_empty_df(self, testdata_tpls):
-        """Test if check returns False if DataFrame is empty"""
-        assert not Triplegs._check(testdata_tpls.drop(testdata_tpls.index))
-
-    def test_check_no_tz(self, testdata_tpls):
-        """Test if check returns False if tracked at column has no tz"""
-        tmp = testdata_tpls["started_at"]
-        testdata_tpls["started_at"] = testdata_tpls["started_at"].dt.tz_localize(None)
-        assert not Triplegs._check(testdata_tpls)
-        testdata_tpls["started_at"] = tmp
-        testdata_tpls["finished_at"] = testdata_tpls["finished_at"].dt.tz_localize(None)
-        assert not Triplegs._check(testdata_tpls)
-
-    def test_check_false_geometry_type(self, testdata_tpls):
-        """Test if check returns False if geometry type is wrong"""
-        testdata_tpls["geom"] = Point([(13.476808430, 48.573711823)])
-        assert not Triplegs._check(testdata_tpls)
-
-    def test_check_ignore_false_geometry_type(self, testdata_tpls):
-        """Test if check returns True if geometry type is wrong but validate_geometry is set to False"""
-        testdata_tpls["geom"] = Point([(13.476808430, 48.573711823)])
-        assert Triplegs._check(testdata_tpls, validate_geometry=False)

--- a/tests/model/test_trips.py
+++ b/tests/model/test_trips.py
@@ -46,38 +46,3 @@ class TestTrips:
         # check that it works with other geometry name
         with pytest.raises(ValueError, match="The geometry must be a MultiPoint"):
             trips_other_geom_name.as_trips
-
-
-class TestTripsDataFrame:
-    """Test TripsDataFrame class"""
-
-    def test_check_suceeding(self, testdata_trips):
-        """Test if check returns True on valid trips"""
-        assert TripsDataFrame._check(testdata_trips)
-
-    def test_check_missing_columns(self, testdata_trips):
-        """Test if check returns False if column is missing"""
-        assert not TripsDataFrame._check(testdata_trips.drop(columns="user_id"))
-
-    def test_check_no_tz(self, testdata_trips):
-        """Test if check returns False if datetime columns have no tz"""
-        tmp = testdata_trips["started_at"]
-        testdata_trips["started_at"] = testdata_trips["started_at"].dt.tz_localize(None)
-        assert not TripsDataFrame._check(testdata_trips)
-        testdata_trips["started_at"] = tmp
-        testdata_trips["finished_at"] = testdata_trips["finished_at"].dt.tz_localize(None)
-        assert not TripsDataFrame._check(testdata_trips)
-
-
-class TestTripsGeoDataFrame:
-    """Test TripsGeoDataFrame class"""
-
-    def test_check_false_geometry_type(self, testdata_trips):
-        """Test if check returns False if geometry type is wrong"""
-        testdata_trips["geom"] = Point((13.476808430, 48.573711823))
-        assert not TripsGeoDataFrame._check(testdata_trips)
-
-    def test_check_ignore_false_geometry_type(self, testdata_trips):
-        """Test if check returns True if geometry type is wrong but validate_geometry is set to False"""
-        testdata_trips["geom"] = Point((13.476808430, 48.573711823))
-        assert TripsGeoDataFrame._check(testdata_trips, validate_geometry=False)

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -263,7 +263,7 @@ class TestGenerate_trips:
 
     def test_only_staypoints_in_trip(self):
         """Test that trips with only staypoints (non-activities) are deleted."""
-        start = pd.Timestamp("2021-07-11 8:00:00")
+        start = pd.Timestamp("2021-07-11 8:00:00", tz="utc")
         h = pd.to_timedelta("1h")
         sp_tpls = [
             {"is_activity": True, "type": "staypoint"},
@@ -289,7 +289,7 @@ class TestGenerate_trips:
 
     def test_sp_tpls_index(self):
         """Test if staypoint and tripleg index are identical before and after generating trips."""
-        start = pd.Timestamp("2021-07-11 8:00:00")
+        start = pd.Timestamp("2021-07-11 8:00:00", tz="utc")
         h = pd.to_timedelta("1h")
         sp_tpls = [
             {"is_activity": True, "type": "staypoint"},

--- a/tests/preprocessing/test_triplegs.py
+++ b/tests/preprocessing/test_triplegs.py
@@ -278,8 +278,12 @@ class TestGenerate_trips:
             d["started_at"] = start + n * h
             d["finished_at"] = d["started_at"] + h
         sp_tpls = pd.DataFrame(sp_tpls)
-        sp = sp_tpls[sp_tpls["type"] == "staypoint"]
-        tpls = sp_tpls[sp_tpls["type"] == "tripleg"]
+        sp = sp_tpls[sp_tpls["type"] == "staypoint"].copy()
+        tpls = sp_tpls[sp_tpls["type"] == "tripleg"].copy()
+        sp["geom"] = Point(0, 0)
+        tpls["geom"] = LineString([[1, 1], [2, 2]])
+        sp = gpd.GeoDataFrame(sp, geometry="geom")
+        tpls = gpd.GeoDataFrame(tpls, geometry="geom")
         sp_, tpls_, trips = generate_trips(sp, tpls, add_geometry=False)
         trip_id_truth = pd.Series([None, None, None, 0, None], dtype="Int64")
         trip_id_truth.index = sp_.index  # don't check index
@@ -304,8 +308,12 @@ class TestGenerate_trips:
             d["finished_at"] = d["started_at"] + h
 
         sp_tpls = pd.DataFrame(sp_tpls)
-        sp = sp_tpls[sp_tpls["type"] == "staypoint"]
-        tpls = sp_tpls[sp_tpls["type"] != "staypoint"]
+        sp = sp_tpls[sp_tpls["type"] == "staypoint"].copy()
+        tpls = sp_tpls[sp_tpls["type"] != "staypoint"].copy()
+        sp["geom"] = Point(0, 0)
+        tpls["geom"] = LineString([(0, 0), (1, 1)])
+        sp = gpd.GeoDataFrame(sp, geometry="geom")
+        tpls = gpd.GeoDataFrame(tpls, geometry="geom")
         tpls.index.name = "something_long_and_obscure"
         sp.index.name = "even_obscurer"
         sp_, tpls_, _ = generate_trips(sp, tpls, add_geometry=False)

--- a/tests/preprocessing/test_trips.py
+++ b/tests/preprocessing/test_trips.py
@@ -108,6 +108,10 @@ def example_trip_data():
 
     # assign location IDs (only for testing, not a trackintel staypoints standard!)
     sp_locs = pd.DataFrame({"location_id": [1, 1, 2, 3, 1, 2, 4]}, index=[1, 2, 3, 4, 5, 6, 7])
+    sp_locs["user_id"] = 0
+    sp_locs["started_at"] = sp_locs["finished_at"] = pd.Timestamp("2021-07-11 8:00:00", tz="utc")
+    sp_locs["geom"] = Point(0.0, 0.0)
+    sp_locs = gpd.GeoDataFrame(sp_locs, geometry="geom")
 
     trips = gpd.GeoDataFrame(data=trips_list_dict, geometry="geom", crs="EPSG:4326")
     trips = trips.set_index("id")

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -11,6 +11,8 @@ import similaritymeasures
 from scipy.spatial.distance import cdist
 from sklearn.metrics import pairwise_distances
 
+from trackintel import Positionfixes, Triplegs
+
 
 def point_haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_flag=False):
     """
@@ -388,6 +390,7 @@ def get_speed_triplegs(triplegs, positionfixes=None, method="tpls_speed"):
     tpls: GeoDataFrame (as trackintel triplegs)
         The original triplegs with a new column ``[`speed`]``. The speed is given in m/s.
     """
+    Triplegs.validate(triplegs)
     # Simple method: Divide overall tripleg distance by overall duration
     if method == "tpls_speed":
         if check_gdf_planar(triplegs):

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -32,9 +32,11 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
     >>> df.as_locations.to_csv("filename.csv")
     """
 
-    def __init__(self, *args, validate_geometry=True, **kwargs):
+    def __init__(self, *args, validate=True, validate_geometry=True, **kwargs):
         super().__init__(*args, **kwargs)
-        self.validate(self, validate_geometry=validate_geometry)
+        # disable validation after initial creation -> user is responsible for right shape
+        if validate:
+            self.validate(self, validate_geometry=validate_geometry)
 
     @property
     def as_locations(self):
@@ -54,17 +56,6 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
             # todo: We could think about allowing both geometry types for locations (point and polygon)
             # One for extend and one for the center
             raise ValueError("The center geometry must be a Point (only first checked).")
-
-    @staticmethod
-    def _check(obj, validate_geometry=True):
-        """Check does the same as validate but returns bool instead of potentially raising an error."""
-        if any([c not in obj.columns for c in _required_columns]):
-            return False
-        if obj.shape[0] <= 0:
-            return False
-        if validate_geometry:
-            return obj.geometry.iloc[0].geom_type == "Point"
-        return True
 
     @doc(_shared_docs["write_csv"], first_arg="", long="locations", short="locs")
     def to_csv(self, filename, *args, **kwargs):

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -34,14 +34,14 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
 
     def __init__(self, *args, validate_geometry=True, **kwargs):
         super().__init__(*args, **kwargs)
-        self._validate(self, validate_geometry=validate_geometry)
+        self.validate(self, validate_geometry=validate_geometry)
 
     @property
     def as_locations(self):
         return self
 
     @staticmethod
-    def _validate(obj, validate_geometry):
+    def validate(obj, validate_geometry):
         if any([c not in obj.columns for c in _required_columns]):
             raise AttributeError(
                 "To process a DataFrame as a collection of locations, it must have the properties"
@@ -57,7 +57,7 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
 
     @staticmethod
     def _check(obj, validate_geometry=True):
-        """Check does the same as _validate but returns bool instead of potentially raising an error."""
+        """Check does the same as validate but returns bool instead of potentially raising an error."""
         if any([c not in obj.columns for c in _required_columns]):
             return False
         if obj.shape[0] <= 0:

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -32,18 +32,18 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
     >>> df.as_locations.to_csv("filename.csv")
     """
 
-    def __init__(self, *args, validate=True, validate_geometry=True, **kwargs):
+    def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
         # disable validation after initial creation -> user is responsible for right shape
         if validate:
-            self.validate(self, validate_geometry=validate_geometry)
+            self.validate(self)
 
     @property
     def as_locations(self):
         return self
 
     @staticmethod
-    def validate(obj, validate_geometry):
+    def validate(obj):
         if any([c not in obj.columns for c in _required_columns]):
             raise AttributeError(
                 "To process a DataFrame as a collection of locations, it must have the properties"
@@ -52,7 +52,7 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
         if obj.shape[0] <= 0:
             raise ValueError(f"GeoDataFrame is empty with shape: {obj.shape}")
 
-        if validate_geometry and obj["center"].iloc[0].geom_type != "Point":
+        if obj["center"].iloc[0].geom_type != "Point":
             # todo: We could think about allowing both geometry types for locations (point and polygon)
             # One for extend and one for the center
             raise ValueError("The center geometry must be a Point (only first checked).")

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -34,7 +34,6 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
 
     def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
-        # disable validation after initial creation -> user is responsible for right shape
         if validate:
             self.validate(self)
 

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -46,7 +46,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         # validate kwarg is necessary as the object is not fully initialised if we call it from _constructor
         # (geometry-link is missing). thus we need a way to stop validating too early.
         super().__init__(*args, **kwargs)
-        self._validate(self, validate_geometry=validate_geometry)
+        self.validate(self, validate_geometry=validate_geometry)
 
     # create circular reference directly -> avoid second call of init via accessor
     @property
@@ -54,7 +54,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         return self
 
     @staticmethod
-    def _validate(obj, validate_geometry=True):
+    def validate(obj, validate_geometry=True):
         assert obj.shape[0] > 0, f"Geodataframe is empty with shape: {obj.shape}"
         # check columns
         if any([c not in obj.columns for c in _required_columns]):
@@ -78,7 +78,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
 
     @staticmethod
     def _check(obj, validate_geometry=True):
-        """Check does the same as _validate but returns bool instead of potentially raising an error."""
+        """Check does the same as validate but returns bool instead of potentially raising an error."""
         if any([c not in obj.columns for c in _required_columns]):
             return False
         if obj.shape[0] <= 0:

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -46,7 +46,6 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         # validate kwarg is necessary as the object is not fully initialised if we call it from _constructor
         # (geometry-link is missing). thus we need a way to stop validating too early.
         super().__init__(*args, **kwargs)
-        # disable validation after initial creation -> user is responsible for right shape
         if validate:
             self.validate(self)
 

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -41,14 +41,14 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
     >>> df.as_positionfixes.generate_staypoints()
     """
 
-    def __init__(self, *args, validate=True, validate_geometry=True, **kwargs):
+    def __init__(self, *args, validate=True, **kwargs):
         # could be moved to super class
         # validate kwarg is necessary as the object is not fully initialised if we call it from _constructor
         # (geometry-link is missing). thus we need a way to stop validating too early.
         super().__init__(*args, **kwargs)
         # disable validation after initial creation -> user is responsible for right shape
         if validate:
-            self.validate(self, validate_geometry=validate_geometry)
+            self.validate(self)
 
     # create circular reference directly -> avoid second call of init via accessor
     @property
@@ -56,7 +56,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         return self
 
     @staticmethod
-    def validate(obj, validate_geometry=True):
+    def validate(obj):
         assert obj.shape[0] > 0, f"Geodataframe is empty with shape: {obj.shape}"
         # check columns
         if any([c not in obj.columns for c in _required_columns]):
@@ -70,13 +70,12 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         ), f"dtype of tracked_at is {obj['tracked_at'].dtype} but has to be datetime64 and timezone aware"
 
         # check geometry
-        if validate_geometry:
-            assert (
-                obj.geometry.is_valid.all()
-            ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
+        assert (
+            obj.geometry.is_valid.all()
+        ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
 
-            if obj.geometry.iloc[0].geom_type != "Point":
-                raise AttributeError("The geometry must be a Point (only first checked).")
+        if obj.geometry.iloc[0].geom_type != "Point":
+            raise AttributeError("The geometry must be a Point (only first checked).")
 
     @property
     def center(self):

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -45,7 +45,6 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
 
     def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
-        # disable validation after initial creation -> user is responsible for right shape
         if validate:
             self.validate(self)
 

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -43,9 +43,11 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
     >>> df.as_staypoints.generate_locations()
     """
 
-    def __init__(self, *args, validate_geometry=True, **kwargs):
+    def __init__(self, *args, validate=True, validate_geometry=True, **kwargs):
         super().__init__(*args, **kwargs)
-        self.validate(self, validate_geometry=validate_geometry)
+        # disable validation after initial creation -> user is responsible for right shape
+        if validate:
+            self.validate(self, validate_geometry=validate_geometry)
 
     # create circular reference directly -> avoid second call of init via accessor
     @property
@@ -75,19 +77,6 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
             ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
             if obj.geometry.iloc[0].geom_type != "Point":
                 raise AttributeError("The geometry must be a Point (only first checked).")
-
-    @staticmethod
-    def _check(obj, validate_geometry=True):
-        """Check does the same as validate but returns bool instead of potentially raising an error."""
-        if any([c not in obj.columns for c in _required_columns]):
-            return False
-        if not isinstance(obj["started_at"].dtype, pd.DatetimeTZDtype):
-            return False
-        if not isinstance(obj["finished_at"].dtype, pd.DatetimeTZDtype):
-            return False
-        if validate_geometry:
-            return obj.geometry.is_valid.all() and obj.geometry.iloc[0].geom_type == "Point"
-        return True
 
     @property
     def center(self):

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -45,7 +45,7 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
 
     def __init__(self, *args, validate_geometry=True, **kwargs):
         super().__init__(*args, **kwargs)
-        self._validate(self, validate_geometry=validate_geometry)
+        self.validate(self, validate_geometry=validate_geometry)
 
     # create circular reference directly -> avoid second call of init via accessor
     @property
@@ -53,7 +53,7 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
         return self
 
     @staticmethod
-    def _validate(obj, validate_geometry=True):
+    def validate(obj, validate_geometry=True):
         # check columns
         if any([c not in obj.columns for c in _required_columns]):
             raise AttributeError(
@@ -78,7 +78,7 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
 
     @staticmethod
     def _check(obj, validate_geometry=True):
-        """Check does the same as _validate but returns bool instead of potentially raising an error."""
+        """Check does the same as validate but returns bool instead of potentially raising an error."""
         if any([c not in obj.columns for c in _required_columns]):
             return False
         if not isinstance(obj["started_at"].dtype, pd.DatetimeTZDtype):

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -43,11 +43,11 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
     >>> df.as_staypoints.generate_locations()
     """
 
-    def __init__(self, *args, validate=True, validate_geometry=True, **kwargs):
+    def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
         # disable validation after initial creation -> user is responsible for right shape
         if validate:
-            self.validate(self, validate_geometry=validate_geometry)
+            self.validate(self)
 
     # create circular reference directly -> avoid second call of init via accessor
     @property
@@ -55,7 +55,7 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
         return self
 
     @staticmethod
-    def validate(obj, validate_geometry=True):
+    def validate(obj):
         # check columns
         if any([c not in obj.columns for c in _required_columns]):
             raise AttributeError(
@@ -70,13 +70,12 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
             obj["finished_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be tz aware datetime64"
 
-        if validate_geometry:
-            # check geometry
-            assert (
-                obj.geometry.is_valid.all()
-            ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
-            if obj.geometry.iloc[0].geom_type != "Point":
-                raise AttributeError("The geometry must be a Point (only first checked).")
+        # check geometry
+        assert (
+            obj.geometry.is_valid.all()
+        ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
+        if obj.geometry.iloc[0].geom_type != "Point":
+            raise AttributeError("The geometry must be a Point (only first checked).")
 
     @property
     def center(self):

--- a/trackintel/model/tours.py
+++ b/trackintel/model/tours.py
@@ -36,9 +36,11 @@ class Tours(TrackintelBase, TrackintelDataFrame):
     >>> df.as_tours.to_csv("filename.csv")
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
-        self.validate(self)
+        # disable validation after initial creation -> user is responsible for right shape
+        if validate:
+            self.validate(self)
 
     # createte circular reference directly -> avoid second call of init via accessor
     @property
@@ -60,17 +62,6 @@ class Tours(TrackintelBase, TrackintelDataFrame):
         assert isinstance(
             obj["finished_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be datetime64 and timezone aware"
-
-    @staticmethod
-    def _check(obj):
-        """Check does the same as validate but returns bool instead of potentially raising an error."""
-        if any([c not in obj.columns for c in _required_columns]):
-            return False
-        if not isinstance(obj["started_at"].dtype, pd.DatetimeTZDtype):
-            return False
-        if not isinstance(obj["finished_at"].dtype, pd.DatetimeTZDtype):
-            return False
-        return True
 
     @doc(_shared_docs["write_csv"], first_arg="", long="tours", short="tours")
     def to_csv(self, filename, *args, **kwargs):

--- a/trackintel/model/tours.py
+++ b/trackintel/model/tours.py
@@ -38,7 +38,7 @@ class Tours(TrackintelBase, TrackintelDataFrame):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._validate(self)
+        self.validate(self)
 
     # createte circular reference directly -> avoid second call of init via accessor
     @property
@@ -46,7 +46,7 @@ class Tours(TrackintelBase, TrackintelDataFrame):
         return self
 
     @staticmethod
-    def _validate(obj):
+    def validate(obj):
         if any([c not in obj.columns for c in _required_columns]):
             raise AttributeError(
                 "To process a DataFrame as a collection of tours, it must have the properties"
@@ -63,7 +63,7 @@ class Tours(TrackintelBase, TrackintelDataFrame):
 
     @staticmethod
     def _check(obj):
-        """Check does the same as _validate but returns bool instead of potentially raising an error."""
+        """Check does the same as validate but returns bool instead of potentially raising an error."""
         if any([c not in obj.columns for c in _required_columns]):
             return False
         if not isinstance(obj["started_at"].dtype, pd.DatetimeTZDtype):

--- a/trackintel/model/tours.py
+++ b/trackintel/model/tours.py
@@ -38,7 +38,6 @@ class Tours(TrackintelBase, TrackintelDataFrame):
 
     def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
-        # disable validation after initial creation -> user is responsible for right shape
         if validate:
             self.validate(self)
 

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -41,7 +41,6 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
 
     def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
-        # disable validation after initial creation -> user is responsible for right shape
         if validate:
             self.validate(self)
 

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -54,7 +54,6 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
     def validate(obj, validate_geometry=True):
         assert obj.shape[0] > 0, f"Geodataframe is empty with shape: {obj.shape}"
         # check columns
-        print(obj.columns)
         if any([c not in obj.columns for c in _required_columns]):
             raise AttributeError(
                 "To process a DataFrame as a collection of triplegs, it must have the properties"

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -41,7 +41,7 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
 
     def __init__(self, *args, validate_geometry=True, **kwargs):
         super().__init__(*args, **kwargs)
-        self._validate(self, validate_geometry=validate_geometry)
+        self.validate(self, validate_geometry=validate_geometry)
 
     # create circular reference directly -> avoid second call of init via accessor
     @property
@@ -49,7 +49,7 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
         return self
 
     @staticmethod
-    def _validate(obj, validate_geometry=True):
+    def validate(obj, validate_geometry=True):
         assert obj.shape[0] > 0, f"Geodataframe is empty with shape: {obj.shape}"
         # check columns
         if any([c not in obj.columns for c in _required_columns]):
@@ -76,7 +76,7 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
 
     @staticmethod
     def _check(obj, validate_geometry=True):
-        """Check does the same as _validate but returns bool instead of potentially raising an error."""
+        """Check does the same as validate but returns bool instead of potentially raising an error."""
         if any([c not in obj.columns for c in _required_columns]):
             return False
         if obj.shape[0] <= 0:

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -39,11 +39,11 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
     >>> df.as_triplegs.generate_trips()
     """
 
-    def __init__(self, *args, validate=True, validate_geometry=True, **kwargs):
+    def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
         # disable validation after initial creation -> user is responsible for right shape
         if validate:
-            self.validate(self, validate_geometry=validate_geometry)
+            self.validate(self)
 
     # create circular reference directly -> avoid second call of init via accessor
     @property
@@ -51,7 +51,7 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
         return self
 
     @staticmethod
-    def validate(obj, validate_geometry=True):
+    def validate(obj):
         assert obj.shape[0] > 0, f"Geodataframe is empty with shape: {obj.shape}"
         # check columns
         if any([c not in obj.columns for c in _required_columns]):
@@ -69,12 +69,11 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
         ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be datetime64 and timezone aware"
 
         # check geometry
-        if validate_geometry:
-            assert (
-                obj.geometry.is_valid.all()
-            ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
-            if obj.geometry.iloc[0].geom_type != "LineString":
-                raise AttributeError("The geometry must be a LineString (only first checked).")
+        assert (
+            obj.geometry.is_valid.all()
+        ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
+        if obj.geometry.iloc[0].geom_type != "LineString":
+            raise AttributeError("The geometry must be a LineString (only first checked).")
 
     @doc(_shared_docs["write_csv"], first_arg="", long="triplegs", short="tpls")
     def to_csv(self, filename, *args, **kwargs):

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -89,9 +89,11 @@ class TripsDataFrame(TrackintelBase, TrackintelDataFrame):
     >>> df.as_trips.generate_tours()
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
-        TripsDataFrame.validate(self)  # static call
+        # disable validation after initial creation -> user is responsible for right shape
+        if validate:
+            TripsDataFrame.validate(self)  # static call
 
     @staticmethod
     def validate(obj):
@@ -108,16 +110,6 @@ class TripsDataFrame(TrackintelBase, TrackintelDataFrame):
         assert isinstance(
             obj["finished_at"].dtype, pd.DatetimeTZDtype
         ), f"dtype of finished_at is {obj['finished_at'].dtype} but has to be datetime64 and timezone aware"
-
-    @staticmethod
-    def _check(obj):
-        if any([c not in obj.columns for c in _required_columns]):
-            return False
-        if not isinstance(obj["started_at"].dtype, pd.DatetimeTZDtype):
-            return False
-        if not isinstance(obj["finished_at"].dtype, pd.DatetimeTZDtype):
-            return False
-        return True
 
     @doc(_shared_docs["write_csv"], first_arg="", long="trips", short="trips")
     def to_csv(self, filename, *args, **kwargs):
@@ -180,9 +172,11 @@ class TripsGeoDataFrame(TrackintelGeoDataFrame, TripsDataFrame, gpd.GeoDataFrame
 
     fallback_class = TripsDataFrame
 
-    def __init__(self, *args, validate_geometry=True, **kwargs):
+    def __init__(self, *args, validate=True, validate_geometry=True, **kwargs):
         super().__init__(*args, **kwargs)
-        TripsGeoDataFrame.validate(self, validate_geometry=validate_geometry)
+        # disable validation after initial creation -> user is responsible for right shape
+        if validate:
+            TripsGeoDataFrame.validate(self, validate_geometry=validate_geometry)
 
     @staticmethod
     def validate(self, validate_geometry=True):
@@ -194,10 +188,3 @@ class TripsGeoDataFrame(TrackintelGeoDataFrame, TripsDataFrame, gpd.GeoDataFrame
         ), "Not all geometries are valid. Try x[~x.geometry.is_valid] where x is you GeoDataFrame"
         if self.geometry.iloc[0].geom_type != "MultiPoint":
             raise ValueError("The geometry must be a MultiPoint (only first checked).")
-
-    @staticmethod
-    def _check(self, validate_geometry=True):
-        val = TripsDataFrame._check(self)
-        if not validate_geometry:
-            return val
-        return val and self.geometry.is_valid.all() and self.geometry.iloc[0].geom_type == "MultiPoint"

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -91,7 +91,6 @@ class TripsDataFrame(TrackintelBase, TrackintelDataFrame):
 
     def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
-        # disable validation after initial creation -> user is responsible for right shape
         if validate:
             TripsDataFrame.validate(self)  # static call
 
@@ -174,7 +173,6 @@ class TripsGeoDataFrame(TrackintelGeoDataFrame, TripsDataFrame, gpd.GeoDataFrame
 
     def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
-        # disable validation after initial creation -> user is responsible for right shape
         if validate:
             TripsGeoDataFrame.validate(self)
 

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -91,10 +91,10 @@ class TripsDataFrame(TrackintelBase, TrackintelDataFrame):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        TripsDataFrame._validate(self)  # static call
+        TripsDataFrame.validate(self)  # static call
 
     @staticmethod
-    def _validate(obj):
+    def validate(obj):
         if any([c not in obj.columns for c in _required_columns]):
             raise AttributeError(
                 "To process a DataFrame as a collection of trips, it must have the properties"
@@ -182,14 +182,13 @@ class TripsGeoDataFrame(TrackintelGeoDataFrame, TripsDataFrame, gpd.GeoDataFrame
 
     def __init__(self, *args, validate_geometry=True, **kwargs):
         super().__init__(*args, **kwargs)
-        TripsGeoDataFrame._validate(self, validate_geometry=validate_geometry)
+        TripsGeoDataFrame.validate(self, validate_geometry=validate_geometry)
 
     @staticmethod
-    def _validate(self, validate_geometry=True):
+    def validate(self, validate_geometry=True):
+        TripsDataFrame.validate(self)
         if not validate_geometry:
             return
-        # _validate should not be called from the outside -> we can use fact that it is called only from __init__
-        # therefore TrackintelDataFrame validated all the columns and here we only have to validate the geometry
         assert (
             self.geometry.is_valid.all()
         ), "Not all geometries are valid. Try x[~x.geometry.is_valid] where x is you GeoDataFrame"

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -172,17 +172,15 @@ class TripsGeoDataFrame(TrackintelGeoDataFrame, TripsDataFrame, gpd.GeoDataFrame
 
     fallback_class = TripsDataFrame
 
-    def __init__(self, *args, validate=True, validate_geometry=True, **kwargs):
+    def __init__(self, *args, validate=True, **kwargs):
         super().__init__(*args, **kwargs)
         # disable validation after initial creation -> user is responsible for right shape
         if validate:
-            TripsGeoDataFrame.validate(self, validate_geometry=validate_geometry)
+            TripsGeoDataFrame.validate(self)
 
     @staticmethod
-    def validate(self, validate_geometry=True):
+    def validate(self):
         TripsDataFrame.validate(self)
-        if not validate_geometry:
-            return
         assert (
             self.geometry.is_valid.all()
         ), "Not all geometries are valid. Try x[~x.geometry.is_valid] where x is you GeoDataFrame"

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -7,6 +7,7 @@ import pandas as pd
 from shapely.geometry import LineString
 from tqdm import tqdm
 
+from trackintel import Positionfixes, Staypoints
 from trackintel.geogr import check_gdf_planar, point_haversine_dist
 from trackintel.preprocessing.util import _explode_agg, angle_centroid_multipoints, applyParallel
 
@@ -96,6 +97,7 @@ def generate_staypoints(
     similarity based on location history. In Proceedings of the 16th ACM SIGSPATIAL international
     conference on Advances in geographic information systems (p. 34). ACM.
     """
+    Positionfixes.validate(positionfixes)
     # copy the original pfs for adding 'staypoint_id' column
     pfs = positionfixes.copy()
 
@@ -220,6 +222,9 @@ def generate_triplegs(
     --------
     >>> pfs.as_positionfixes.generate_triplegs('between_staypoints', gap_threshold=15)
     """
+    Positionfixes.validate(positionfixes)
+    if staypoints is not None:
+        Staypoints.validate(staypoints)
     # copy the original pfs for adding 'tripleg_id' column
     pfs = positionfixes.copy()
 

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -4,6 +4,7 @@ import pandas as pd
 from sklearn.cluster import DBSCAN
 import warnings
 
+from trackintel import Staypoints
 from trackintel.geogr.distances import meters_to_decimal_degrees, check_gdf_planar
 from trackintel.preprocessing.util import applyParallel, angle_centroid_multipoints
 
@@ -71,6 +72,7 @@ def generate_locations(
     --------
     >>> sp.as_staypoints.generate_locations(method='dbscan', epsilon=100, num_samples=1)
     """
+    Staypoints.validate(staypoints)
     if agg_level not in ["user", "dataset"]:
         raise AttributeError(f"agg_level '{agg_level}' is unknown. Supported values are ['user', 'dataset'].")
     if method not in ["dbscan"]:

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -67,8 +67,8 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
     trips can also be directly generated using the tripleg accessor
     >>> staypoints, triplegs, trips = triplegs.as_triplegs.generate_trips(staypoints)
     """
-    Triplegs.validate(triplegs, validate_geometry=add_geometry)
-    Staypoints.validate(staypoints, validate_geometry=add_geometry)
+    Triplegs.validate(triplegs)
+    Staypoints.validate(staypoints)
     gap_threshold = pd.to_timedelta(gap_threshold, unit="min")
     sp_tpls = _concat_staypoints_triplegs(staypoints, triplegs, add_geometry)
 

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 from shapely.geometry import MultiPoint, Point
 
+from trackintel import Staypoints, Triplegs
 from trackintel.preprocessing.util import _explode_agg
 
 
@@ -66,6 +67,8 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
     trips can also be directly generated using the tripleg accessor
     >>> staypoints, triplegs, trips = triplegs.as_triplegs.generate_trips(staypoints)
     """
+    Triplegs.validate(triplegs, validate_geometry=add_geometry)
+    Staypoints.validate(staypoints, validate_geometry=add_geometry)
     gap_threshold = pd.to_timedelta(gap_threshold, unit="min")
     sp_tpls = _concat_staypoints_triplegs(staypoints, triplegs, add_geometry)
 

--- a/trackintel/preprocessing/trips.py
+++ b/trackintel/preprocessing/trips.py
@@ -119,12 +119,14 @@ def generate_tours(
         ), "Staypoints with location ID is required, otherwise tours are generated without location using max_dist"
         geom_col = None  # not used
         crs_is_projected = False  # not used
+        ti.Staypoints.validate(staypoints)
     else:
         # if no location is given, we need the trips table to have a geometry column
         assert isinstance(trips, gpd.geodataframe.GeoDataFrame), "Trips table must be a GeoDataFrame"
         geom_col = trips.geometry.name
         # get crs
         crs_is_projected = ti.geogr.check_gdf_planar(trips)
+        ti.TripsGeoDataFrame.validate(trips)
 
     # convert max_time to timedelta
     if isinstance(max_time, str):


### PR DESCRIPTION
Closes #534  
See there for motivation.
To allow constructions of trackintel class instances that do not follow the model, the additional keyword `validate` has been introduced for all class constructors.
To avoid the wrong data shape, `validate` is now public, when called it throws an exception if the data is not in the correct shape. 
