### PR TITLE
ENH: replace all `as_xyz` with method calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,14 +69,6 @@ All trackintel objects have an ID that is the index of the dataframe [Issue 97](
 See [issue 117](https://github.com/mie-lab/trackintel/issues/117)
 - All docstrings follow the [numpy format](https://numpydoc.readthedocs.io/en/latest/format.html).
 - The example section is mandatory.
-- Naming of trackintel data types in the docstring:
-  - Positionfixes: `GeoDataFrame (as trackintel positionfixes)`  
-  - Staypoints: `GeoDataFrame (as trackintel staypoints)`
-  - Triplegs: `GeoDataFrame (as trackintel triplegs)`
-  - Locations: `GeoDataFrame (as trackintel locations)`  
-  - Trips: `(Geo)DataFrame (as trackintel trips)`
-  - Tours: `DataFrame (as trackintel tours)` 
-
 
 ### Performance benchmarking
 - We use [airspeed velocity](https://asv.readthedocs.io/en/stable/) to benchmark key trackintel functions. 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ pfs, _ = ti.io.dataset_reader.read_geolife(".\tests\data\geolife_long")
 **[2.]** Data model generation. 
 ```python
 # generate staypoints and triplegs
-pfs, sp = pfs.as_positionfixes.generate_staypoints(method='sliding')
-pfs, tpls = pfs.as_positionfixes.generate_triplegs(sp, method='between_staypoints')
+pfs, sp = pfs.generate_staypoints(method='sliding')
+pfs, tpls = pfs.generate_triplegs(sp, method='between_staypoints')
 ```
 
 **[3.]** Visualization.
@@ -79,7 +79,7 @@ ti.plot(positionfixes=pfs, staypoints=sp, triplegs=tpls, radius_sp=10)
 **[4.]** Analysis.
  ```python
 # e.g., predict travel mode labels based on travel speed
-tpls = tpls.as_triplegs.predict_transport_mode()
+tpls = tpls.predict_transport_mode()
 # or calculate the temporal tracking coverage of users
 tracking_coverage = ti.temporal_tracking_quality(tpls, granularity='all')
 ```
@@ -87,8 +87,8 @@ tracking_coverage = ti.temporal_tracking_quality(tpls, granularity='all')
 **[5.]** Save results.
  ```python
 # save the generated results as csv file 
-sp.as_staypoints.to_csv('.\examples\data\sp.csv')
-tpls.as_triplegs.to_csv('.\examples\data\tpls.csv')
+sp.to_csv(r'.\examples\data\sp.csv')
+tpls.to_csv(r'.\examples\data\tpls.csv')
 ```
 
 For example, the plot below shows the generated staypoints and triplegs from the imported raw positionfix data.

--- a/docs/modules/model.rst
+++ b/docs/modules/model.rst
@@ -44,7 +44,7 @@ do not extend the given DataFrame constructs, we provide accessors that validate
 corresponds to a set of constraints, and make functions available on the DataFrames. For example::
 
     df = trackintel.read_positionfixes_csv('data.csv')
-    df.as_positionfixes.generate_staypoints()
+    df.generate_staypoints()
 
 This will read a CSV into a format compatible with the trackintel understanding of a collection of 
 positionfixes, and the second line will wrap the DataFrame with an accessor providing functions such 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -39,7 +39,7 @@ You can import one of these by executing the following steps::
     conn_string = 'postgresql://test:1234@localhost:5432/' + database_name
 
     pfs = ti.read_positionfixes_csv('examples/data/posmo_trajectory_2.csv', sep=';')
-    pfs.as_positionfixes.to_postgis('positionfixes', conn_string, if_exists='append')
+    pfs.to_postgis('positionfixes', conn_string, if_exists='append')
 
 This will fill the positionfixes of ``posmo_trajectory_2.csv`` into the table
 ``positionfixes`` of the database ``trackintel-tests``. Make sure that you update the
@@ -52,14 +52,14 @@ We now can for example plot the positionfixes::
 Of course, we can start our analysis, for example by detecting staypoints (aggregated positionfixes 
 where the user stayed for a certain amount of time)::
 
-    _, sp = pfs.as_positionfixes.generate_staypoints(method='sliding')
+    _, sp = pfs.generate_staypoints(method='sliding')
     ti.plot(filename="staypoints.png", radius_sp=10, staypoints=sp, positionfixes=pfs, plot_osm=True)
 
 This will additionally plot the original positionfixes, as well as the underlying 
 street network from OSM. We can for example continue by extracting and plotting locations 
 (locations that "contain" multiple staypoints, i.e., are visited often by a user)::
 
-    _, locs = sp.as_staypoints.generate_locations(method='dbscan', epsilon=100, num_samples=1)
+    _, locs = sp.generate_locations(method='dbscan', epsilon=100, num_samples=1)
     ti.plot(filename="locations.png", locations=locs, radius_locs=125, positionfixes=pfs,
             staypoints=sp, radius_sp=100, plot_osm=True)
     

--- a/examples/import_export_postgis.py
+++ b/examples/import_export_postgis.py
@@ -13,7 +13,7 @@ conn_string = "postgresql://test:1234@localhost:5432/trackintel-tests"
 
 # Geolife trajectory to PostGIS.
 pfs = ti.read_positionfixes_csv("examples/data/geolife_trajectory.csv", sep=";")
-# pfs.as_positionfixes.to_postgis('positionfixes', conn_string)
+# pfs.to_postgis('positionfixes', conn_string)
 
 # Geolife trajectory from PostGIS.
 # pfs = ti.io.read_positionfixes_postgis('positionfixes', conn_string)

--- a/examples/preprocess_trajectories.py
+++ b/examples/preprocess_trajectories.py
@@ -15,7 +15,7 @@ logging.basicConfig(filename="examples/log/preprocessing.log", level=logging.INF
 pfs = ti.read_positionfixes_csv("examples/data/geolife_trajectory.csv", sep=";", crs="EPSG:4326", index_col=None)
 ti.plot(filename="examples/out/gps_trajectory_positionfixes.png", positionfixes=pfs, plot_osm=True)
 
-_, sp = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=100, time_threshold=5)
+_, sp = pfs.generate_staypoints(method="sliding", dist_threshold=100, time_threshold=5)
 ti.plot(
     filename="examples/out/gps_trajectory_staypoints.png",
     staypoints=sp,
@@ -24,7 +24,7 @@ ti.plot(
     plot_osm=True,
 )
 
-_, locs = sp.as_staypoints.generate_locations(method="dbscan", epsilon=100, num_samples=3)
+_, locs = sp.generate_locations(method="dbscan", epsilon=100, num_samples=3)
 ti.plot(
     filename="examples/out/gps_trajectory_locations.png",
     locations=locs,
@@ -35,7 +35,7 @@ ti.plot(
     plot_osm=True,
 )
 
-_, tpls = pfs.as_positionfixes.generate_triplegs(staypoints=sp)
+_, tpls = pfs.generate_triplegs(staypoints=sp)
 ti.plot(
     filename="examples/out/gpsies_trajectory_triplegs.png", triplegs=tpls, staypoints=sp, radius_sp=100, plot_osm=True
 )
@@ -44,7 +44,7 @@ ti.plot(
 pfs = ti.read_positionfixes_csv("examples/data/geolife_trajectory.csv", sep=";", crs="EPSG:4326", index_col=None)
 ti.plot(filename="examples/out/geolife_trajectory_positionfixes.png", positionfixes=pfs)
 
-_, sp = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=100, time_threshold=10)
+_, sp = pfs.generate_staypoints(method="sliding", dist_threshold=100, time_threshold=10)
 ti.plot(
     filename="examples/out/geolife_trajectory_staypoints.png",
     staypoints=sp,
@@ -55,7 +55,7 @@ ti.plot(
 
 # Google trajectory.
 pfs = ti.read_positionfixes_csv("examples/data/google_trajectory.csv", sep=";", crs="EPSG:4326", index_col=None)
-_, sp = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=75, time_threshold=10)
+_, sp = pfs.generate_staypoints(method="sliding", dist_threshold=75, time_threshold=10)
 ti.plot(
     filename="examples/out/google_trajectory_staypoints.png",
     staypoints=sp,
@@ -68,7 +68,7 @@ ti.plot(
 pfs = ti.read_positionfixes_csv(
     "examples/data/posmo_trajectory.csv", sep=";", crs="EPSG:4326", index_col=None, tz="UTC"
 )
-_, sp = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=50, time_threshold=1)
+_, sp = pfs.generate_staypoints(method="sliding", dist_threshold=50, time_threshold=1)
 ti.plot(
     filename="examples/out/posmo_trajectory_staypoints.png",
     staypoints=sp,

--- a/examples/setup_example_database.py
+++ b/examples/setup_example_database.py
@@ -33,6 +33,6 @@ except Exception:
 # Now we fill in some new data.
 conn_string = "postgresql://test:1234@localhost:5432/" + database_name
 pfs = ti.read_positionfixes_csv("data/posmo_trajectory_2.csv", sep=";")
-pfs.as_positionfixes.to_postgis("positionfixes", conn_string, if_exists="append")
+pfs.to_postgis("positionfixes", conn_string, if_exists="append")
 
 # We use the trackintel functionality to fill consecutive tables.

--- a/examples/trackintel_basic_tutorial.ipynb
+++ b/examples/trackintel_basic_tutorial.ipynb
@@ -36,7 +36,6 @@
     "import trackintel as ti\n",
     "import geopandas as gpd\n",
     "import pandas as pd\n",
-    "import numpy as np\n",
     "\n",
     "from matplotlib import pyplot as plt\n",
     "%matplotlib inline"
@@ -68,7 +67,8 @@
    "id": "02f7b1b7",
    "metadata": {},
    "source": [
-    "gdf is currently a GeoDataFrame (gdf) and not yet ready to used by trackintel. If you try to call a trackintel function (e.g. plotting) on this GeoDataFrame, an error will occur. "
+    "gdf is currently a GeoDataFrame and not in the right shape to be used with trackintel.\n",
+    "If you try to create Positionfixes an error will occur."
    ]
   },
   {
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "# an error will occur as the gdf is not yet transformed\n",
-    "# gdf.as_positionfixes.generate_staypoints()"
+    "# ti.Positionfixes(gdf)"
    ]
   },
   {
@@ -87,7 +87,7 @@
    "id": "f2dbf1ec",
    "metadata": {},
    "source": [
-    "From the error message it is clear that the column names are not yet recognized by trackintel. We provide helper function to transform a GeoDataFrame object into trackintel compatible format: [positionfixes_from_gpd](https://trackintel.readthedocs.io/en/latest/modules/io.html#geodataframe-import). The method allows to rename the columns and define a timezone. The index is assumed to be the unique identifier of the data."
+    "From the error message it is clear that the column names are not yet recognized by trackintel. We provide helper functions to easily transform a GeoDataFrame into trackintel classes. One of them is [positionfixes_from_gpd](https://trackintel.readthedocs.io/en/latest/modules/io.html#geodataframe-import). The method allows to rename the columns and define a timezone. The index is assumed to be the unique identifier of the data."
    ]
   },
   {
@@ -97,9 +97,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pfs = ti.io.from_geopandas.read_positionfixes_gpd(gdf, tracked_at=\"time\", user_id=\"User\", geom_col=\"geometry\", tz='UTC')\n",
-    "# now you can safely call .as_positionfixes or use any trackintel functions\n",
-    "pfs.as_positionfixes.generate_staypoints()"
+    "pfs = ti.io.read_positionfixes_gpd(gdf, tracked_at=\"time\", user_id=\"User\", geom_col=\"geometry\", tz='UTC')\n",
+    "# pfs is of class Positionfixes that has the generate_staypoints method\n",
+    "pfs.generate_staypoints()"
    ]
   },
   {
@@ -118,7 +118,7 @@
    "outputs": [],
    "source": [
     "# load from csv\n",
-    "ti.io.file.read_positionfixes_csv('./data/pfs.csv', tz='UTC', sep=\";\", index_col=\"id\", crs=\"EPSG:4326\")"
+    "ti.io.read_positionfixes_csv('./data/pfs.csv', tz='UTC', sep=\";\", index_col=\"id\", crs=\"EPSG:4326\")"
    ]
   },
   {
@@ -129,9 +129,28 @@
    "outputs": [],
    "source": [
     "# Load example geolife dataset\n",
-    "pfs, _ = ti.io.dataset_reader.read_geolife('../tests/data/geolife_long')\n",
+    "pfs, _ = ti.io.read_geolife('../tests/data/geolife_long')\n",
     "# plot the raw positionfixes\n",
     "ti.plot(positionfixes=pfs, plot_osm=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "786328cf",
+   "metadata": {},
+   "source": [
+    "Once imported trackintel classes like Positionfixes can be used like GeoDataFrames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11476fde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pfs[\"new_column\"] = 1\n",
+    "pfs.head()"
    ]
   },
   {
@@ -148,7 +167,8 @@
    "metadata": {},
    "source": [
     "# Data model generation\n",
-    "When the GeoDataFrame is once in the right format, all registered trackintel functions at the positionfixes level can be called using the accessor _as_positionfixes_. The registered functions for each data level are slightly different. Relevant information can be found in the [Model documentation](https://trackintel.readthedocs.io/en/latest/modules/model.html). Of course, functions can always be called directly from the respective module using function names.\n",
+    "All trackintel classes have of course different methods available depending on the data level.\n",
+    "Relevant information can be found in the [Model documentation](https://trackintel.readthedocs.io/en/latest/modules/model.html). Equivalent functions exist for every method and can be called directly from the respective module.\n",
     "\n",
     "As an example, we generate the staypoints and triplegs with the raw positionfix data."
    ]
@@ -161,11 +181,12 @@
    "outputs": [],
    "source": [
     "# generate staypoints from positionfixes. The two lines are equivalent\n",
-    "pfs, sp = pfs.as_positionfixes.generate_staypoints(method='sliding', dist_threshold=100, time_threshold=5.0, include_last=False)\n",
+    "pfs, sp = pfs.generate_staypoints(method='sliding', dist_threshold=100, time_threshold=5.0, include_last=False)\n",
     "# pfs, sp = ti.preprocessing.generate_staypoints(pfs, method='sliding', dist_threshold=100, time_threshold=5.0, include_last=False)\n",
     "\n",
     "# generate triplegs from positionfixes and staypoints. \n",
-    "pfs, tpls = pfs.as_positionfixes.generate_triplegs(sp, method='between_staypoints', gap_threshold=15)\n",
+    "pfs, tpls = pfs.generate_triplegs(sp, method='between_staypoints', gap_threshold=15)\n",
+    "# pfs, tpls = ti.preprocessing.generate_triplegs(pfs, sp, method=\"between_staypoints\", gap_threshold=15)\n",
     "\n",
     "# plot the triplegs together with staypoints and positionfixes\n",
     "ti.plot(triplegs=tpls, positionfixes=pfs, staypoints=sp, radius_sp=30, plot_osm=True)"
@@ -187,7 +208,7 @@
    "outputs": [],
    "source": [
     "# infer activity label based on duration, here any staypoint larger than 15 min is considered as an activity\n",
-    "sp = sp.as_staypoints.create_activity_flag(time_threshold=15)\n",
+    "sp = sp.create_activity_flag(time_threshold=15)\n",
     "\n",
     "# generate trips with triplegs and staypoints with activity labels\n",
     "sp, tpls, trips = ti.preprocessing.triplegs.generate_trips(sp, tpls, gap_threshold=15)\n",
@@ -212,7 +233,7 @@
    "outputs": [],
    "source": [
     "# infer activity label based on duration\n",
-    "sp = sp.as_staypoints.create_activity_flag(time_threshold=15)\n",
+    "sp = sp.create_activity_flag(time_threshold=15)\n",
     "\n",
     "# the result is the original staypoint with a column 'is_activity', indicating whether the stp correspond to an activity\n",
     "sp.head(5)"
@@ -226,7 +247,7 @@
    "outputs": [],
    "source": [
     "# infer transport mode based on speed \n",
-    "tpls = tpls.as_triplegs.predict_transport_mode()\n",
+    "tpls = tpls.predict_transport_mode()\n",
     "\n",
     "# the result is the original tripleg with a column 'mode'\n",
     "tpls.head(5)"
@@ -251,7 +272,7 @@
     "trace = pd.concat([sp, tpls])\n",
     "\n",
     "# calculate the overall tracking coverage\n",
-    "ti.analysis.tracking_quality.temporal_tracking_quality(trace, granularity='all')"
+    "ti.analysis.temporal_tracking_quality(trace, granularity='all')"
    ]
   },
   {
@@ -262,8 +283,8 @@
    "outputs": [],
    "source": [
     "# or coverage by day or hour\n",
-    "ti.analysis.tracking_quality.temporal_tracking_quality(trace, granularity='hour')\n",
-    "ti.analysis.tracking_quality.temporal_tracking_quality(trace, granularity='day')"
+    "ti.analysis.temporal_tracking_quality(trace, granularity='hour')\n",
+    "ti.analysis.temporal_tracking_quality(trace, granularity='day')"
    ]
   },
   {
@@ -282,14 +303,14 @@
    "outputs": [],
    "source": [
     "# for the modal split we load a special subset of geolife dataset with tripleg modes\n",
-    "pfs, labels = ti.io.dataset_reader.read_geolife('../tests/data/geolife_modes')\n",
+    "pfs, labels = ti.io.read_geolife('../tests/data/geolife_modes')\n",
     "\n",
     "# sp and tpls are generated \n",
-    "pfs, sp = pfs.as_positionfixes.generate_staypoints(method=\"sliding\", dist_threshold=25, time_threshold=5)\n",
-    "_, tpls = pfs.as_positionfixes.generate_triplegs(sp, method=\"between_staypoints\")\n",
+    "pfs, sp = pfs.generate_staypoints(method=\"sliding\", dist_threshold=25, time_threshold=5)\n",
+    "_, tpls = pfs.generate_triplegs(sp, method=\"between_staypoints\")\n",
     "\n",
     "# the mode labels are assigned to each tpls\n",
-    "tpls_with_modes = ti.io.dataset_reader.geolife_add_modes_to_triplegs(tpls, labels)\n",
+    "tpls_with_modes = ti.io.geolife_add_modes_to_triplegs(tpls, labels)\n",
     "tpls_with_modes.head(5)"
    ]
   },
@@ -301,10 +322,10 @@
    "outputs": [],
    "source": [
     "# the modal split can then be calculated\n",
-    "modal_split = ti.analysis.modal_split.calculate_modal_split(tpls_with_modes, metric=\"count\", freq=\"D\", per_user=False, norm=True)\n",
+    "modal_split = ti.analysis.calculate_modal_split(tpls_with_modes, metric=\"count\", freq=\"D\", per_user=False, norm=True)\n",
     "\n",
     "# and visualized\n",
-    "ti.visualization.plot_modal_split(modal_split, date_fmt_x_axis='%d', y_label='Percentage of daily count', x_label='days')\n",
+    "ti.plot_modal_split(modal_split, date_fmt_x_axis='%d', y_label='Percentage of daily count', x_label='days')\n",
     "plt.show()"
    ]
   },
@@ -325,10 +346,10 @@
    "outputs": [],
    "source": [
     "# save datamodels to csv files\n",
-    "pfs.as_positionfixes.to_csv('./out/pfs_tutorial.csv')\n",
-    "sp.as_staypoints.to_csv('./out/sp_tutorial.csv')\n",
-    "tpls.as_triplegs.to_csv('./out/tpls_tutorial.csv')\n",
-    "trips.as_trips.to_csv('./out/trips_tutorial.csv')\n",
+    "pfs.to_csv('./out/pfs_tutorial.csv')\n",
+    "sp.to_csv('./out/sp_tutorial.csv')\n",
+    "tpls.to_csv('./out/tpls_tutorial.csv')\n",
+    "trips.to_csv('./out/trips_tutorial.csv')\n",
     "\n",
     "# filename will save the generated plot as a file\n",
     "ti.plot(filename='./out/pfs.png', positionfixes=pfs)"

--- a/trackintel/analysis/labelling.py
+++ b/trackintel/analysis/labelling.py
@@ -11,7 +11,7 @@ def create_activity_flag(staypoints, method="time_threshold", time_threshold=15.
 
     Parameters
     ----------
-    staypoints: GeoDataFrame (as trackintel staypoints)
+    staypoints: Staypoints
 
     method: {'time_threshold'}, default = 'time_threshold'
         - 'time_threshold' : All staypoints with a duration greater than the time_threshold are considered an activity.
@@ -24,12 +24,12 @@ def create_activity_flag(staypoints, method="time_threshold", time_threshold=15.
 
     Returns
     -------
-    staypoints : GeoDataFrame (as trackintel staypoints)
+    staypoints : Staypoints
         Original staypoints with the additional activity column
 
     Examples
     --------
-    >>> sp  = sp.as_staypoints.create_activity_flag(method='time_threshold', time_threshold=15)
+    >>> sp  = sp.create_activity_flag(method='time_threshold', time_threshold=15)
     >>> print(sp['is_activity'])
     """
     if method == "time_threshold":
@@ -51,7 +51,7 @@ def predict_transport_mode(triplegs, method="simple-coarse", **kwargs):
 
     Parameters
     ----------
-    triplegs: GeoDataFrame (as trackintel triplegs)
+    triplegs: Triplegs
 
     method: {'simple-coarse'}, default 'simple-coarse'
         The following methods are available for transport mode inference/prediction:
@@ -59,7 +59,7 @@ def predict_transport_mode(triplegs, method="simple-coarse", **kwargs):
 
     Returns
     -------
-    triplegs : GeoDataFrame (as trackintel triplegs)
+    triplegs : Triplegs
         The triplegs with added column mode, containing the predicted transport modes.
 
     Notes
@@ -72,7 +72,7 @@ def predict_transport_mode(triplegs, method="simple-coarse", **kwargs):
 
     Examples
     --------
-    >>> tpls  = tpls.as_triplegs.predict_transport_mode()
+    >>> tpls  = tpls.predict_transport_mode()
     >>> print(tpls["mode"])
     """
     if method == "simple-coarse":
@@ -95,7 +95,7 @@ def _predict_transport_mode_simple_coarse(triplegs_in, categories):
 
     Parameters
     ----------
-    triplegs_in : GeoDataFrame (as trackintel triplegs)
+    triplegs_in : Triplegs
         The triplegs for the transport mode prediction.
 
     categories : dict, optional

--- a/trackintel/analysis/location_identification.py
+++ b/trackintel/analysis/location_identification.py
@@ -8,7 +8,7 @@ def location_identifier(staypoints, method="FREQ", pre_filter=True, **pre_filter
 
     Parameters
     ----------
-    staypoints : Geodataframe (as trackintel staypoints)
+    staypoints : Staypoints
         Staypoints with column "location_id".
 
     method : {'FREQ', 'OSNA'}, default "FREQ"
@@ -26,7 +26,7 @@ def location_identifier(staypoints, method="FREQ", pre_filter=True, **pre_filter
 
     Returns
     -------
-    sp: Geodataframe (as trackintel staypoints)
+    sp: Staypoints
         With additional column `purpose` assigning one of three activity labels {'home', 'work', None}.
 
     Note
@@ -51,7 +51,7 @@ def location_identifier(staypoints, method="FREQ", pre_filter=True, **pre_filter
     if "location_id" not in sp.columns:
         raise KeyError(
             (
-                "To derive activity labels the GeoDataFrame (as trackintel staypoints) must have a column "
+                "To derive activity labels the Staypoints must have a column "
                 f"named 'location_id' but it has [{', '.join(sp.columns)}]"
             )
         )
@@ -86,7 +86,7 @@ def pre_filter_locations(
 
     Parameters
     ----------
-    staypoints : GeoDataFrame (as trackintel staypoints)
+    staypoints : Staypoints
         Staypoints with the column "location_id".
 
     agg_level: {"user", "dataset"}, default "user"
@@ -172,7 +172,7 @@ def freq_method(staypoints, *labels):
 
     Parameters
     ----------
-    staypoints : GeoDataFrame (as trackintel staypoints)
+    staypoints : Staypoints
         Staypoints with the column "location_id".
 
     labels : collection of str, default ("home", "work")
@@ -180,7 +180,7 @@ def freq_method(staypoints, *labels):
 
     Returns
     -------
-    sp: GeoDataFrame (as trackintel staypoints)
+    sp: Staypoints
         The input staypoints with additional column "purpose".
 
     Examples
@@ -250,12 +250,12 @@ def osna_method(staypoints):
 
     Parameters
     ----------
-    staypoints : GeoDataFrame (as trackintel staypoints)
+    staypoints : Staypoints
         Staypoints with the column "location_id".
 
     Returns
     -------
-    GeoDataFrame (as trackintel staypoints)
+    Staypoints
         The input staypoints with additional column "purpose".
 
     Note

--- a/trackintel/analysis/modal_split.py
+++ b/trackintel/analysis/modal_split.py
@@ -9,7 +9,7 @@ def calculate_modal_split(tpls, freq=None, metric="count", per_user=False, norm=
 
     Parameters
     ----------
-    tpls : GeoDataFrame (as trackintel triplegs)
+    tpls : Triplegs
         triplegs require the column `mode`.
     freq : str
         frequency string passed on as `freq` keyword to the pandas.Grouper class. If `freq=None` the modal split is
@@ -82,7 +82,7 @@ def _calculate_length(tpls):
 
     Parameters
     ----------
-    tpls : GeoDataFrame (as trackintel triplegs)
+    tpls : Triplegs
     """
     if check_gdf_planar(tpls):
         return tpls.length  # if planar use geopandas function

--- a/trackintel/analysis/tracking_quality.py
+++ b/trackintel/analysis/tracking_quality.py
@@ -10,7 +10,7 @@ def temporal_tracking_quality(source, granularity="all"):
 
     Parameters
     ----------
-    df : GeoDataFrame (as trackintel datamodels)
+    df : Trackintel class
         The source dataframe to calculate temporal tracking quality.
 
     granularity : {"all", "day", "week", "weekday", "hour"}
@@ -132,7 +132,7 @@ def _get_tracking_quality_user(df, granularity="all"):
 
     Parameters
     ----------
-    df : GeoDataFrame (as trackintel datamodels)
+    df : Trackintel class
         The source dataframe
 
     granularity : {"all", "day", "weekday", "week", "hour"}, default "all"
@@ -175,7 +175,7 @@ def _split_overlaps(source, granularity="day"):
 
     Parameters
     ----------
-    source : GeoDataFrame (as trackintel datamodels)
+    source : Trackintel class
         The GeoDataFrame to perform the split on.
 
     granularity : {'day', 'hour'}, default 'day'
@@ -184,8 +184,8 @@ def _split_overlaps(source, granularity="day"):
 
     Returns
     -------
-    GeoDataFrame (as trackintel datamodels)
-        The GeoDataFrame object after the splitting
+    Trackintel class
+        The input object after the splitting
     """
     freq = "H" if granularity == "hour" else "D"
     gdf = source.copy()

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -92,9 +92,9 @@ def calculate_distance_matrix(X, Y=None, dist_metric="haversine", n_jobs=0, **kw
 
     Parameters
     ----------
-    X : GeoDataFrame (as trackintel model)
+    X : Trackintel class
 
-    Y : GeoDataFrame (as trackintel model), optional
+    Y : Trackintel class, optional
         Should be of the same type as X
 
     dist_metric: {{'haversine', 'euclidean', 'dtw', 'frechet'}}, optional
@@ -130,7 +130,7 @@ def calculate_distance_matrix(X, Y=None, dist_metric="haversine", n_jobs=0, **kw
     --------
     >>> calculate_distance_matrix(staypoints, dist_metric="haversine")
     >>> calculate_distance_matrix(triplegs_1, triplegs_2, dist_metric="dtw")
-    >>> pfs.as_positionfixes.calculate_distance_matrix(dist_metric="haversine")
+    >>> pfs.calculate_distance_matrix(dist_metric="haversine")
     """
     geom_type = X.geometry.iat[0].geom_type
     if Y is None:
@@ -335,11 +335,11 @@ def get_speed_positionfixes(positionfixes):
 
     Parameters
     ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
+    positionfixes : Positionfixes
 
     Returns
     -------
-    pfs: GeoDataFrame (as trackintel positionfixes)
+    pfs: Positionfixes
         Copy of the original positionfixes with a new column ``[`speed`]``. The speed is given in m/s
 
     Notes
@@ -374,9 +374,9 @@ def get_speed_triplegs(triplegs, positionfixes=None, method="tpls_speed"):
 
     Parameters
     ----------
-    triplegs: GeoDataFrame (as trackintel triplegs)
+    triplegs: Triplegs
 
-    positionfixes: GeoDataFrame (as trackintel positionfixes), optional
+    positionfixes: Positionfixes, optional
         Only required if the method is 'pfs_mean_speed'.
         In addition to the standard columns positionfixes must include the column ``[`tripleg_id`]``.
 
@@ -387,7 +387,7 @@ def get_speed_triplegs(triplegs, positionfixes=None, method="tpls_speed"):
 
     Returns
     -------
-    tpls: GeoDataFrame (as trackintel triplegs)
+    tpls: Triplegs
         The original triplegs with a new column ``[`speed`]``. The speed is given in m/s.
     """
     Triplegs.validate(triplegs)

--- a/trackintel/io/dataset_reader.py
+++ b/trackintel/io/dataset_reader.py
@@ -36,7 +36,7 @@ def read_geolife(geolife_path, print_progress=False):
 
     Returns
     -------
-    gdf: GeoDataFrame (as trackintel positionfixes)
+    gdf: Positionfixes
         Contains all loaded geolife positionfixes
 
     labels: dict
@@ -204,7 +204,7 @@ def geolife_add_modes_to_triplegs(
 
     Parameters
     ----------
-    triplegs : GeoDataFrame (as trackintel triplegs)
+    triplegs : Triplegs
         Geolife triplegs.
 
     labels : dictionary
@@ -222,7 +222,7 @@ def geolife_add_modes_to_triplegs(
 
     Returns
     -------
-    tpls : GeoDataFrame (as trackintel triplegs)
+    tpls : Triplegs
         triplegs with mode labels.
 
     Notes
@@ -234,8 +234,8 @@ def geolife_add_modes_to_triplegs(
     ----------
     >>> from trackintel.io.dataset_reader import read_geolife, geolife_add_modes_to_triplegs
     >>> pfs, mode_labels = read_geolife(os.path.join('downloads', 'Geolife Trajectories 1.3'))
-    >>> pfs, sp = pfs.as_positionfixes.generate_staypoints()
-    >>> pfs, tpls = pfs.as_positionfixes.generate_triplegs(sp)
+    >>> pfs, sp = pfs.generate_staypoints()
+    >>> pfs, tpls = pfs.generate_triplegs(sp)
     >>> tpls = geolife_add_modes_to_triplegs(tpls, mode_labels)
     """
     tpls = triplegs.copy()
@@ -311,7 +311,7 @@ def _calc_overlap_for_candidates(candidates, tpls_this, labels_this, ratio_thres
         columns: nb of neighbors, sorted by temporal distance
         values: Reference to position in the tpls_this dataframe
 
-    tpls_this : GeoDataFrame (as trackintel triplegs)
+    tpls_this : Triplegs
         triplegs of a single user
 
     labels_this : DataFrame
@@ -375,9 +375,9 @@ def read_mzmv(mzmv_path):
 
     Returns
     -------
-    trips : GeoDataFrame (as trackintel trips)
-    sp : GeoDataFrame (as trackintel staypoints)
-    tpls : GeoDataFrame (as trackintel triplegs)
+    trips : Trips
+    sp : Staypoints
+    tpls : Triplegs
 
     Notes
     -----
@@ -556,7 +556,7 @@ def _mzmv_generate_sp(tpls, zf):
 
     Returns
     -------
-    staypoints : GeoDataFrame (as trackintel staypoints)
+    staypoints : Staypoints
         staypoints with mandatory columns, all the columns for staypoints from mzmv,
         and additionally "prev_trip_id", "trip_id", "next_trip_id", "is_activity",
         "purpose", "purpose_tpls"

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -21,7 +21,7 @@ def read_positionfixes_csv(*args, columns=None, tz=None, index_col=None, geom_co
     Read positionfixes from csv file.
 
     Wraps the pandas read_csv function, extracts longitude and latitude and
-    builds a POINT GeoSeries.
+    builds a POINT GeoSeries, extracts datetime from column `tracked_at`.
 
     Parameters
     ----------
@@ -129,7 +129,7 @@ def read_triplegs_csv(*args, columns=None, tz=None, index_col=None, geom_col="ge
     Read triplegs from csv file.
 
     Wraps the pandas read_csv function, extracts a WKT for the tripleg geometry (LINESTRING)
-    and builds a Triplegs instance.
+    and builds a Triplegs instance, extracts datetime from column `started_at` & `finished_at`.
 
     Parameters
     ----------
@@ -197,7 +197,7 @@ def read_staypoints_csv(*args, columns=None, tz=None, index_col=None, geom_col="
     Read staypoints from csv file.
 
     Wraps the pandas read_csv function, extracts a WKT for the staypoint geometry (Point)
-    and builds a Staypoints instance.
+    and builds a Staypoints instance, extracts datetime from column `started_at` & `finished_at`.
 
     Parameters
     ----------
@@ -265,7 +265,8 @@ def read_locations_csv(*args, columns=None, index_col=None, crs=None, **kwargs):
     Read locations from csv file.
 
     Wraps the pandas read_csv function, extracts a WKT for the location center geometry (POINT)
-    (and optional extent (POLYGON)) and builds a Locations instance.
+    (and optional extent (POLYGON)) and builds a Locations instance, extracts datetime from
+    column `started_at` & `finished_at`.
 
     Parameters
     ----------
@@ -327,6 +328,7 @@ def read_trips_csv(*args, columns=None, tz=None, index_col=None, geom_col=None, 
     Read trips from csv file.
 
     Wraps the pandas read_csv function and builds a Trips instance.
+    Extracts datetime from column `started_at` & `finished_at`.
 
     Parameters
     ----------
@@ -405,6 +407,8 @@ def write_trips_csv(trips, filename, *args, **kwargs):
 def read_tours_csv(*args, columns=None, index_col=None, tz=None, **kwargs):
     """
     Read tours from csv file.
+    
+    Extracts datetime from column `started_at` & `finished_at`.
 
     Parameters
     ----------

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -21,9 +21,7 @@ def read_positionfixes_csv(*args, columns=None, tz=None, index_col=None, geom_co
     Read positionfixes from csv file.
 
     Wraps the pandas read_csv function, extracts longitude and latitude and
-    builds a geopandas GeoDataFrame (POINT). This also validates that the ingested data
-    conforms to the trackintel understanding of positionfixes (see
-    :doc:`/modules/model`).
+    builds a POINT GeoSeries.
 
     Parameters
     ----------
@@ -55,8 +53,7 @@ def read_positionfixes_csv(*args, columns=None, tz=None, index_col=None, geom_co
 
     Returns
     -------
-    pfs : GeoDataFrame (as trackintel positionfixes)
-        A GeoDataFrame containing the positionfixes.
+    pfs : Positionfixes
 
     Notes
     -----
@@ -97,7 +94,7 @@ def write_positionfixes_csv(positionfixes, filename, *args, **kwargs):
 
     Parameters
     ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
+    positionfixes : Positionfixes
 
     filename : str
         The file to write to.
@@ -115,7 +112,7 @@ def write_positionfixes_csv(positionfixes, filename, *args, **kwargs):
 
     Examples
     ---------
-    >>> pfs.as_positionfixes.to_csv("export_pfs.csv")
+    >>> pfs.to_csv("export_pfs.csv")
     >>> ti.io.write_positionfixes_csv(pfs, "export_pfs.csv")
     """
     gdf = positionfixes.copy()
@@ -132,8 +129,7 @@ def read_triplegs_csv(*args, columns=None, tz=None, index_col=None, geom_col="ge
     Read triplegs from csv file.
 
     Wraps the pandas read_csv function, extracts a WKT for the tripleg geometry (LINESTRING)
-    and builds a geopandas GeoDataFrame. This also validates that the ingested data
-    conforms to the trackintel understanding of triplegs (see :doc:`/modules/model`).
+    and builds a Triplegs instance.
 
     Parameters
     ----------
@@ -165,8 +161,7 @@ def read_triplegs_csv(*args, columns=None, tz=None, index_col=None, geom_col="ge
 
     Returns
     -------
-    tpls : GeoDataFrame (as trackintel triplegs)
-        A GeoDataFrame containing the triplegs.
+    tpls : Triplegs
 
     Examples
     --------
@@ -188,7 +183,7 @@ def read_triplegs_csv(*args, columns=None, tz=None, index_col=None, geom_col="ge
 
 @doc(
     _shared_docs["write_csv"],
-    first_arg="\ntriplegs : GeoDataFrame (as trackintel triplegs)\n",
+    first_arg="\ntriplegs : Triplegs\n",
     long="triplegs",
     short="tpls",
 )
@@ -201,10 +196,8 @@ def read_staypoints_csv(*args, columns=None, tz=None, index_col=None, geom_col="
     """
     Read staypoints from csv file.
 
-    Wraps the pandas read_csv function, extracts a WKT for the staypoint
-    geometry (POINT) and builds a geopandas GeoDataFrame. This also validates that
-    the ingested data conforms to the trackintel understanding of staypoints
-    (see :doc:`/modules/model`).
+    Wraps the pandas read_csv function, extracts a WKT for the staypoint geometry (Point)
+    and builds a Staypoints instance.
 
     Parameters
     ----------
@@ -236,8 +229,7 @@ def read_staypoints_csv(*args, columns=None, tz=None, index_col=None, geom_col="
 
     Returns
     -------
-    sp : GeoDataFrame (as trackintel staypoints)
-        A GeoDataFrame containing the staypoints.
+    sp : Staypoints
 
     Examples
     --------
@@ -259,7 +251,7 @@ def read_staypoints_csv(*args, columns=None, tz=None, index_col=None, geom_col="
 
 @doc(
     _shared_docs["write_csv"],
-    first_arg="\nstaypoints : GeoDataFrame (as trackintel staypoints)\n",
+    first_arg="\nstaypoints : Staypoints\n",
     long="staypoints",
     short="sp",
 )
@@ -272,10 +264,8 @@ def read_locations_csv(*args, columns=None, index_col=None, crs=None, **kwargs):
     """
     Read locations from csv file.
 
-    Wraps the pandas read_csv function, extracts a WKT for the location
-    center (POINT) (and extent (POLYGON)) and builds a geopandas GeoDataFrame. This also
-    validates that the ingested data conforms to the trackintel understanding
-    of locations (see :doc:`/modules/model`).
+    Wraps the pandas read_csv function, extracts a WKT for the location center geometry (POINT)
+    (and optional extent (POLYGON)) and builds a Locations instance.
 
     Parameters
     ----------
@@ -300,8 +290,7 @@ def read_locations_csv(*args, columns=None, index_col=None, crs=None, **kwargs):
 
     Returns
     -------
-    locs : GeoDataFrame (as trackintel locations)
-        A GeoDataFrame containing the locations.
+    locs : Locations
 
     Examples
     --------
@@ -324,7 +313,7 @@ def read_locations_csv(*args, columns=None, index_col=None, crs=None, **kwargs):
 
 @doc(
     _shared_docs["write_csv"],
-    first_arg="\nlocations : GeoDataFrame (as trackintel locations)\n",
+    first_arg="\nlocations : Locations\n",
     long="locations",
     short="locs",
 )
@@ -336,10 +325,6 @@ def write_locations_csv(locations, filename, *args, **kwargs):
 def read_trips_csv(*args, columns=None, tz=None, index_col=None, geom_col=None, crs=None, **kwargs):
     """
     Read trips from csv file.
-
-    Wraps the pandas read_csv function and extracts proper datetimes. This also
-    validates that the ingested data conforms to the trackintel understanding
-    of trips (see :doc:`/modules/model`).
 
     Parameters
     ----------
@@ -373,8 +358,8 @@ def read_trips_csv(*args, columns=None, tz=None, index_col=None, geom_col=None, 
 
     Returns
     -------
-    trips : (Geo)DataFrame (as trackintel trips)
-        A DataFrame containing the trips. GeoDataFrame if geometry column exists.
+    trips : Trips
+        A TripsDataFrame containing the trips. TripsGeoDataFrame if geometry column exists.
 
     Notes
     -----
@@ -406,9 +391,7 @@ def read_trips_csv(*args, columns=None, tz=None, index_col=None, geom_col=None, 
     return read_trips_gpd(trips, geom_col=geom_col, crs=crs, tz=tz)
 
 
-@doc(
-    _shared_docs["write_csv"], first_arg="\ntrips : (Geo)DataFrame (as trackintel trips)\n", long="trips", short="trips"
-)
+@doc(_shared_docs["write_csv"], first_arg="\ntrips : Trips\n", long="trips", short="trips")
 def write_trips_csv(trips, filename, *args, **kwargs):
     if isinstance(trips, GeoDataFrame):
         trips = trips.to_wkt(rounding_precision=-1, trim=False)
@@ -420,10 +403,6 @@ def write_trips_csv(trips, filename, *args, **kwargs):
 def read_tours_csv(*args, columns=None, index_col=None, tz=None, **kwargs):
     """
     Read tours from csv file.
-
-    Wraps the pandas read_csv function and extracts proper datetimes. This also
-    validates that the ingested data conforms to the trackintel understanding
-    of tours (see :doc:`/modules/model`).
 
     Parameters
     ----------
@@ -444,8 +423,7 @@ def read_tours_csv(*args, columns=None, index_col=None, tz=None, **kwargs):
 
     Returns
     -------
-    tours : DataFrame (as trackintel tours)
-        A DataFrame containing the tours.
+    tours : Tours
 
     Examples
     --------
@@ -462,6 +440,6 @@ def read_tours_csv(*args, columns=None, index_col=None, tz=None, **kwargs):
     return read_tours_gpd(tours, tz=tz)
 
 
-@doc(_shared_docs["write_csv"], first_arg="\ntours : DataFrame (as trackintel tours)\n", long="tours", short="tours")
+@doc(_shared_docs["write_csv"], first_arg="\ntours : Tours\n", long="tours", short="tours")
 def write_tours_csv(tours, filename, *args, **kwargs):
     pd.DataFrame.to_csv(tours, filename, index=True, *args, **kwargs)

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -407,7 +407,7 @@ def write_trips_csv(trips, filename, *args, **kwargs):
 def read_tours_csv(*args, columns=None, index_col=None, tz=None, **kwargs):
     """
     Read tours from csv file.
-    
+
     Extracts datetime from column `started_at` & `finished_at`.
 
     Parameters

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -326,6 +326,8 @@ def read_trips_csv(*args, columns=None, tz=None, index_col=None, geom_col=None, 
     """
     Read trips from csv file.
 
+    Wraps the pandas read_csv function and builds a Trips instance.
+
     Parameters
     ----------
     args

--- a/trackintel/io/from_geopandas.py
+++ b/trackintel/io/from_geopandas.py
@@ -41,7 +41,7 @@ def read_positionfixes_gpd(
 
     Returns
     -------
-    pfs : GeoDataFrame (as trackintel positionfixes)
+    pfs : Positionfixes
         A GeoDataFrame containing the positionfixes.
 
     Examples
@@ -101,7 +101,7 @@ def read_staypoints_gpd(
 
     Returns
     -------
-    sp : GeoDataFrame (as trackintel staypoints)
+    sp : Staypoints
         A GeoDataFrame containing the staypoints
 
     Examples
@@ -162,7 +162,7 @@ def read_triplegs_gpd(
 
     Returns
     -------
-    tpls : GeoDataFrame (as trackintel triplegs)
+    tpls : Triplegs
         A GeoDataFrame containing the triplegs
 
     Examples
@@ -230,8 +230,7 @@ def read_trips_gpd(
 
     Returns
     -------
-    trips : (Geo)DataFrame (as trackintel trips)
-        A (Geo)DataFrame containing the trips.
+    trips : Trips
 
     Examples
     --------
@@ -282,8 +281,7 @@ def read_locations_gpd(gdf, user_id="user_id", center="center", extent=None, crs
 
     Returns
     -------
-    locs : GeoDataFrame (as trackintel locations)
-        A GeoDataFrame containing the locations.
+    locs : Locations
 
     Examples
     --------
@@ -338,8 +336,7 @@ def read_tours_gpd(
 
     Returns
     -------
-    tours : GeoDataFrame (as trackintel tours)
-        A GeoDataFrame containing the tours
+    tours : Tours
     """
     columns = {
         user_id: "user_id",

--- a/trackintel/io/postgis.py
+++ b/trackintel/io/postgis.py
@@ -129,7 +129,7 @@ def read_positionfixes_postgis(
 
 @doc(
     _shared_docs["write_postgis"],
-    first_arg="\npositionfixes : GeoDataFrame (as trackintel positionfixes)\n    The positionfixes to store to the database.\n",
+    first_arg="\npositionfixes : Positionfixes\n    The positionfixes to store to the database.\n",
     long="positionfixes",
     short="pfs",
 )
@@ -226,7 +226,7 @@ def read_triplegs_postgis(
 
 @doc(
     _shared_docs["write_postgis"],
-    first_arg="\ntriplegs : GeoDataFrame (as trackintel triplegs)\n    The triplegs to store to the database.\n",
+    first_arg="\ntriplegs : Triplegs\n    The triplegs to store to the database.\n",
     long="triplegs",
     short="tpls",
 )
@@ -335,7 +335,7 @@ def read_staypoints_postgis(
 
 @doc(
     _shared_docs["write_postgis"],
-    first_arg="\nstaypoints : GeoDataFrame (as trackintel staypoints)\n    The staypoints to store to the database.\n",
+    first_arg="\nstaypoints : Staypoints\n    The staypoints to store to the database.\n",
     long="staypoints",
     short="sp",
 )
@@ -450,7 +450,7 @@ def read_locations_postgis(
 
 @doc(
     _shared_docs["write_postgis"],
-    first_arg="\nlocations : GeoDataFrame (as trackintel locations)\n    The locations to store to the database.\n",
+    first_arg="\nlocations : Locations\n    The locations to store to the database.\n",
     long="locations",
     short="locs",
 )
@@ -586,7 +586,7 @@ def read_trips_postgis(
 
 @doc(
     _shared_docs["write_postgis"],
-    first_arg="\ntrips : GeoDataFrame (as trackintel trips)\n    The trips to store to the database.\n",
+    first_arg="\ntrips : Trips\n    The trips to store to the database.\n",
     long="trips",
     short="trips",
 )
@@ -680,8 +680,7 @@ def read_tours_postgis(
 
     Returns
     -------
-    GeoDataFrame (as trackintel tours)
-        A GeoDataFrame containing the tours.
+    Tours
 
     Examples
     --------
@@ -717,7 +716,7 @@ def read_tours_postgis(
 
 @doc(
     _shared_docs["write_postgis"],
-    first_arg="\ntours : GeoDataFrame (as trackintel tours)\n    The tours to store to the database.\n",
+    first_arg="\ntours : Tours\n    The tours to store to the database.\n",
     long="tours",
     short="tours",
 )

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -29,7 +29,7 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
 
     Examples
     --------
-    >>> df.as_locations.to_csv("filename.csv")
+    >>> locations.to_csv("filename.csv")
     """
 
     def __init__(self, *args, validate=True, **kwargs):

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -38,7 +38,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
 
     Examples
     --------
-    >>> df.as_positionfixes.generate_staypoints()
+    >>> positionfixes.generate_staypoints()
     """
 
     def __init__(self, *args, validate=True, **kwargs):

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -40,7 +40,7 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
 
     Examples
     --------
-    >>> df.as_staypoints.generate_locations()
+    >>> staypoints.generate_locations()
     """
 
     def __init__(self, *args, validate=True, **kwargs):

--- a/trackintel/model/tours.py
+++ b/trackintel/model/tours.py
@@ -33,7 +33,7 @@ class Tours(TrackintelBase, TrackintelDataFrame):
 
     Examples
     --------
-    >>> df.as_tours.to_csv("filename.csv")
+    >>> tours.to_csv("filename.csv")
     """
 
     def __init__(self, *args, validate=True, **kwargs):

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -36,7 +36,7 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
 
     Examples
     --------
-    >>> df.as_triplegs.generate_trips()
+    >>> triplegs.generate_trips()
     """
 
     def __init__(self, *args, validate=True, **kwargs):

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -43,7 +43,7 @@ class Trips:
 
     Examples
     --------
-    >>> df.as_trips.generate_tours()
+    >>> trips.generate_tours()
     """
 
     def __new__(cls, *args, **kwargs):
@@ -86,7 +86,7 @@ class TripsDataFrame(TrackintelBase, TrackintelDataFrame):
 
     Examples
     --------
-    >>> df.as_trips.generate_tours()
+    >>> trips.generate_tours()
     """
 
     def __init__(self, *args, validate=True, **kwargs):
@@ -166,7 +166,7 @@ class TripsGeoDataFrame(TrackintelGeoDataFrame, TripsDataFrame, gpd.GeoDataFrame
 
     Examples
     --------
-    >>> df.as_trips.generate_tours()
+    >>> trips.generate_tours()
     """
 
     fallback_class = TripsDataFrame

--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -203,7 +203,7 @@ dtype: dict of column name to SQL type, default None
 
 Examples
 --------
->>> {short}.as_{long}.to_postgis(conn_string, table_name)
+>>> {short}.to_postgis(conn_string, table_name)
 >>> ti.io.postgis.write_{long}_postgis({short}, conn_string, table_name)
 """
 
@@ -228,5 +228,5 @@ kwargs
 
 Examples
 --------
->>> {short}.as_{long}.to_csv("export_{long}.csv")
+>>> {short}.to_csv("export_{long}.csv")
 """

--- a/trackintel/preprocessing/filter.py
+++ b/trackintel/preprocessing/filter.py
@@ -32,7 +32,7 @@ def spatial_filter(source, areas, method="within", re_project=False):
 
     Examples
     --------
-    >>> sp.as_staypoints.spatial_filter(areas, method="within", re_project=False)
+    >>> sp.spatial_filter(areas, method="within", re_project=False)
     """
     gdf = source.copy()
 

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -29,7 +29,7 @@ def generate_staypoints(
 
     Parameters
     ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
+    positionfixes : Positionfixes
 
     method : {'sliding'}
         Method to create staypoints. 'sliding' applies a sliding window over the data.
@@ -70,10 +70,10 @@ def generate_staypoints(
 
     Returns
     -------
-    pfs: GeoDataFrame (as trackintel positionfixes)
+    pfs: Positionfixes
         The original positionfixes with a new column ``[`staypoint_id`]``.
 
-    sp: GeoDataFrame (as trackintel staypoints)
+    sp: Staypoints
         The generated staypoints.
 
     Notes
@@ -86,7 +86,7 @@ def generate_staypoints(
 
     Examples
     --------
-    >>> pfs.as_positionfixes.generate_staypoints('sliding', dist_threshold=100)
+    >>> pfs.generate_staypoints('sliding', dist_threshold=100)
 
     References
     ----------
@@ -178,10 +178,10 @@ def generate_triplegs(
 
     Parameters
     ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
+    positionfixes : Positionfixes
         If 'staypoint_id' column is not found, 'staypoints' needs to be provided.
 
-    staypoints : GeoDataFrame (as trackintel staypoints), optional
+    staypoints : Staypoints, optional
         The staypoints (corresponding to the positionfixes). If this is not passed, the
         positionfixes need 'staypoint_id' associated with them.
 
@@ -199,10 +199,10 @@ def generate_triplegs(
 
     Returns
     -------
-    pfs: GeoDataFrame (as trackintel positionfixes)
+    pfs: Positionfixes
         The original positionfixes with a new column ``[`tripleg_id`]``.
 
-    tpls: GeoDataFrame (as trackintel triplegs)
+    tpls: Triplegs
         The generated triplegs.
 
     Notes
@@ -219,7 +219,7 @@ def generate_triplegs(
 
     Examples
     --------
-    >>> pfs.as_positionfixes.generate_triplegs('between_staypoints', gap_threshold=15)
+    >>> pfs.generate_triplegs('between_staypoints', gap_threshold=15)
     """
     Positionfixes.validate(positionfixes)
     if staypoints is not None:
@@ -477,15 +477,15 @@ def _drop_invalid_triplegs(tpls, pfs):
 
     Parameters
     ----------
-    tpls : GeoDataFrame (as trackintel triplegs)
-    pfs : GeoDataFrame (as trackintel positionfixes)
+    tpls : Triplegs
+    pfs : Positionfixes
 
     Returns
     -------
-    tpls: GeoDataFrame (as trackintel triplegs)
+    tpls: Triplegs
         original tpls with invalid geometries removed.
 
-    pfs: GeoDataFrame (as trackintel positionfixes)
+    pfs: Positionfixes
         original pfs with invalid tripleg id set to pd.NA.
 
     Notes

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -25,7 +25,7 @@ def generate_locations(
 
     Parameters
     ----------
-    staypoints : GeoDataFrame (as trackintel staypoints)
+    staypoints : Staypoints
 
     method : {'dbscan'}
         Method to create locations.
@@ -62,15 +62,15 @@ def generate_locations(
 
     Returns
     -------
-    sp: GeoDataFrame (as trackintel staypoints)
+    sp: Staypoints
         The original staypoints with a new column ``[`location_id`]``.
 
-    locs: GeoDataFrame (as trackintel locations)
+    locs: Locations
         The generated locations.
 
     Examples
     --------
-    >>> sp.as_staypoints.generate_locations(method='dbscan', epsilon=100, num_samples=1)
+    >>> sp.generate_locations(method='dbscan', epsilon=100, num_samples=1)
     """
     Staypoints.validate(staypoints)
     if agg_level not in ["user", "dataset"]:
@@ -200,13 +200,13 @@ def _gen_locs_dbscan(sp, distance_metric, db):
 
     Parameters
     ----------
-    sp : GeoDataFrame (as trackintel staypoints)
+    sp : Staypoints
     distance_metric : str
     db : sklearn.cluster.DBSCAN
 
     Returns
     -------
-    sp : GeoDataFrame (as trackintel staypoints)
+    sp : Staypoints
         Staypoints with new column "location_id"
     """
     p = np.array([sp.geometry.x, sp.geometry.y]).transpose()
@@ -223,10 +223,10 @@ def merge_staypoints(staypoints, triplegs, max_time_gap="10min", agg={}):
 
     Parameters
     ----------
-    staypoints : GeoDataFrame (as trackintel staypoints)
+    staypoints : Staypoints
         The staypoints must contain a column `location_id` (see `generate_locations` function)
 
-    triplegs: GeoDataFrame (as trackintel triplegs)
+    triplegs: Triplegs
 
     max_time_gap : str or pd.Timedelta, default "10min"
         Maximum duration between staypoints to still be merged.
@@ -242,7 +242,7 @@ def merge_staypoints(staypoints, triplegs, max_time_gap="10min", agg={}):
 
     Returns
     -------
-    sp: GeoDataFrame (as trackintel staypoints)
+    sp: Staypoints
         The new staypoints with the default columns and columns in `agg`, where staypoints at same location and close in
         time are aggregated.
 
@@ -260,7 +260,7 @@ def merge_staypoints(staypoints, triplegs, max_time_gap="10min", agg={}):
     >>> # direct function call
     >>> ti.preprocessing.staypoints.merge_staypoints(staypoints=sp, triplegs=tpls)
     >>> # or using the trackintel datamodel
-    >>> sp.as_staypoints.merge_staypoints(triplegs, max_time_gap="1h", agg={"geom":"first"})
+    >>> sp.merge_staypoints(triplegs, max_time_gap="1h", agg={"geom":"first"})
     """
     if isinstance(max_time_gap, str):
         max_time_gap = pd.to_timedelta(max_time_gap)

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -15,9 +15,9 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
 
     Parameters
     ----------
-    staypoints : GeoDataFrame (as trackintel staypoints)
+    staypoints : Staypoints
 
-    triplegs : GeoDataFrame (as trackintel triplegs)
+    triplegs : Triplegs
 
     gap_threshold : float, default 15 (minutes)
         Maximum allowed temporal gap size in minutes. If tracking data is missing for more than
@@ -32,13 +32,13 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
 
     Returns
     -------
-    sp: GeoDataFrame (as trackintel staypoints)
+    sp: Staypoints
         The original staypoints with new columns ``[`trip_id`, `prev_trip_id`, `next_trip_id`]``.
 
-    tpls: GeoDataFrame (as trackintel triplegs)
+    tpls: Triplegs
         The original triplegs with a new column ``[`trip_id`]``.
 
-    trips: (Geo)DataFrame (as trackintel trips)
+    trips: Trips
         The generated trips.
 
     Notes
@@ -65,7 +65,7 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
     >>> staypoints, triplegs, trips = generate_trips(staypoints, triplegs)
 
     trips can also be directly generated using the tripleg accessor
-    >>> staypoints, triplegs, trips = triplegs.as_triplegs.generate_trips(staypoints)
+    >>> staypoints, triplegs, trips = triplegs.generate_trips(staypoints)
     """
     Triplegs.validate(triplegs)
     Staypoints.validate(staypoints)
@@ -233,8 +233,8 @@ def _concat_staypoints_triplegs(staypoints, triplegs, add_geometry):
 
     Parameters
     ----------
-    staypoints : GeoDataFrame (as trackintel staypoints)
-    triplegs : GeoDataFrame (as trackintel triplegs)
+    staypoints : Staypoints
+    triplegs : Triplegs
     add_geometry : bool
 
     Returns

--- a/trackintel/preprocessing/trips.py
+++ b/trackintel/preprocessing/trips.py
@@ -15,10 +15,10 @@ def get_trips_grouped(trips, tours):
 
     Parameters
     ----------
-    trips: GeoDataFrame (as trackintel trips)
+    trips: Trips
         Trips dataframe
 
-    tours: GeoDataFrame (as trackintel tours)
+    tours: Tours
         Output of generate_tours function, must contain column "trips" with list of trip ids on tour
 
     Returns
@@ -65,9 +65,9 @@ def generate_tours(
 
     Parameters
     ----------
-    trips : GeoDataFrame (as trackintel trips)
+    trips : Trips
 
-    staypoints : GeoDataFrame (as trackintel staypoints), optional
+    staypoints : Staypoints, default None
         Must have `location_id` column to connect trips via locations to a tour.
         If None, trips will be connected based only by the set distance threshold `max_dist`.
 
@@ -87,15 +87,15 @@ def generate_tours(
 
     Returns
     -------
-    trips_with_tours: GeoDataFrame (as trackintel trips)
+    trips_with_tours: Trips
         Same as `trips`, but with column `tour_id`, containing a list of the tours that the trip is part of (see notes).
 
-    tours: GeoDataFrame (as trackintel tours)
+    tours: Tours
         The generated tours
 
     Examples
     --------
-    >>> trips.as_trips.generate_tours(staypoints)
+    >>> trips.generate_tours(staypoints)
 
     Notes
     -------
@@ -201,13 +201,12 @@ def _generate_tours_user(
 
     Parameters
     ----------
-    user_trip_df : GeoDataFrame (as trackintel trips)
+    user_trip_df : Trips
         The trips have to follow the standard definition for trips DataFrames
 
-    staypoints : GeoDataFrame (as trackintel staypoints, preprocessed to contain location IDs), default None
-        The staypoints have to follow the standard definition for staypoints DataFrames. The location ID column
-        is necessary to connect trips via locations to a tour. If None, trips will be connected based only on a
-        distance threshold `max_dist`.
+    staypoints : Staypoints, optional
+        Must contain location ID column to connect trips via locations to a tour.
+        If None, trips will be connected based only on a distance threshold `max_dist`.
 
     max_dist: float, default 100 (meters)
         Maximum distance between the end point of one trip and the start point of the next trip on a tour.

--- a/trackintel/visualization/plotting.py
+++ b/trackintel/visualization/plotting.py
@@ -177,10 +177,10 @@ def _prepare_frames(positionfixes, staypoints, triplegs, locations):
 
     Parameters
     ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
-    staypoints : GeoDataFrame (as trackintel staypoints)
-    triplegs : GeoDataFrame (as trackintel triplegs)
-    locations : GeoDataFrame (as trackintel locations)
+    positionfixes : Positionfixes
+    staypoints : Staypoints
+    triplegs : Triplegs
+    locations : Locations
 
     Returns
     -------
@@ -203,10 +203,10 @@ def _calculate_bounds(positionfixes, staypoints, triplegs, locations):
 
     Parameters
     ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
-    staypoints : GeoDataFrame (as trackintel staypoints)
-    triplegs : GeoDataFrame (as trackintel triplegs)
-    locations : GeoDataFrame (as trackintel locations)
+    positionfixes : Positionfixes
+    staypoints : Staypoints
+    triplegs : Triplegs
+    locations : Locations
 
     Returns
     -------
@@ -244,10 +244,10 @@ def _plot_frames(positionfixes, staypoints, triplegs, locations, radius_sp, radi
 
     Parameters
     ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes)
-    staypoints : GeoDataFrame (as trackintel staypoints)
-    triplegs : GeoDataFrame (as trackintel triplegs)
-    locations : GeoDataFrame (as trackintel locations)
+    positionfixes : Positionfixes
+    staypoints : Staypoints
+    triplegs : Triplegs
+    locations : Locations
     radius_sp : float
     radius_locs : float
     ax : matplotlib.pyplot.Artist
@@ -292,13 +292,13 @@ def plot(
 
     Parameters
     ----------
-    positionfixes : GeoDataFrame (as trackintel positionfixes), optional
+    positionfixes : Positionfixes, optional
         Positionfixes to plot, by default None
-    staypoints : GeoDataFrame (as trackintel staypoints), optional
+    staypoints : Staypoints, optional
         Staypoints to plot, by default None
-    triplegs : GeoDataFrame (as trackintel triplegs), optional
+    triplegs : Triplegs, optional
         Triplegs to plot, by default None
-    locations : GeoDataFrame (as trackintel locations), optional
+    locations : Locations, optional
         Locations to plot, by default None
     radius_sp : float, optional
         Radius in meter for circles around staypoints, default 100


### PR DESCRIPTION
Closes #532 
I replaced in all public visible code sections `as_xyz` with their respective method calls.
Also updated the tutorial minimally to reflect the new class change.
Further the documentation strings `(Geo)DataFrame (as xyz)` got replaced with their respective Trackintel class.
After this #529 should be next.