### PR TITLE
ENH: Reexport functions from modules

### DIFF
--- a/benchmarks/preprocessing_benchmarks.py
+++ b/benchmarks/preprocessing_benchmarks.py
@@ -86,7 +86,7 @@ class BM_Generate_TRIPS:
 
     def common_func(self):
         """Generate Trips"""
-        _, _, trips = ti.preprocessing.triplegs.generate_trips(self.sp, self.tpls)
+        _, _, trips = ti.preprocessing.generate_trips(self.sp, self.tpls)
         return trips
 
     def time_gen_trips_geolife_long(self):
@@ -109,11 +109,11 @@ class BM_Generate_TOURS:
         pfs, sp = pfs.as_positionfixes.generate_staypoints(method="sliding", dist_threshold=25, time_threshold=5)
         pfs, tpls = pfs.as_positionfixes.generate_triplegs(sp, method="between_staypoints")
         sp = sp.as_staypoints.create_activity_flag(time_threshold=15)
-        _, _, self.trips = ti.preprocessing.triplegs.generate_trips(sp, tpls)
+        _, _, self.trips = ti.preprocessing.generate_trips(sp, tpls)
 
     def common_func(self):
         """Generate Tours"""
-        _, tours = ti.preprocessing.trips.generate_tours(self.trips, max_dist=100)
+        _, tours = ti.preprocessing.generate_tours(self.trips, max_dist=100)
         return tours
 
     def time_gen_tours_geolife_long(self):

--- a/docs/modules/analysis.rst
+++ b/docs/modules/analysis.rst
@@ -7,30 +7,30 @@ datasets computed by trackintel.
 Labelling
 =========
 
-.. autofunction:: trackintel.analysis.labelling.create_activity_flag
+.. autofunction:: trackintel.analysis.create_activity_flag
 
-.. autofunction:: trackintel.analysis.labelling.predict_transport_mode
+.. autofunction:: trackintel.analysis.predict_transport_mode
 
 Tracking Quality
 ================
 
-.. autofunction:: trackintel.analysis.tracking_quality.temporal_tracking_quality
+.. autofunction:: trackintel.analysis.temporal_tracking_quality
 
 Modal Split
 ===========
 
-.. autofunction:: trackintel.analysis.modal_split.calculate_modal_split
+.. autofunction:: trackintel.analysis.calculate_modal_split
 
 Location Identification
 =======================
 
-.. autofunction:: trackintel.analysis.location_identification.location_identifier
+.. autofunction:: trackintel.analysis.location_identifier
 
-.. autofunction:: trackintel.analysis.location_identification.pre_filter_locations
+.. autofunction:: trackintel.analysis.pre_filter_locations
 
-.. autofunction:: trackintel.analysis.location_identification.freq_method
+.. autofunction:: trackintel.analysis.freq_method
 
-.. autofunction:: trackintel.analysis.location_identification.osna_method
+.. autofunction:: trackintel.analysis.osna_method
 
 Metrics
 =======

--- a/docs/modules/geogr.rst
+++ b/docs/modules/geogr.rst
@@ -4,16 +4,16 @@ Geography Utils
 To make handling of mobility and geodata easier, *trackintel* features several geographic utility functions and
 distance functions for points and trajectories
 
-.. autofunction:: trackintel.geogr.distances.point_haversine_dist
+.. autofunction:: trackintel.geogr.point_haversine_dist
 
-.. autofunction:: trackintel.geogr.distances.calculate_distance_matrix
+.. autofunction:: trackintel.geogr.calculate_distance_matrix
 
-.. autofunction:: trackintel.geogr.distances.meters_to_decimal_degrees
+.. autofunction:: trackintel.geogr.meters_to_decimal_degrees
 
-.. autofunction:: trackintel.geogr.distances.check_gdf_planar
+.. autofunction:: trackintel.geogr.check_gdf_planar
 
-.. autofunction:: trackintel.geogr.distances.calculate_haversine_length
+.. autofunction:: trackintel.geogr.calculate_haversine_length
 
-.. autofunction:: trackintel.geogr.distances.get_speed_positionfixes
+.. autofunction:: trackintel.geogr.get_speed_positionfixes
 
-.. autofunction:: trackintel.geogr.distances.get_speed_triplegs
+.. autofunction:: trackintel.geogr.get_speed_triplegs

--- a/docs/modules/io.rst
+++ b/docs/modules/io.rst
@@ -20,78 +20,78 @@ and ``**kwargs`` are forwarded to them.
 CSV File Import
 ===============
 
-.. autofunction:: trackintel.io.file.read_positionfixes_csv
+.. autofunction:: trackintel.io.read_positionfixes_csv
 
-.. autofunction:: trackintel.io.file.read_triplegs_csv
+.. autofunction:: trackintel.io.read_triplegs_csv
 
-.. autofunction:: trackintel.io.file.read_staypoints_csv
+.. autofunction:: trackintel.io.read_staypoints_csv
 
-.. autofunction:: trackintel.io.file.read_locations_csv
+.. autofunction:: trackintel.io.read_locations_csv
 
-.. autofunction:: trackintel.io.file.read_trips_csv
+.. autofunction:: trackintel.io.read_trips_csv
 
-.. autofunction:: trackintel.io.file.read_tours_csv
+.. autofunction:: trackintel.io.read_tours_csv
 
 GeoDataFrame Import
 =============================
 
-.. autofunction:: trackintel.io.from_geopandas.read_positionfixes_gpd
+.. autofunction:: trackintel.io.read_positionfixes_gpd
 
-.. autofunction:: trackintel.io.from_geopandas.read_triplegs_gpd
+.. autofunction:: trackintel.io.read_triplegs_gpd
 
-.. autofunction:: trackintel.io.from_geopandas.read_staypoints_gpd
+.. autofunction:: trackintel.io.read_staypoints_gpd
 
-.. autofunction:: trackintel.io.from_geopandas.read_locations_gpd
+.. autofunction:: trackintel.io.read_locations_gpd
 
-.. autofunction:: trackintel.io.from_geopandas.read_trips_gpd
+.. autofunction:: trackintel.io.read_trips_gpd
 
-.. autofunction:: trackintel.io.from_geopandas.read_tours_gpd
+.. autofunction:: trackintel.io.read_tours_gpd
 
 
 PostGIS Import
 ==============
 
-.. autofunction:: trackintel.io.postgis.read_positionfixes_postgis
+.. autofunction:: trackintel.io.read_positionfixes_postgis
 
-.. autofunction:: trackintel.io.postgis.read_triplegs_postgis
+.. autofunction:: trackintel.io.read_triplegs_postgis
 
-.. autofunction:: trackintel.io.postgis.read_staypoints_postgis
+.. autofunction:: trackintel.io.read_staypoints_postgis
 
-.. autofunction:: trackintel.io.postgis.read_locations_postgis
+.. autofunction:: trackintel.io.read_locations_postgis
 
-.. autofunction:: trackintel.io.postgis.read_trips_postgis
+.. autofunction:: trackintel.io.read_trips_postgis
 
-.. autofunction:: trackintel.io.postgis.read_tours_postgis
+.. autofunction:: trackintel.io.read_tours_postgis
 
 CSV File Export
 ===============
 
-.. autofunction:: trackintel.io.file.write_positionfixes_csv
+.. autofunction:: trackintel.io.write_positionfixes_csv
 
-.. autofunction:: trackintel.io.file.write_triplegs_csv
+.. autofunction:: trackintel.io.write_triplegs_csv
 
-.. autofunction:: trackintel.io.file.write_staypoints_csv
+.. autofunction:: trackintel.io.write_staypoints_csv
 
-.. autofunction:: trackintel.io.file.write_locations_csv
+.. autofunction:: trackintel.io.write_locations_csv
 
-.. autofunction:: trackintel.io.file.write_trips_csv
+.. autofunction:: trackintel.io.write_trips_csv
 
-.. autofunction:: trackintel.io.file.write_tours_csv
+.. autofunction:: trackintel.io.write_tours_csv
 
 PostGIS Export
 ==============
 
-.. autofunction:: trackintel.io.postgis.write_positionfixes_postgis
+.. autofunction:: trackintel.io.write_positionfixes_postgis
 
-.. autofunction:: trackintel.io.postgis.write_triplegs_postgis
+.. autofunction:: trackintel.io.write_triplegs_postgis
 
-.. autofunction:: trackintel.io.postgis.write_staypoints_postgis
+.. autofunction:: trackintel.io.write_staypoints_postgis
 
-.. autofunction:: trackintel.io.postgis.write_locations_postgis
+.. autofunction:: trackintel.io.write_locations_postgis
 
-.. autofunction:: trackintel.io.postgis.write_trips_postgis
+.. autofunction:: trackintel.io.write_trips_postgis
 
-.. autofunction:: trackintel.io.postgis.write_tours_postgis
+.. autofunction:: trackintel.io.write_tours_postgis
 
 Predefined dataset readers
 ==========================
@@ -101,6 +101,6 @@ Geolife
 -----------
 We support easy parsing of the Geolife dataset including available mode labels.
 
-.. autofunction:: trackintel.io.dataset_reader.read_geolife
+.. autofunction:: trackintel.io.read_geolife
 
-.. autofunction:: trackintel.io.dataset_reader.geolife_add_modes_to_triplegs
+.. autofunction:: trackintel.io.geolife_add_modes_to_triplegs

--- a/docs/modules/model.rst
+++ b/docs/modules/model.rst
@@ -59,37 +59,37 @@ The following accessors are available within *trackintel*.
 Positionfixes
 ---------------------
 
-.. autoclass:: trackintel.model.positionfixes.Positionfixes
+.. autoclass:: trackintel.Positionfixes
 	:members:
 
 Staypoints
 ------------------
 
-.. autoclass:: trackintel.model.staypoints.Staypoints
+.. autoclass:: trackintel.Staypoints
 	:members:
 
 Triplegs
 ----------------
 
-.. autoclass:: trackintel.model.triplegs.Triplegs
+.. autoclass:: trackintel.Triplegs
 	:members:
 
 Locations
 -----------------
 
-.. autoclass:: trackintel.model.locations.Locations
+.. autoclass:: trackintel.Locations
 	:members:
 
 Trips
 -------------
 
-.. autoclass:: trackintel.model.trips.Trips
+.. autoclass:: trackintel.Trips
 	:members:
 
 Tours
 -------------
 
-.. autoclass:: trackintel.model.tours.Tours
+.. autoclass:: trackintel.Tours
 	:members:
 
 

--- a/docs/modules/preprocessing.rst
+++ b/docs/modules/preprocessing.rst
@@ -6,7 +6,7 @@ data into richer data sources.
 
 Filtering
 =============
-.. autofunction:: trackintel.preprocessing.filter.spatial_filter
+.. autofunction:: trackintel.preprocessing.spatial_filter
 
 
 Positionfixes
@@ -18,9 +18,9 @@ turn it into a higher-level *trackintel* data structure).
 
 In particular, we can generate staypoints and triplegs from positionfixes.
 
-.. autofunction:: trackintel.preprocessing.positionfixes.generate_staypoints
+.. autofunction:: trackintel.preprocessing.generate_staypoints
 
-.. autofunction:: trackintel.preprocessing.positionfixes.generate_triplegs
+.. autofunction:: trackintel.preprocessing.generate_triplegs
 
 Staypoints
 ==========
@@ -29,12 +29,12 @@ Staypoints are points where someone stayed for a longer period of time (e.g., du
 transfer between two transport modes). We can cluster these into locations that a user 
 frequently visits and/or infer if they correspond to activities.
 
-.. autofunction:: trackintel.preprocessing.staypoints.generate_locations
+.. autofunction:: trackintel.preprocessing.generate_locations
 
 Due to tracking artifacts, it can occur that one activity is split into several staypoints. 
 We can aggregate the staypoints horizontally that are close in time and at the same location.
 
-.. autofunction:: trackintel.preprocessing.staypoints.merge_staypoints
+.. autofunction:: trackintel.preprocessing.merge_staypoints
 
 Triplegs
 ========
@@ -60,7 +60,7 @@ Trips denote the sequence of all triplegs between two consecutive activities. Th
 of transports. A further aggregation of Trips are Tours, which is a sequence of trips such that it starts and ends
 at the same location. Using the trips, we can generate tours.
 
-.. autofunction:: trackintel.preprocessing.trips.generate_tours
+.. autofunction:: trackintel.preprocessing.generate_tours
 
 Trips and Tours have an n:n relationship: One tour consists of multiple trips, but due to nested or overlapping tours,
 one trip can also be part of mulitple tours. A helper function can be used to get the trips grouped by tour.

--- a/docs/modules/visualization.rst
+++ b/docs/modules/visualization.rst
@@ -7,7 +7,7 @@ intermediate and final datasets within trackintel.
 plot
 =============
 
-.. autofunction:: trackintel.visualization.plot
+.. autofunction:: trackintel.plot
 
 .. image:: /_static/example_locations.png
    :scale: 25 %
@@ -16,7 +16,7 @@ plot
 Modal split
 ===========
 
-.. autofunction:: trackintel.visualization.plot_modal_split
+.. autofunction:: trackintel.plot_modal_split
 
 .. image:: /_static/example_modal_split_geolife.png
    :scale: 18 %

--- a/examples/trackintel_basic_tutorial.ipynb
+++ b/examples/trackintel_basic_tutorial.ipynb
@@ -211,7 +211,7 @@
     "sp = sp.create_activity_flag(time_threshold=15)\n",
     "\n",
     "# generate trips with triplegs and staypoints with activity labels\n",
-    "sp, tpls, trips = ti.preprocessing.triplegs.generate_trips(sp, tpls, gap_threshold=15)\n",
+    "sp, tpls, trips = ti.preprocessing.generate_trips(sp, tpls, gap_threshold=15)\n",
     "\n",
     "trips.head(5)"
    ]

--- a/trackintel/analysis/location_identification.py
+++ b/trackintel/analysis/location_identification.py
@@ -44,7 +44,7 @@ def location_identifier(staypoints, method="FREQ", pre_filter=True, **pre_filter
 
     Examples
     --------
-    >>> from ti.analysis.location_identification import location_identifier
+    >>> from ti.analysis import location_identifier
     >>> location_identifier(staypoints, pre_filter=True, method="FREQ")
     """
     sp = staypoints.copy()
@@ -117,7 +117,7 @@ def pre_filter_locations(
 
     Examples
     --------
-    >>> from ti.analysis.location_identification import pre_filter_locations
+    >>> from ti.analysis import pre_filter_locations
     >>> mask = pre_filter_locations(staypoints)
     >>> staypoints = staypoints[mask]
     """
@@ -185,7 +185,7 @@ def freq_method(staypoints, *labels):
 
     Examples
     --------
-    >>> from ti.analysis.location_identification import freq_method
+    >>> from ti.analysis import freq_method
     >>> staypoints = freq_method(staypoints, "home", "work")
     """
     sp = staypoints.copy()
@@ -273,7 +273,7 @@ def osna_method(staypoints):
 
     Examples
     --------
-    >>> from ti.analysis.location_identification import osna_method
+    >>> from ti.analysis import osna_method
     >>> staypoints = osna_method(staypoints)
     """
     sp_in = staypoints  # no copy --> used to join back later.

--- a/trackintel/analysis/modal_split.py
+++ b/trackintel/analysis/modal_split.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from trackintel.geogr.distances import check_gdf_planar, calculate_haversine_length
+from trackintel.geogr import check_gdf_planar, calculate_haversine_length
 
 
 def calculate_modal_split(tpls, freq=None, metric="count", per_user=False, norm=False):
@@ -34,7 +34,7 @@ def calculate_modal_split(tpls, freq=None, metric="count", per_user=False, norm=
     ------
         `freq='W-MON'` is used for a weekly aggregation that starts on mondays.
         If `freq=None` and `per_user=False` are passed the modal split collapses to a single column.
-        The modal split can be visualized using :func:`trackintel.visualization.plot_modal_split`
+        The modal split can be visualized using :func:`trackintel.plot_modal_split`
 
     Examples
     --------

--- a/trackintel/geogr/__init__.py
+++ b/trackintel/geogr/__init__.py
@@ -1,5 +1,6 @@
 from .distances import calculate_distance_matrix
 from .distances import calculate_haversine_length
+from .distances import meters_to_decimal_degrees
 from .distances import point_haversine_dist
 from .distances import get_speed_positionfixes
 from .distances import get_speed_triplegs
@@ -8,6 +9,7 @@ from .distances import check_gdf_planar
 __all__ = [
     "calculate_distance_matrix",
     "calculate_haversine_length",
+    "meters_to_decimal_degrees",
     "point_haversine_dist",
     "get_speed_positionfixes",
     "get_speed_triplegs",

--- a/trackintel/io/dataset_reader.py
+++ b/trackintel/io/dataset_reader.py
@@ -92,7 +92,7 @@ def read_geolife(geolife_path, print_progress=False):
 
     Example
     ----------
-    >>> from trackintel.io.dataset_reader import read_geolife
+    >>> from trackintel.io import read_geolife
     >>> pfs, mode_labels = read_geolife(os.path.join('downloads', 'Geolife Trajectories 1.3'))
     """
     # u are strings in the format "052", "002".
@@ -232,7 +232,7 @@ def geolife_add_modes_to_triplegs(
 
     Example
     ----------
-    >>> from trackintel.io.dataset_reader import read_geolife, geolife_add_modes_to_triplegs
+    >>> from trackintel.io import read_geolife, geolife_add_modes_to_triplegs
     >>> pfs, mode_labels = read_geolife(os.path.join('downloads', 'Geolife Trajectories 1.3'))
     >>> pfs, sp = pfs.generate_staypoints()
     >>> pfs, tpls = pfs.generate_triplegs(sp)

--- a/trackintel/io/file.py
+++ b/trackintel/io/file.py
@@ -60,7 +60,7 @@ def read_positionfixes_csv(*args, columns=None, tz=None, index_col=None, geom_co
     Note that this function is primarily useful if data is available in a
     longitude/latitude format. If your data already contains a WKT column,
     might be easier to just use the GeoPandas import functions
-    :func:`trackintel.io.from_geopandas.read_positionfixes_gpd`.
+    :func:`trackintel.io.read_positionfixes_gpd`.
 
     Examples
     --------

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -58,13 +58,13 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
 
     @doc(_shared_docs["write_csv"], first_arg="", long="locations", short="locs")
     def to_csv(self, filename, *args, **kwargs):
-        ti.io.file.write_locations_csv(self, filename, *args, **kwargs)
+        ti.io.write_locations_csv(self, filename, *args, **kwargs)
 
     @doc(_shared_docs["write_postgis"], first_arg="", long="locations", short="locs")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        ti.io.postgis.write_locations_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
+        ti.io.write_locations_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
     def spatial_filter(self, areas, method="within", re_project=False):
         """

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -100,7 +100,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
 
         See :func:`trackintel.preprocessing.generate_staypoints` for full documentation.
         """
-        return ti.preprocessing.positionfixes.generate_staypoints(
+        return ti.preprocessing.generate_staypoints(
             self,
             method=method,
             distance_metric=distance_metric,
@@ -125,7 +125,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
 
         See :func:`trackintel.preprocessing.generate_triplegs` for full documentation.
         """
-        return ti.preprocessing.positionfixes.generate_triplegs(
+        return ti.preprocessing.generate_triplegs(
             self,
             staypoints=staypoints,
             method=method,
@@ -139,15 +139,13 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
 
         See :func:`trackintel.io.write_positionfixes_csv` for full documentation.
         """
-        ti.io.file.write_positionfixes_csv(self, filename, *args, **kwargs)
+        ti.io.write_positionfixes_csv(self, filename, *args, **kwargs)
 
     @doc(_shared_docs["write_postgis"], first_arg="", long="positionfixes", short="pfs")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        ti.io.postgis.write_positionfixes_postgis(
-            self, name, con, schema, if_exists, index, index_label, chunksize, dtype
-        )
+        ti.io.write_positionfixes_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
     def calculate_distance_matrix(self, Y=None, dist_metric="haversine", n_jobs=0, **kwds):
         """
@@ -155,7 +153,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
 
         See :func:`trackintel.geogr.calculate_distance_matrix` for full documentation.
         """
-        return ti.geogr.distances.calculate_distance_matrix(self, Y=Y, dist_metric=dist_metric, n_jobs=n_jobs, **kwds)
+        return ti.geogr.calculate_distance_matrix(self, Y=Y, dist_metric=dist_metric, n_jobs=n_jobs, **kwds)
 
     def get_speed(self):
         """
@@ -163,4 +161,4 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
 
         See :func:`trackintel.geogr.get_speed_positionfixes` for full documentation.
         """
-        return ti.geogr.distances.get_speed_positionfixes(self)
+        return ti.geogr.get_speed_positionfixes(self)

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -99,7 +99,7 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
 
         See :func:`trackintel.preprocessing.generate_locations` for full documentation.
         """
-        return ti.preprocessing.staypoints.generate_locations(
+        return ti.preprocessing.generate_locations(
             self,
             method=method,
             epsilon=epsilon,
@@ -115,9 +115,9 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
         """
         Aggregate staypoints horizontally via time threshold.
 
-        See :func:`trackintel.preprocessing.staypoints.merge_staypoints` for full documentation.
+        See :func:`trackintel.preprocessing.merge_staypoints` for full documentation.
         """
-        return ti.preprocessing.staypoints.merge_staypoints(self, triplegs, max_time_gap=max_time_gap, agg=agg)
+        return ti.preprocessing.merge_staypoints(self, triplegs, max_time_gap=max_time_gap, agg=agg)
 
     def create_activity_flag(self, method="time_threshold", time_threshold=15.0, activity_column_name="is_activity"):
         """
@@ -139,13 +139,13 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
 
     @doc(_shared_docs["write_csv"], first_arg="", long="staypoints", short="sp")
     def to_csv(self, filename, *args, **kwargs):
-        ti.io.file.write_staypoints_csv(self, filename, *args, **kwargs)
+        ti.io.write_staypoints_csv(self, filename, *args, **kwargs)
 
     @doc(_shared_docs["write_postgis"], first_arg="", long="staypoints", short="sp")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        ti.io.postgis.write_staypoints_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
+        ti.io.write_staypoints_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
     def temporal_tracking_quality(self, granularity="all"):
         """
@@ -153,7 +153,7 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
 
         See :func:`trackintel.analysis.temporal_tracking_quality` for full documentation.
         """
-        return ti.analysis.tracking_quality.temporal_tracking_quality(self, granularity=granularity)
+        return ti.analysis.temporal_tracking_quality(self, granularity=granularity)
 
     def generate_trips(self, triplegs, gap_threshold=15, add_geometry=True):
         """
@@ -161,9 +161,7 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
 
         See :func:`trackintel.preprocessing.generate_triplegs` for full documentation.
         """
-        return ti.preprocessing.triplegs.generate_trips(
-            self, triplegs, gap_threshold=gap_threshold, add_geometry=add_geometry
-        )
+        return ti.preprocessing.generate_trips(self, triplegs, gap_threshold=gap_threshold, add_geometry=add_geometry)
 
     def radius_gyration(self, method="count", print_progress=False):
         """

--- a/trackintel/model/tours.py
+++ b/trackintel/model/tours.py
@@ -64,10 +64,10 @@ class Tours(TrackintelBase, TrackintelDataFrame):
 
     @doc(_shared_docs["write_csv"], first_arg="", long="tours", short="tours")
     def to_csv(self, filename, *args, **kwargs):
-        ti.io.file.write_tours_csv(self, filename, *args, **kwargs)
+        ti.io.write_tours_csv(self, filename, *args, **kwargs)
 
     @doc(_shared_docs["write_postgis"], first_arg="", long="tours", short="tours")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        ti.io.postgis.write_tours_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
+        ti.io.write_tours_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -76,13 +76,13 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
 
     @doc(_shared_docs["write_csv"], first_arg="", long="triplegs", short="tpls")
     def to_csv(self, filename, *args, **kwargs):
-        ti.io.file.write_triplegs_csv(self, filename, *args, **kwargs)
+        ti.io.write_triplegs_csv(self, filename, *args, **kwargs)
 
     @doc(_shared_docs["write_postgis"], first_arg="", long="triplegs", short="tpls")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        ti.io.postgis.write_triplegs_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
+        ti.io.write_triplegs_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
     def calculate_distance_matrix(self, Y=None, dist_metric="haversine", n_jobs=0, **kwds):
         """
@@ -98,7 +98,7 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
 
         See :func:`trackintel.preprocessing.spatial_filter` for full documentation.
         """
-        return ti.preprocessing.filter.spatial_filter(self, areas, method=method, re_project=re_project)
+        return ti.preprocessing.spatial_filter(self, areas, method=method, re_project=re_project)
 
     def generate_trips(self, staypoints, gap_threshold=15, add_geometry=True):
         """
@@ -106,17 +106,15 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
 
         See :func:`trackintel.preprocessing.generate_triplegs` for full documentation.
         """
-        return ti.preprocessing.triplegs.generate_trips(
-            staypoints, self, gap_threshold=gap_threshold, add_geometry=add_geometry
-        )
+        return ti.preprocessing.generate_trips(staypoints, self, gap_threshold=gap_threshold, add_geometry=add_geometry)
 
     def predict_transport_mode(self, method="simple-coarse", **kwargs):
         """
         Predict the transport mode of triplegs.
 
-        See :func:`trackintel.analysis.labelling.predict_transport_mode` for full documentation.
+        See :func:`trackintel.analysis.predict_transport_mode` for full documentation.
         """
-        return ti.analysis.labelling.predict_transport_mode(self, method=method, **kwargs)
+        return ti.analysis.predict_transport_mode(self, method=method, **kwargs)
 
     def calculate_modal_split(self, freq=None, metric="count", per_user=False, norm=False):
         """

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -112,13 +112,13 @@ class TripsDataFrame(TrackintelBase, TrackintelDataFrame):
 
     @doc(_shared_docs["write_csv"], first_arg="", long="trips", short="trips")
     def to_csv(self, filename, *args, **kwargs):
-        ti.io.file.write_trips_csv(self, filename, *args, **kwargs)
+        ti.io.write_trips_csv(self, filename, *args, **kwargs)
 
     @doc(_shared_docs["write_postgis"], first_arg="", long="trips", short="trips")
     def to_postgis(
         self, name, con, schema=None, if_exists="fail", index=True, index_label=None, chunksize=None, dtype=None
     ):
-        ti.io.postgis.write_trips_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
+        ti.io.write_trips_postgis(self, name, con, schema, if_exists, index, index_label, chunksize, dtype)
 
     def temporal_tracking_quality(self, granularity="all"):
         """
@@ -134,7 +134,7 @@ class TripsDataFrame(TrackintelBase, TrackintelDataFrame):
 
         See :func:`trackintel.preprocessing.generate_tours` for full documentation.
         """
-        return ti.preprocessing.trips.generate_tours(trips=self, **kwargs)
+        return ti.preprocessing.generate_tours(trips=self, **kwargs)
 
 
 # added GeoDataFrame manually afterwards such that our methods always come first

--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -204,7 +204,7 @@ dtype: dict of column name to SQL type, default None
 Examples
 --------
 >>> {short}.to_postgis(conn_string, table_name)
->>> ti.io.postgis.write_{long}_postgis({short}, conn_string, table_name)
+>>> ti.io.write_{long}_postgis({short}, conn_string, table_name)
 """
 
 _shared_docs[

--- a/trackintel/preprocessing/__init__.py
+++ b/trackintel/preprocessing/__init__.py
@@ -4,6 +4,7 @@ from .positionfixes import generate_triplegs
 from .filter import spatial_filter
 
 from .staypoints import generate_locations
+from .staypoints import merge_staypoints
 
 from .triplegs import generate_trips
 
@@ -14,6 +15,7 @@ __all__ = [
     "generate_triplegs",
     "spatial_filter",
     "generate_locations",
+    "merge_staypoints",
     "generate_trips",
     "generate_tours",
 ]

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -5,7 +5,7 @@ from sklearn.cluster import DBSCAN
 import warnings
 
 from trackintel import Staypoints, Locations
-from trackintel.geogr.distances import meters_to_decimal_degrees, check_gdf_planar
+from trackintel.geogr import meters_to_decimal_degrees, check_gdf_planar
 from trackintel.preprocessing.util import applyParallel, angle_centroid_multipoints
 
 
@@ -260,7 +260,7 @@ def merge_staypoints(staypoints, triplegs, max_time_gap="10min", agg={}):
     Examples
     --------
     >>> # direct function call
-    >>> ti.preprocessing.staypoints.merge_staypoints(staypoints=sp, triplegs=tpls)
+    >>> ti.preprocessing.merge_staypoints(staypoints=sp, triplegs=tpls)
     >>> # or using the trackintel datamodel
     >>> sp.merge_staypoints(triplegs, max_time_gap="1h", agg={"geom":"first"})
     """

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -61,7 +61,7 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
 
     Examples
     --------
-    >>> from trackintel.preprocessing.triplegs import generate_trips
+    >>> from trackintel.preprocessing import generate_trips
     >>> staypoints, triplegs, trips = generate_trips(staypoints, triplegs)
 
     trips can also be directly generated using the tripleg accessor

--- a/trackintel/visualization/plotting.py
+++ b/trackintel/visualization/plotting.py
@@ -11,7 +11,7 @@ from networkx.exception import NetworkXPointlessConcept
 from pandas.api.types import is_datetime64_any_dtype
 from pint import UnitRegistry
 
-from trackintel.geogr.distances import check_gdf_planar, meters_to_decimal_degrees
+from trackintel.geogr import check_gdf_planar, meters_to_decimal_degrees
 
 
 def a4_figsize(fig_height_mm=None, columns=2):
@@ -150,7 +150,7 @@ def plot_osm_streets(north, south, east, west, ax):
 
     Examples
     --------
-    >>> ti.visualization.osm.plot_osm_street(47.392, 47.364, 8.557, 8.509, ax)
+    >>> ti.visualization.plotting.plot_osm_street(47.392, 47.364, 8.557, 8.509, ax)
     """
     try:
         G = ox.graph_from_bbox(north, south, east, west, network_type="drive")
@@ -355,7 +355,7 @@ def plot_modal_split(
     bar_kws=None,
 ):
     """
-    Plot modal split as returned by `trackintel.analysis.modal_split.calculate_modal_split`
+    Plot modal split as returned by `trackintel.analysis.calculate_modal_split`
 
     Parameters
     ----------


### PR DESCRIPTION
closes #546
Changed how we export and import functions.
This makes the module paths clearer and additionally all links in the documentation work now as well.