### PR TITLE
DOC: replace accessor docs with new class style

### DIFF
--- a/docs/modules/model.rst
+++ b/docs/modules/model.rst
@@ -39,22 +39,21 @@ GeoPandas Implementation
 
 .. highlight:: python
 
-In trackintel, we assume that all these classes are available as (Geo)Pandas (Geo)DataFrames. While we
-do not extend the given DataFrame constructs, we provide accessors that validate that a given DataFrame
-corresponds to a set of constraints, and make functions available on the DataFrames. For example::
+In trackintel we provide 5 classes that subclass DataFrames or GeoDataFrames, depending if there is a
+geometry or not. That means all trackintel classes work like (Geo)DataFrames with some additional features, 
+like: data validation and new methods for analyzing mobility data.
+For example::
 
     df = trackintel.read_positionfixes_csv('data.csv')
     df.generate_staypoints()
 
-This will read a CSV into a format compatible with the trackintel understanding of a collection of 
-positionfixes, and the second line will wrap the DataFrame with an accessor providing functions such 
-as ``generate_staypoints()``. You can read up more on Pandas accessors in `the Pandas documentation 
-<https://pandas.pydata.org/pandas-docs/stable/development/extending.html>`_.
+This will read a CSV into a `Positionfixes` trackintel class and validate the input data corresponding to
+our model. This allows access to the trackintel methods such as ``generate_staypoints()``.
 
-Available Accessors
+Trackintel Classes
 ===================
 
-The following accessors are available within *trackintel*.
+The following classes are implemented within *trackintel*.
 
 Positionfixes
 ---------------------

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -12,10 +12,7 @@ _required_columns = ["user_id", "center"]
 
 @_register_trackintel_accessor("as_locations")
 class Locations(TrackintelBase, TrackintelGeoDataFrame):
-    """A pandas accessor to treat a GeoDataFrames as a collections of locations.
-
-    This will define certain methods and accessors, as well as make sure that the DataFrame
-    adheres to some requirements.
+    """Trackintel class to treat a GeoDataFrames as a collections of locations.
 
     Requires at least the following columns:
     ['user_id', 'center']

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -15,10 +15,7 @@ _required_columns = ["user_id", "tracked_at"]
 
 @_register_trackintel_accessor("as_positionfixes")
 class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
-    """A pandas accessor to treat (Geo)DataFrames as collections of `Positionfixes`.
-
-    This will define certain methods and accessors, as well as make sure that the DataFrame
-    adheres to some requirements.
+    """Trackintel class to treat GeoDataFrames as collections of `Positionfixes`.
 
     Requires at least the following columns:
     ['user_id', 'tracked_at']

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -14,10 +14,7 @@ _required_columns = ["user_id", "started_at", "finished_at"]
 
 @_register_trackintel_accessor("as_staypoints")
 class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
-    """A pandas accessor to treat a GeoDataFrame as collections of `Staypoints`.
-
-    This will define certain methods and accessors, as well as make sure that the DataFrame
-    adheres to some requirements.
+    """Trackintel class to treat a GeoDataFrame as collections of `Staypoints`.
 
     Requires at least the following columns:
     ['user_id', 'started_at', 'finished_at']

--- a/trackintel/model/tours.py
+++ b/trackintel/model/tours.py
@@ -14,7 +14,7 @@ _required_columns = ["user_id", "started_at", "finished_at"]
 
 @_register_trackintel_accessor("as_tours")
 class Tours(TrackintelBase, TrackintelDataFrame):
-    """A pandas accessor to treat DataFrames as collections of `Tours`.
+    """Trackintel class to treat DataFrames as collections of `Tours`.
 
     Requires at least the following columns:
     ['user_id', 'started_at', 'finished_at']

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -14,10 +14,7 @@ _required_columns = ["user_id", "started_at", "finished_at"]
 
 @_register_trackintel_accessor("as_triplegs")
 class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
-    """A pandas accessor to treat a GeoDataFrame as a collections of `Tripleg`.
-
-    This will define certain methods and accessors, as well as make sure that the DataFrame
-    adheres to some requirements.
+    """Trackintel class to treat a GeoDataFrame as a collections of `Tripleg`.
 
     Requires at least the following columns:
     ['user_id', 'started_at', 'finished_at']

--- a/trackintel/model/trips.py
+++ b/trackintel/model/trips.py
@@ -14,7 +14,7 @@ from trackintel.model.util import (
 
 @_register_trackintel_accessor("as_trips")
 class Trips:
-    """Class to treat (Geo)DataFrames as collections of trips.
+    """Trackintel class to treat (Geo)DataFrames as collections of trips.
 
     The class constructor will create a TripsDataFrame or a TripsGeoDataFrame depending if a geometry column is present.
 

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -64,7 +64,7 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
     >>> from trackintel.preprocessing import generate_trips
     >>> staypoints, triplegs, trips = generate_trips(staypoints, triplegs)
 
-    trips can also be directly generated using the tripleg accessor
+    trips can also be directly generated using the tripleg class method
     >>> staypoints, triplegs, trips = triplegs.generate_trips(staypoints)
     """
     Triplegs.validate(triplegs)


### PR DESCRIPTION
closes #565 
With the new class style mentioning the pandas accessor thing will lead to confusion. 
So I removed it from all documentation. I've done it rather quickly, so if somebody would take a second look at my formulation, I would be really happy about that. :)