### PR TITLE
ENH: Add gpx reader for single user

### DIFF
--- a/docs/modules/io.rst
+++ b/docs/modules/io.rst
@@ -104,3 +104,10 @@ We support easy parsing of the Geolife dataset including available mode labels.
 .. autofunction:: trackintel.io.read_geolife
 
 .. autofunction:: trackintel.io.geolife_add_modes_to_triplegs
+
+
+GPX
+-----------
+Load multiple tracks of the same user with this function.
+
+.. autofunction:: trackintel.io.read_gpx

--- a/tests/data/gpx_data/track1.gpx
+++ b/tests/data/gpx_data/track1.gpx
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="HiWi" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+    <name>2023-11-08_15-56_Tue</name>
+    <time>2023-11-08T15:00:00Z</time>
+  </metadata>
+<trk>
+    <trkseg>
+      <trkpt lat="47.0" lon="8.0">
+        <ele>1000.0</ele>
+        <time>2023-11-08T10:00:00Z</time>
+        <hdop>10.0</hdop>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/tests/data/gpx_data/track2.gpx
+++ b/tests/data/gpx_data/track2.gpx
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="HiWi" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+    <name>2023-11-08_15-56_Tue</name>
+    <time>2023-11-08T15:00:00Z</time>
+  </metadata>
+<trk>
+    <trkseg>
+      <trkpt lat="48.0" lon="9.0">
+        <ele>1001.0</ele>
+        <time>2023-11-08T11:00:00Z</time>
+        <hdop>11.0</hdop>
+        <extensions> <!-- cannot be read by fiora -->
+          <osmand:speed>0.2</osmand:speed>
+        </extensions>
+      </trkpt>
+      <trkpt lat="49.0" lon="10.0">
+        <ele>1002.0</ele>
+        <time>2023-11-08T12:00:00Z</time>
+        <hdop>12.0</hdop>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/tests/io/test_dataset_reader.py
+++ b/tests/io/test_dataset_reader.py
@@ -7,7 +7,8 @@ from geopandas.testing import assert_geodataframe_equal
 from shapely.geometry import Point
 
 import trackintel as ti
-from trackintel.io.dataset_reader import _get_df, _get_labels, geolife_add_modes_to_triplegs, read_geolife
+from trackintel.io.dataset_reader import _get_df, _get_labels, geolife_add_modes_to_triplegs, read_geolife, read_gpx
+from trackintel import Positionfixes
 
 
 @pytest.fixture
@@ -244,3 +245,26 @@ class TestGeolife_add_modes_to_triplegs:
 
         tpls = geolife_add_modes_to_triplegs(tpls, labels)
         assert pd.isna(tpls.iloc[0]["mode"])
+
+
+class TestGpx_reader:
+    def test_simple_input(self):
+        """Test if gpx_reader works on simple input"""
+        pfs = read_gpx(os.path.join("tests", "data", "gpx_data"))
+        elev = 1000.0
+        h = pd.Timedelta(hours=1)
+        time = pd.Timestamp("2023-11-08 10:00:00+00:00")
+        hdop = 10.0
+        x, y = 8, 47
+        data = {
+            "track_fid": [0, 1, 1],  # track 0 with 1 point, track 1 with 2 points
+            "track_seg_id": [0, 0, 0],  # each track has 1 segment
+            "track_seg_point_id": [0, 0, 1],
+            "ele": [elev, elev + 1, elev + 2],
+            "tracked_at": [time, time + h, time + 2 * h],
+            "hdop": [hdop, hdop + 1, hdop + 2],
+            "geometry": [Point(x, y), Point(x + 1, y + 1), Point(x + 2, y + 2)],
+            "user_id": [0, 0, 0],
+        }
+        pfs_test = Positionfixes(data, geometry="geometry", crs=4326)
+        assert_geodataframe_equal(pfs, pfs_test)

--- a/trackintel/io/__init__.py
+++ b/trackintel/io/__init__.py
@@ -80,5 +80,5 @@ __all__ = [
     "read_geolife",
     "read_mzmv",
     "geolife_add_modes_to_triplegs",
-    "read_gpx"
+    "read_gpx",
 ]

--- a/trackintel/io/__init__.py
+++ b/trackintel/io/__init__.py
@@ -37,6 +37,7 @@ from .from_geopandas import read_tours_gpd
 from .dataset_reader import read_geolife
 from .dataset_reader import read_mzmv
 from .dataset_reader import geolife_add_modes_to_triplegs
+from .dataset_reader import read_gpx
 
 __all__ = [
     # positionfixes
@@ -79,4 +80,5 @@ __all__ = [
     "read_geolife",
     "read_mzmv",
     "geolife_add_modes_to_triplegs",
+    "read_gpx"
 ]

--- a/trackintel/io/dataset_reader.py
+++ b/trackintel/io/dataset_reader.py
@@ -702,7 +702,8 @@ def read_gpx(path):
     pattern = os.path.join(path, "*.gpx")
     pfs_list = []
     track_fid_offset = 0
-    for file in glob.glob(pattern):
+    # sorted to make result deterministic
+    for file in sorted(glob.glob(pattern)):
         pfs = _read_single_gpx_file(file)
         # give each track an unique ID
         pfs["track_fid"] += track_fid_offset


### PR DESCRIPTION
That was a lot simpler than I thought.
Currently we assign to all positionfixes `user_id = 0`.