### PR TITLE
BUG: `calculate_distance_matrix` computes all pairs

### DIFF
--- a/tests/geogr/test_distances.py
+++ b/tests/geogr/test_distances.py
@@ -309,6 +309,14 @@ class TestCalculate_distance_matrix:
         with pytest.raises(ValueError, match="We only support 'Point' and 'LineString'."):
             calculate_distance_matrix(X=gdf, dist_metric="dtw", n_jobs=1)
 
+    def test_same_geometry_type(self, single_linestring, geolife_tpls):
+        """Test if error is raised if X and Y have different geometries"""
+        multi = MultiLineString([single_linestring, single_linestring])
+        t = [(0, multi), (1, multi)]
+        gdf = gpd.GeoDataFrame(t, columns=["id", "geometry"], geometry="geometry", crs="wgs84")
+        with pytest.raises(ValueError, match="X and Y need to have same geometry type."):
+            calculate_distance_matrix(gdf, geolife_tpls)
+
 
 class TestCheck_gdf_planar:
     """Tests for check_gdf_planar() method."""

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -114,7 +114,9 @@ def calculate_distance_matrix(X, Y=None, dist_metric="haversine", n_jobs=None, *
         For LineStrings, we provide the metrics {'dtw', 'frechet'} via the implementation from similaritymeasures.
 
     n_jobs: int, optional
-        Number of cores to use. Only used for Point-distances. Default uses all possible cores
+        The number of jobs to use for the computation. Ignored for LineStrings.
+        None means 1 unless in a joblib.parallel_backend context. -1 means using all processors.
+        See `sklearn.metrics.pairwise_distances` for more informations.
 
     **kwds:
         Optional keywords passed to the distance functions.

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -141,8 +141,6 @@ def calculate_distance_matrix(X, Y=None, dist_metric="haversine", n_jobs=None, *
             dist_metric = lambda a, b, **_: point_haversine_dist(*a, *b, float_flag=True)
         X = shapely.get_coordinates(X.geometry)
         Y = shapely.get_coordinates(Y.geometry) if Y is not None else X
-        print(X)
-        print(Y)
         return pairwise_distances(X, Y, metric=dist_metric, n_jobs=n_jobs, **kwds)
 
     # geom_type == "LineString"

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -137,8 +137,12 @@ def calculate_distance_matrix(X, Y=None, dist_metric="haversine", n_jobs=None, *
         raise ValueError(f"We only support 'Point' and 'LineString'. Your geometry is {geom_type}")
 
     if geom_type == "Point":
-        if dist_metric == "haversine":  # curry our haversine distance
-            dist_metric = lambda a, b, **_: point_haversine_dist(*a, *b, float_flag=True)
+        if dist_metric == "haversine":
+            # curry our haversine distance
+            def haversine_curry(a, b, **_):
+                return point_haversine_dist(*a, *b, float_flag=True)
+
+            dist_metric = haversine_curry
         X = shapely.get_coordinates(X.geometry)
         Y = shapely.get_coordinates(Y.geometry) if Y is not None else X
         return pairwise_distances(X, Y, metric=dist_metric, n_jobs=n_jobs, **kwds)
@@ -146,7 +150,11 @@ def calculate_distance_matrix(X, Y=None, dist_metric="haversine", n_jobs=None, *
     # geom_type == "LineString"
     # for LineStrings we cannot use pairwise_distance because it enforces float in its array
     if dist_metric == "dtw":
-        dist_metric = lambda a, b, **kwd: similaritymeasures.dtw(a, b, **kwd)[0]
+
+        def dtw(a, b, **kwds):
+            return similaritymeasures.dtw(a, b, **kwds)[0]
+
+        dist_metric = dtw
     elif dist_metric == "frechet":
         dist_metric = similaritymeasures.frechet_dist
     else:


### PR DESCRIPTION
fixes  #592
One of the added tests has a very generous relative tolerance, this is due to #593.
I made this function probably quite a bit slower. I thought that correctness is more important and if nobody experienced this bug in 3 years maybe it isn't called that often either.
Tried to use pairwise distance for everything. That wasn't possible for the LineStrings as sklearn and scipy both enforce float as data type. Thus I copied the code out of sklearn and adapted it a bit. 