### PR TITLE
TST: correct calculate_dist_matrix test

### DIFF
--- a/tests/geogr/test_distances.py
+++ b/tests/geogr/test_distances.py
@@ -231,10 +231,11 @@ class TestCalculate_distance_matrix:
         res01 = calculate_distance_matrix(X=pfs0, Y=pfs1, dist_metric="haversine")
         rad0 = np.radians(shapely.get_coordinates(pfs0.geometry))
         rad1 = np.radians(shapely.get_coordinates(pfs1.geometry))
+        # pairwise distance takes lat, lon input. Points are lon, lat
+        rad0 = np.roll(rad0, 1, axis=1)
+        rad1 = np.roll(rad1, 1, axis=1)
         sol01 = pairwise_distances(rad0, rad1, metric="haversine") * 6371000
-        # TODO: increase precision of haversine dist such we can lower the tolerance
-        # see issue #593 for more information
-        assert np.allclose(res01, sol01, rtol=1e-2)
+        assert np.allclose(res01, sol01)
 
     def test_known_euclidean_distance(self, two_pfs):
         """Test the result comparing to known euclidean distances"""

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -1,18 +1,15 @@
 import itertools
 import math
-import multiprocessing
 import warnings
-from functools import partial
 from math import cos, pi
 
 import numpy as np
 import pandas as pd
 import shapely
 import similaritymeasures
-from scipy.spatial.distance import cdist
 from sklearn.metrics import pairwise_distances
 
-from trackintel import Positionfixes, Triplegs
+from trackintel import Triplegs
 
 
 def point_haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_flag=False):


### PR DESCRIPTION
fixes #593 
It wasn't a bug. I just entered `longitude`, `latitude ` into the function instead of `latitude`, `longitude`. 
This PR fixes the test.