### PR TITLE
CLN: update license, remove unused imports

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 mie-lab at ETH Zurich, Switzerland
+Copyright (c) 2024 mie-lab at ETH Zurich, Switzerland
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apt.txt
+++ b/apt.txt
@@ -1,1 +1,0 @@
-libspatialindex-dev

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ autodoc_mock_imports = [
 # -- Project information -----------------------------------------------------
 
 project = "trackintel"
-copyright = "2019 - 2023, Dominik Bucher, Henry Martin, Ye Hong, Nina Wiedemann"
+copyright = "2019 - 2024, Dominik Bucher, Henry Martin, Ye Hong, Nina Wiedemann"
 author = "Dominik Bucher, Henry Martin, Ye Hong, Nina Wiedemann"
 
 

--- a/tests/visualization/test_plotting.py
+++ b/tests/visualization/test_plotting.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-import warnings
 
 import matplotlib
 import numpy as np

--- a/trackintel/analysis/tracking_quality.py
+++ b/trackintel/analysis/tracking_quality.py
@@ -1,6 +1,5 @@
 import warnings
 
-import numpy as np
 import pandas as pd
 
 

--- a/trackintel/io/from_geopandas.py
+++ b/trackintel/io/from_geopandas.py
@@ -1,7 +1,6 @@
 import warnings
 import pandas as pd
 import geopandas as gpd
-import pytz
 
 from trackintel import Positionfixes, Staypoints, Triplegs, Locations, Trips, Tours
 

--- a/trackintel/preprocessing/trips.py
+++ b/trackintel/preprocessing/trips.py
@@ -1,13 +1,11 @@
 import warnings
 from datetime import timedelta
 
-import geopandas as gpd
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
 
 import trackintel as ti
-from trackintel import Tours, Trips
+from trackintel import Tours
 from trackintel.preprocessing.util import applyParallel
 
 


### PR DESCRIPTION
Just a small cleanup PR. 
- updated the license year
- removed unused `apt.txt` file
- removed unused imports