### PR TITLE
ENH: Change AttributeError to ValueError

### DIFF
--- a/tests/analysis/test_label.py
+++ b/tests/analysis/test_label.py
@@ -27,11 +27,11 @@ class TestCreate_activity_flag:
         sp_test = ti.read_staypoints_csv(sp_file, tz="utc", index_col="id")
 
         method = 12345
-        with pytest.raises(AttributeError, match=f"Method {method} not known for creating activity flag."):
+        with pytest.raises(ValueError, match=f"Method {method} not known for creating activity flag."):
             sp_test.as_staypoints.create_activity_flag(method=method)
 
         method = "random"
-        with pytest.raises(AttributeError, match=f"Method {method} not known for creating activity flag."):
+        with pytest.raises(ValueError, match=f"Method {method} not known for creating activity flag."):
             sp_test.as_staypoints.create_activity_flag(method=method)
 
 
@@ -44,11 +44,11 @@ class TestPredict_transport_mode:
         tpls = ti.read_triplegs_csv(tpls_file, sep=";", index_col="id")
 
         method = 12345
-        with pytest.raises(AttributeError, match=f"Method {method} not known for predicting tripleg transport modes."):
+        with pytest.raises(ValueError, match=f"Method {method} not known for predicting tripleg transport modes."):
             tpls.as_triplegs.predict_transport_mode(method=method)
 
         method = "random"
-        with pytest.raises(AttributeError, match=f"Method {method} not known for predicting tripleg transport modes."):
+        with pytest.raises(ValueError, match=f"Method {method} not known for predicting tripleg transport modes."):
             tpls.as_triplegs.predict_transport_mode(method=method)
 
     def test_check_empty_dataframe(self):

--- a/tests/analysis/test_modal_split.py
+++ b/tests/analysis/test_modal_split.py
@@ -204,7 +204,7 @@ class TestModalSplit:
         """Check if error is raised if unknown metric is passed."""
         metric = "unknown_metric"
         error_msg = f"Metric {metric} unknown, only metrics {{'count', 'distance', 'duration'}} are supported."
-        with pytest.raises(AttributeError, match=error_msg):
+        with pytest.raises(ValueError, match=error_msg):
             calculate_modal_split(test_triplegs_modal_split, metric=metric)
 
 

--- a/tests/analysis/test_tracking_quality.py
+++ b/tests/analysis/test_tracking_quality.py
@@ -163,9 +163,9 @@ class TestTemporal_tracking_quality:
         """Test if the an error is raised when passing unknown 'granularity' to temporal_tracking_quality()."""
         sp_tpls = testdata_sp_tpls_geolife_long
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             ti.analysis.tracking_quality.temporal_tracking_quality(sp_tpls, granularity=12345)
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             ti.analysis.tracking_quality.temporal_tracking_quality(sp_tpls, granularity="random")
 
     def test_tracking_quality_wrong_datamodel(self):
@@ -189,9 +189,9 @@ class TestTemporal_tracking_quality:
         sp_tpls = testdata_sp_tpls_geolife_long
         user_0 = sp_tpls.loc[sp_tpls["user_id"] == 0]
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             ti.analysis.tracking_quality._get_tracking_quality_user(user_0, granularity=12345)
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             ti.analysis.tracking_quality._get_tracking_quality_user(user_0, granularity="random")
 
     def test_staypoints_accessors(self, testdata_all_geolife_long):

--- a/tests/geogr/test_distances.py
+++ b/tests/geogr/test_distances.py
@@ -506,10 +506,10 @@ class TestPfsMeanSpeedTriplegs:
         assert_geodataframe_equal(tpls_speed_acc, tpls_speed_normal)
 
     def test_pfs_input_assertion(self, example_triplegs):
-        """Test whether an AttributeError is raised if no positionfixes are provided as input"""
+        """Test whether an ValueError is raised if no positionfixes are provided as input"""
         error_msg = 'Method "pfs_mean_speed" requires positionfixes as input.'
         _, tpls = example_triplegs
-        with pytest.raises(AttributeError, match=error_msg):
+        with pytest.raises(ValueError, match=error_msg):
             ti.geogr.distances.get_speed_triplegs(tpls, None, method="pfs_mean_speed")
 
     def test_pfs_tripleg_id_assertion(self, example_triplegs):
@@ -548,8 +548,9 @@ class TestSimpleSpeedTriplegs:
         tpls_speed_normal = ti.geogr.distances.get_speed_triplegs(tpls)
         assert_geodataframe_equal(tpls_speed_acc, tpls_speed_normal)
 
-    def test_method_error(self):
+    def test_method_error(self, example_triplegs):
         """Test whether an error is triggered if wrong posistionfixes are used as input"""
-        with pytest.raises(Exception) as e_info:
-            _ = ti.geogr.distances.get_speed_triplegs(None, None, method="wrong_method")
-            assert e_info == "Method wrong_method not known for speed computation."
+        meth = "wrong_method"
+        _, tpls = example_triplegs
+        with pytest.raises(ValueError, match=f"Method {meth} not known for speed computation."):
+            _ = ti.geogr.distances.get_speed_triplegs(tpls, None, method=meth)

--- a/tests/geogr/test_filter.py
+++ b/tests/geogr/test_filter.py
@@ -117,5 +117,5 @@ class TestSpatial_filter:
         """Test if the an error is raised when passing unknown 'method' to spatial_filter()."""
         locs = locs_from_geolife
         extent = gpd.read_file(os.path.join("tests", "data", "area", "tsinghua.geojson"))
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError):
             locs.spatial_filter(areas=extent, method=12345)

--- a/tests/model/test_locations.py
+++ b/tests/model/test_locations.py
@@ -34,7 +34,7 @@ class TestLocations:
         testdata_locs["center"] = LineString(
             [(13.476808430, 48.573711823), (13.506804, 48.939008), (13.4664690, 48.5706414)]
         )
-        with pytest.raises(ValueError, match="The center geometry must be a Point"):
+        with pytest.raises(TypeError, match="The center geometry must be a Point"):
             testdata_locs.as_locations
 
     def test_accessor_empty(self, testdata_locs):

--- a/tests/model/test_positionfixes.py
+++ b/tests/model/test_positionfixes.py
@@ -41,7 +41,7 @@ class TestPositionfixes:
         pfs = testdata_geolife.copy()
 
         # check geometry type
-        with pytest.raises(AttributeError, match="The geometry must be a Point"):
+        with pytest.raises(TypeError, match="The geometry must be a Point"):
             pfs["geom"] = LineString([(13.476808430, 48.573711823), (13.506804, 48.939008), (13.4664690, 48.5706414)])
             pfs.as_positionfixes
 

--- a/tests/model/test_staypoints.py
+++ b/tests/model/test_staypoints.py
@@ -40,7 +40,7 @@ class TestStaypoints:
         sp = testdata_sp.copy()
 
         # check geometry type
-        with pytest.raises(AttributeError, match="The geometry must be a Point"):
+        with pytest.raises(TypeError, match="The geometry must be a Point"):
             sp["geom"] = LineString([(13.476808430, 48.573711823), (13.506804, 48.939008), (13.4664690, 48.5706414)])
             sp.as_staypoints
 

--- a/tests/model/test_triplegs.py
+++ b/tests/model/test_triplegs.py
@@ -44,7 +44,7 @@ class TestTriplegs:
         tpls = testdata_tpls.copy()
 
         # check geometry type
-        with pytest.raises(AttributeError, match="The geometry must be a LineString"):
+        with pytest.raises(TypeError, match="The geometry must be a LineString"):
             tpls["geom"] = Point([(13.476808430, 48.573711823)])
             tpls.as_triplegs
 

--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -313,8 +313,8 @@ class Test_Generate_staypoints_sliding_user:
     """Test for _generate_staypoints_sliding_user."""
 
     def test_unknown_distance_metric(self, example_positionfixes):
-        """Test if the distance metric is unknown, an AttributeError will be raised."""
-        with pytest.raises(AttributeError):
+        """Test if the distance metric is unknown, an ValueError will be raised."""
+        with pytest.raises(ValueError):
             example_positionfixes.as_positionfixes.generate_staypoints(
                 method="sliding", dist_threshold=100, time_threshold=5, distance_metric="unknown"
             )
@@ -508,12 +508,12 @@ class TestGenerate_triplegs:
         assert (tpls_case2.index == np.arange(len(tpls_case2))).any()
 
     def test_invalid_inputs(self, geolife_pfs_sp_long):
-        """Test if AttributeError will be raised after invalid method input."""
+        """Test if ValueError will be raised after invalid method input."""
         pfs, sp = geolife_pfs_sp_long
 
-        with pytest.raises(AttributeError, match="Method unknown"):
+        with pytest.raises(ValueError, match="Method unknown"):
             pfs.as_positionfixes.generate_triplegs(sp, method="random")
-        with pytest.raises(AttributeError, match="Method unknown"):
+        with pytest.raises(ValueError, match="Method unknown"):
             pfs.as_positionfixes.generate_triplegs(sp, method=12345)
 
     def test_temporal(self, geolife_pfs_sp_long):

--- a/tests/preprocessing/test_staypoints.py
+++ b/tests/preprocessing/test_staypoints.py
@@ -438,18 +438,18 @@ class TestGenerate_locations:
         assert sp2.loc[[2, 7], "location_id"].isnull().all()
 
     def test_agg_level_error(self, example_staypoints):
-        """Test if unknown "agg_level" raises AttributeError"""
+        """Test if unknown "agg_level" raises ValueError"""
         agg_level = "unknown"
         error_msg = f"agg_level '{agg_level}' is unknown. Supported values are ['user', 'dataset']."
-        with pytest.raises(AttributeError) as e:
+        with pytest.raises(ValueError) as e:
             example_staypoints.as_staypoints.generate_locations(method="dbscan", agg_level="unkown")
             assert error_msg == str(e.value)
 
     def test_method_error(self, example_staypoints):
-        """Test if unknown "method" raises AttributeError"""
+        """Test if unknown "method" raises ValueError"""
         method = "unknown"
         error_msg = f"method '{method}' is unknown. Supported values are ['dbscan']."
-        with pytest.raises(AttributeError) as e:
+        with pytest.raises(ValueError) as e:
             example_staypoints.as_staypoints.generate_locations(method="unknown")
             assert error_msg == str(e.value)
 

--- a/trackintel/analysis/labelling.py
+++ b/trackintel/analysis/labelling.py
@@ -38,7 +38,7 @@ def create_activity_flag(staypoints, method="time_threshold", time_threshold=15.
             minutes=time_threshold
         )
     else:
-        raise AttributeError(f"Method {method} not known for creating activity flag.")
+        raise ValueError(f"Method {method} not known for creating activity flag.")
 
     return staypoints
 
@@ -86,7 +86,7 @@ def predict_transport_mode(triplegs, method="simple-coarse", **kwargs):
         triplegs["mode"] = _predict_transport_mode_simple_coarse(triplegs, categories)
         return triplegs
     else:
-        raise AttributeError(f"Method {method} not known for predicting tripleg transport modes.")
+        raise ValueError(f"Method {method} not known for predicting tripleg transport modes.")
 
 
 def _predict_transport_mode_simple_coarse(triplegs, categories):

--- a/trackintel/analysis/modal_split.py
+++ b/trackintel/analysis/modal_split.py
@@ -55,7 +55,7 @@ def calculate_modal_split(tpls, freq=None, metric="count", per_user=False, norm=
         metric = "mode"  # count on mode
     else:
         error_msg = f"Metric {metric} unknown, only metrics {{'count', 'distance', 'duration'}} are supported."
-        raise AttributeError(error_msg)
+        raise ValueError(error_msg)
 
     group = []
     if per_user:

--- a/trackintel/analysis/tracking_quality.py
+++ b/trackintel/analysis/tracking_quality.py
@@ -108,7 +108,7 @@ def temporal_tracking_quality(source, granularity="all"):
         column_name = "hour"
 
     else:
-        raise AttributeError(
+        raise ValueError(
             f"granularity unknown. We only support ['all', 'day', 'week', 'weekday', 'hour']. You passed {granularity}"
         )
 
@@ -159,7 +159,7 @@ def _get_tracking_quality_user(df, granularity="all"):
         # (entries from multiple days may be grouped together)
         extent = (60 * 60) * (df["day"].max() - df["day"].min() + 1)
     else:
-        raise AttributeError(
+        raise ValueError(
             f"granularity unknown. We only support ['all', 'day', 'week', 'weekday', 'hour']. You passed {granularity}"
         )
     return pd.Series([tracked_duration / extent], index=["quality"])

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -348,7 +348,7 @@ def get_speed_triplegs(triplegs, positionfixes=None, method="tpls_speed"):
     # Pfs-based method: compute speed per positionfix and average then
     elif method == "pfs_mean_speed":
         if positionfixes is None:
-            raise AttributeError('Method "pfs_mean_speed" requires positionfixes as input.')
+            raise ValueError('Method "pfs_mean_speed" requires positionfixes as input.')
         if "tripleg_id" not in positionfixes:
             raise AttributeError('Positionfixes must include column "tripleg_id".')
         # group positionfixes by triplegs and compute average speed for each collection of positionfixes
@@ -359,7 +359,7 @@ def get_speed_triplegs(triplegs, positionfixes=None, method="tpls_speed"):
         return tpls
 
     else:
-        raise AttributeError(f"Method {method} not known for speed computation.")
+        raise ValueError(f"Method {method} not known for speed computation.")
 
 
 def _single_tripleg_mean_speed(positionfixes):

--- a/trackintel/geogr/filter.py
+++ b/trackintel/geogr/filter.py
@@ -61,9 +61,7 @@ def spatial_filter(source, areas, method="within", re_project=False):
     elif method == "crosses":
         ret_gdf = possible_matches.loc[possible_matches.crosses(areas.unary_union)]
     else:
-        raise AttributeError(
-            "method unknown. We only support ['within', 'intersects', 'crosses']. " f"You passed {method}"
-        )
+        raise ValueError("method unknown. We only support ['within', 'intersects', 'crosses']. " f"You passed {method}")
 
     if re_project:
         return ret_gdf.to_crs(init_crs)

--- a/trackintel/model/locations.py
+++ b/trackintel/model/locations.py
@@ -51,7 +51,7 @@ class Locations(TrackintelBase, TrackintelGeoDataFrame):
         if obj["center"].iloc[0].geom_type != "Point":
             # todo: We could think about allowing both geometry types for locations (point and polygon)
             # One for extend and one for the center
-            raise ValueError("The center geometry must be a Point (only first checked).")
+            raise TypeError("The center geometry must be a Point (only first checked).")
 
     @doc(_shared_docs["write_csv"], first_arg="", long="locations", short="locs")
     def to_csv(self, filename, *args, **kwargs):

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -71,7 +71,7 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
 
         if obj.geometry.iloc[0].geom_type != "Point":
-            raise AttributeError("The geometry must be a Point (only first checked).")
+            raise TypeError("The geometry must be a Point (only first checked).")
 
     @property
     def center(self):

--- a/trackintel/model/staypoints.py
+++ b/trackintel/model/staypoints.py
@@ -71,7 +71,7 @@ class Staypoints(TrackintelBase, TrackintelGeoDataFrame):
             obj.geometry.is_valid.all()
         ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
         if obj.geometry.iloc[0].geom_type != "Point":
-            raise AttributeError("The geometry must be a Point (only first checked).")
+            raise TypeError("The geometry must be a Point (only first checked).")
 
     @property
     def center(self):

--- a/trackintel/model/triplegs.py
+++ b/trackintel/model/triplegs.py
@@ -69,7 +69,7 @@ class Triplegs(TrackintelBase, TrackintelGeoDataFrame):
             obj.geometry.is_valid.all()
         ), "Not all geometries are valid. Try x[~ x.geometry.is_valid] where x is you GeoDataFrame"
         if obj.geometry.iloc[0].geom_type != "LineString":
-            raise AttributeError("The geometry must be a LineString (only first checked).")
+            raise TypeError("The geometry must be a LineString (only first checked).")
 
     @doc(_shared_docs["write_csv"], first_arg="", long="triplegs", short="tpls")
     def to_csv(self, filename, *args, **kwargs):

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -395,7 +395,7 @@ def generate_triplegs(
         return pfs, Triplegs(tpls)
 
     else:
-        raise AttributeError(f"Method unknown. We only support 'between_staypoints'. You passed {method}")
+        raise ValueError(f"Method unknown. We only support 'between_staypoints'. You passed {method}")
 
 
 def _generate_staypoints_sliding_user(
@@ -405,7 +405,7 @@ def _generate_staypoints_sliding_user(
     if distance_metric == "haversine":
         dist_func = point_haversine_dist
     else:
-        raise AttributeError("distance_metric unknown. We only support ['haversine']. " f"You passed {distance_metric}")
+        raise ValueError("distance_metric unknown. We only support ['haversine']. " f"You passed {distance_metric}")
 
     df = df.sort_index(kind="stable").sort_values(by=["tracked_at"], kind="stable")
 

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -76,9 +76,9 @@ def generate_locations(
     """
     Staypoints.validate(staypoints)
     if agg_level not in ["user", "dataset"]:
-        raise AttributeError(f"agg_level '{agg_level}' is unknown. Supported values are ['user', 'dataset'].")
+        raise ValueError(f"agg_level '{agg_level}' is unknown. Supported values are ['user', 'dataset'].")
     if method not in ["dbscan"]:
-        raise AttributeError(f"method '{method}' is unknown. Supported value is ['dbscan'].")
+        raise ValueError(f"method '{method}' is unknown. Supported value is ['dbscan'].")
 
     # initialize the return GeoDataFrames
     sp = staypoints.copy()


### PR DESCRIPTION
A bit of a pet peeve of mine.
All over trackintel we used `AttributeError` where `ValueError` would make more sense.
I changed it where it made sense for me.

for reference: https://docs.python.org/3/library/exceptions.html
>**AttributeError**
Raised when an attribute reference (see [Attribute references](https://docs.python.org/3/reference/expressions.html#attribute-references)) or assignment fails. (When an object does not support attribute references or attribute assignments at all, [TypeError](https://docs.python.org/3/library/exceptions.html#TypeError) is raised.)

e.g.
```python
>> a = object()
>> a.not_existing_field
AttributeError: 'object' object has no attribute 'not_existing_field'
```
> **ValueError**
Raised when an operation or function receives an argument that has the right type but an inappropriate value, and the situation is not described by a more precise exception such as [IndexError](https://docs.python.org/3/library/exceptions.html#IndexError).

e.g.
```python
>> chr(0x1100001)
ValueError: chr() arg not in range(0x110000)
```