### PR TITLE
BUG: catch `_constructor_from_mgr` from geopandas

### DIFF
--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -51,6 +51,12 @@ class TrackintelGeoDataFrame(GeoDataFrame):
 
         return _constructor_with_fallback
 
+    def _constructor_from_mgr(self, mgr, axes):
+        """
+        GeoPandas cannot use Pandas methods due to some difficulties.
+        Thus they have their own _constructor_from_mgr, which we need to mirror."""
+        return self._constructor(GeoDataFrame._constructor_from_mgr(self, mgr, axes))
+
     # Following methods manually set self.__class__ fix to GeoDataFrame.
     # Thus to properly subtype, we need to downcast them with the _wrapped_gdf_method decorator.
     @_wrapped_gdf_method

--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -52,9 +52,7 @@ class TrackintelGeoDataFrame(GeoDataFrame):
         return _constructor_with_fallback
 
     def _constructor_from_mgr(self, mgr, axes):
-        """
-        GeoPandas cannot use Pandas methods due to some difficulties.
-        Thus they have their own _constructor_from_mgr, which we need to mirror."""
+        """Mirror GeoPandas _constructor_from_mgr method."""
         return self._constructor(GeoDataFrame._constructor_from_mgr(self, mgr, axes))
 
     # Following methods manually set self.__class__ fix to GeoDataFrame.


### PR DESCRIPTION
Recently the GeoPandas team had some issues with the `_constructor_from_mgr` and in a change they added [here](https://github.com/geopandas/geopandas/blob/74263151bccd2e26a024719137c4e877cab495ce/geopandas/geodataframe.py#L1634) `_geodataframe_constructor_with_fallback` and this breaks our code. For our code to work they should have to use `self._constructor`, so we do that manually in our code to repair this. 

closes #605