### PR TITLE
DOC/TST: generate tripleg

### DIFF
--- a/examples/preprocess_trajectories.py
+++ b/examples/preprocess_trajectories.py
@@ -15,7 +15,7 @@ logging.basicConfig(filename="examples/log/preprocessing.log", level=logging.INF
 pfs = ti.read_positionfixes_csv("examples/data/geolife_trajectory.csv", sep=";", crs="EPSG:4326", index_col=None)
 ti.plot(filename="examples/out/gps_trajectory_positionfixes.png", positionfixes=pfs, plot_osm=True)
 
-_, sp = pfs.generate_staypoints(method="sliding", dist_threshold=100, time_threshold=5)
+pfs, sp = pfs.generate_staypoints(method="sliding", dist_threshold=100, time_threshold=5)
 ti.plot(
     filename="examples/out/gps_trajectory_staypoints.png",
     staypoints=sp,

--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -578,12 +578,10 @@ class TestGenerate_triplegs_overlap_staypoints:
         assert tpl_0["finished_at"] == sp["started_at"]
         assert sp["finished_at"] == tpl_1["started_at"]
 
+        # last point of tpl should correspond to next sp
         assert Point(tpl_0["geom"].coords[-1]) == sp["geom"]
+        # first point of next tpl should correspond to previous sp
         assert sp["geom"] == Point(tpl_1["geom"].coords[0])
-        # # last point of tpl should correspond to first pfs of next sp
-        # assert Point(tpl_0["geom"].coords[-1]) == pfs.loc[sp.name == pfs["staypoint_id"]].iloc[0].geom
-        # # first point of next tpl should correspond to last pfs of previous sp
-        # assert Point(tpl_1["geom"].coords[0]) == pfs.loc[sp.name == pfs["staypoint_id"]].iloc[-1].geom
 
     def test_sp_one_pfs_tpls_overlap(self, geolife_pfs_sp_long):
         """Triplegs should overlap staypoint in time with only one positionfix, but only the first tripleg should
@@ -602,19 +600,6 @@ class TestGenerate_triplegs_overlap_staypoints:
         # no spatial overlap with second tripleg
         assert sp["geom"] != Point(tpl_1["geom"].coords[0])
 
-    def test_stability(self, geolife_pfs_sp_long):
-        """Checks if the results are same for different cases."""
-        pfs, sp = geolife_pfs_sp_long
-        # case 1
-        pfs_case1, tpls_case1 = pfs.generate_triplegs(sp, method="overlap_staypoints")
-
-        # case 2
-        # pfs = pfs.drop(columns="staypoint_id")
-        pfs_case2, tpls_case2 = pfs.drop(columns="staypoint_id").generate_triplegs(sp, method="overlap_staypoints")
-
-        assert_geodataframe_equal(pfs_case1.drop(columns="staypoint_id", axis=1), pfs_case2)
-        # assert_geodataframe_equal(tpls_case1, tpls_case2)
-
     def test_str_userid(self, geolife_pfs_sp_long):
         """Tripleg generation should also work if the user IDs are strings."""
         pfs, sp = geolife_pfs_sp_long
@@ -629,3 +614,10 @@ class TestGenerate_triplegs_overlap_staypoints:
 
         with pytest.raises(TypeError, match="staypoints input must be provide for overlap_staypoints"):
             pfs.generate_triplegs(staypoints=None, method="overlap_staypoints")
+
+    def test_pfs_format(self, geolife_pfs_sp_long):
+        """Test if TypeError will be raised when pfs with no staypoint_id column is provided."""
+        pfs, sp = geolife_pfs_sp_long
+
+        with pytest.raises(TypeError, match="positionfixes must contain a staypoint_id column for overlap_staypoints"):
+            pfs.drop(columns="staypoint_id").generate_triplegs(staypoints=sp, method="overlap_staypoints")

--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -615,14 +615,13 @@ class TestGenerate_triplegs_overlap_staypoints:
         assert_geodataframe_equal(pfs_case1.drop(columns="staypoint_id", axis=1), pfs_case2)
         # assert_geodataframe_equal(tpls_case1, tpls_case2)
 
-    def test_str_userid(self, example_positionfixes_isolated):
+    def test_str_userid(self, geolife_pfs_sp_long):
         """Tripleg generation should also work if the user IDs are strings."""
-        pfs = example_positionfixes_isolated
-        # remove isolated - not needed for this test
-        pfs = pfs[~pfs.index.isin([1, 2])].copy()
+        pfs, sp = geolife_pfs_sp_long
+
         # set user ID to string
         pfs["user_id"] = pfs["user_id"].astype(str) + "not_numerical_interpretable_str"
-        pfs, _ = pfs.generate_triplegs(method="overlap_staypoints")
+        pfs, _ = pfs.generate_triplegs(staypoints=sp, method="overlap_staypoints")
 
     def test_staypoint_inputs(self, geolife_pfs_sp_long):
         """Test if TypeError will be raised when no staypoint is provided."""

--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from geopandas.testing import assert_geodataframe_equal
-from pandas.testing import assert_frame_equal
 from pandas import Timestamp
 from shapely.geometry import Point
 
@@ -403,10 +402,14 @@ class TestGenerate_triplegs_between_staypoints:
 
         ## test for case 2
         pfs.drop(columns="staypoint_id", inplace=True)
-        # manually change the first pfs' user_id, which has no stp correspondence
-        _, tpls_1 = pfs.generate_triplegs(sp, method="between_staypoints")
-        # result should be the same ommiting the first row
-        _, tpls_2 = pfs.iloc[1:].generate_triplegs(sp, method="between_staypoints")
+
+        warn_string = "Providing positionfixes without*"
+        with pytest.warns(DeprecationWarning, match=warn_string):
+            # manually change the first pfs' user_id, which has no stp correspondence
+            _, tpls_1 = pfs.generate_triplegs(sp, method="between_staypoints")
+            # result should be the same ommiting the first row
+            _, tpls_2 = pfs.iloc[1:].generate_triplegs(sp, method="between_staypoints")
+
         assert_geodataframe_equal(tpls_1, tpls_2)
 
     def test_pfs_without_sp(self, geolife_pfs_sp_long):
@@ -416,7 +419,9 @@ class TestGenerate_triplegs_between_staypoints:
         _, tpls_case1 = pfs.generate_triplegs(sp, method="between_staypoints")
         # only keep pfs where staypoint id is nan
         pfs_no_sp = pfs[pd.isna(pfs["staypoint_id"])].drop(columns="staypoint_id")
-        _, tpls_case2 = pfs_no_sp.generate_triplegs(sp, method="between_staypoints")
+        warn_string = "Providing positionfixes without*"
+        with pytest.warns(DeprecationWarning, match=warn_string):
+            _, tpls_case2 = pfs_no_sp.generate_triplegs(sp, method="between_staypoints")
 
         assert_geodataframe_equal(tpls_case1, tpls_case2)
 
@@ -430,7 +435,9 @@ class TestGenerate_triplegs_between_staypoints:
 
         # case 2
         pfs = pfs.drop(columns="staypoint_id")
-        pfs_case2, tpls_case2 = pfs.generate_triplegs(sp, method="between_staypoints")
+        warn_string = "Providing positionfixes without*"
+        with pytest.warns(DeprecationWarning, match=warn_string):
+            pfs_case2, tpls_case2 = pfs.generate_triplegs(sp, method="between_staypoints")
 
         assert_geodataframe_equal(pfs_case1.drop(columns="staypoint_id", axis=1), pfs_case2)
         assert_geodataframe_equal(pfs_case1, pfs_case1_wo)
@@ -494,7 +501,9 @@ class TestGenerate_triplegs_between_staypoints:
         pfs, sp = geolife_pfs_sp_long
 
         _, tpls_case1 = pfs.generate_triplegs(sp)
-        _, tpls_case2 = pfs.drop("staypoint_id", axis=1).generate_triplegs(sp)
+        warn_string = "Providing positionfixes without*"
+        with pytest.warns(DeprecationWarning, match=warn_string):
+            _, tpls_case2 = pfs.drop("staypoint_id", axis=1).generate_triplegs(sp)
 
         assert (tpls_case1.index == np.arange(len(tpls_case1))).any()
         assert (tpls_case2.index == np.arange(len(tpls_case2))).any()

--- a/tests/preprocessing/test_positionfixes.py
+++ b/tests/preprocessing/test_positionfixes.py
@@ -444,7 +444,7 @@ class TestGenerate_triplegs_between_staypoints:
         assert_geodataframe_equal(tpls_case1, tpls_case2)
         assert_geodataframe_equal(tpls_case1, tpls_case1_wo)
 
-        with pytest.raises(TypeError, match="staypoints input must be provide for pfs without staypoint_id column"):
+        with pytest.raises(TypeError, match="staypoints input must be provided for pfs without staypoint_id column"):
             pfs.generate_triplegs(staypoints=None, method="between_staypoints")
 
     def test_random_order(self, geolife_pfs_sp_long):
@@ -621,7 +621,7 @@ class TestGenerate_triplegs_overlap_staypoints:
         """Test if TypeError will be raised when no staypoint is provided."""
         pfs, _ = geolife_pfs_sp_long
 
-        with pytest.raises(TypeError, match="staypoints input must be provide for overlap_staypoints"):
+        with pytest.raises(TypeError, match="staypoints input must be provided for overlap_staypoints"):
             pfs.generate_triplegs(staypoints=None, method="overlap_staypoints")
 
     def test_pfs_format(self, geolife_pfs_sp_long):

--- a/trackintel/model/positionfixes.py
+++ b/trackintel/model/positionfixes.py
@@ -115,7 +115,6 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
         staypoints=None,
         method="between_staypoints",
         gap_threshold=15,
-        print_progress=False,
     ):
         """
         Generate triplegs from positionfixes.
@@ -127,7 +126,6 @@ class Positionfixes(TrackintelBase, TrackintelGeoDataFrame, gpd.GeoDataFrame):
             staypoints=staypoints,
             method=method,
             gap_threshold=gap_threshold,
-            print_progress=print_progress,
         )
 
     def to_csv(self, filename, *args, **kwargs):

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -208,15 +208,11 @@ def generate_triplegs(
 
     Notes
     -----
-    Methods 'between_staypoints' requires either a column 'staypoint_id' on the
-    positionfixes or passing some staypoints that correspond to the positionfixes!
-    This means you usually should call ``generate_staypoints()`` first.
+    The methods require either a column 'staypoint_id' on the positionfixes or passing some staypoints that correspond to the positionfixes! This means you usually should call ``generate_staypoints()`` first.
 
-    The first positionfix after a staypoint is regarded as the first positionfix of the
-    generated tripleg. The generated tripleg will not have overlapping positionfix with
-    the existing staypoints. This means a small temporal gap in user's trace will occur
-    between the first positionfix of staypoint and the last positionfix of tripleg:
-    pfs_stp_first['tracked_at'] - pfs_tpl_last['tracked_at'].
+    Following the assumptions in the function generate_staypoints(), to ensure consistency, the time extend and geometry for triplegs is defined as follows:
+        - 'between_staypoints': The generated tripleg will not have overlapping positionfix with the existing staypoints, thus triplegs' 'geometry' does not have common pfs as sp. 'started_at' is the timestamp of the first pf after a sp, and 'finished_at' is the time of the last pf before a sp. This means a temporal gap will occur between the first positionfix of sp and the last pf of tripleg: pfs_stp_first['tracked_at'] - pfs_tpl_last['tracked_at'] != 0. No temporal gap will occur between sp ends and tripleg starts (as per sp time definition).
+        - 'overlap_staypoints': The generated tripleg will have common start and end positionfix with the existing staypoints, thus triplegs' 'geometry' have common start and end pfs as sp. 'started_at' is the timestamp of the first pf after a sp (same as 'between_staypoints', to be consistent with generate_staypoints()), and 'finished_at' is the time of the first pf of a following sp. Temporal gaps will not occur between sp and triplegs.
 
     Examples
     --------
@@ -288,7 +284,7 @@ def generate_triplegs(
 
     # condition 2: Temporal gaps
     # if there is a gap that is longer than gap_threshold minutes, we start a new tripleg
-    cond_gap = pfs["tracked_at"] - pfs["tracked_at"].shift(1) > datetime.timedelta(minutes=gap_threshold)
+    cond_temporal_gap = pfs["tracked_at"] - pfs["tracked_at"].shift(1) > datetime.timedelta(minutes=gap_threshold)
 
     # condition 3: staypoint
     # By our definition the pf after a stp is the first pf of a tpl.
@@ -302,7 +298,7 @@ def generate_triplegs(
         cond_stp = cond_stp | cond_staypoints_case2
 
     # combine conditions
-    cond_all = cond_new_user | cond_gap | cond_stp
+    cond_all = cond_new_user | cond_temporal_gap | cond_stp
     # make sure not to create triplegs within staypoints:
     cond_all = cond_all & pd.isna(pfs["staypoint_id"])
 
@@ -369,7 +365,7 @@ def generate_triplegs(
         tpls = tpls.set_geometry("geom")
         tpls.crs = pfs.crs
     elif method == "overlap_staypoints":
-        tpls = _generate_triplegs_overlap_staypoints(cond_gap, pfs, staypoints)
+        tpls, pfs = _generate_triplegs_overlap_staypoints(cond_temporal_gap, pfs, staypoints)
     else:
         raise ValueError(
             f"Method unknown. We only support 'between_staypoints' and 'overlap_staypoints'. You passed {method}"
@@ -395,12 +391,12 @@ def generate_triplegs(
     return pfs, Triplegs(tpls)
 
 
-def _generate_triplegs_overlap_staypoints(cond_gap, pfs, staypoints):
+def _generate_triplegs_overlap_staypoints(cond_temporal_gap, pfs, staypoints):
     """Connect staypoints with overlapping triplegs
 
     Parameters
     ----------
-    cond_gap : A boolean mask indicating gaps in the pfs data frame.
+    cond_temporal_gap : A boolean mask indicating gaps in the pfs data frame.
     pfs : Positionfixes
     staypoints : Staypoints
 
@@ -409,11 +405,13 @@ def _generate_triplegs_overlap_staypoints(cond_gap, pfs, staypoints):
     tpls: Triplegs
         tpls with geometries.
 
+    pfs: Positionfixes
+        original pfs with overlaping tripleg_id with staypoint_id.
+
     Notes
     -----
-    In case of a staypoint with only one positionfix the previous tripleg will have a spatial overlap with the
-    staypoint, while the following tripleg will not overlap with the staypoint. Otherwise, the positionfix of the
-    staypoints would need a duplication.
+    In case of a staypoint with only one positionfix, the previous tripleg will have a spatial overlap with the
+    staypoint, while the following tripleg will not overlap with the staypoint.
     """
     # keep initial ids from the between staypoints method
     between_tpls_ids = pfs["tripleg_id"].copy()
@@ -424,14 +422,16 @@ def _generate_triplegs_overlap_staypoints(cond_gap, pfs, staypoints):
     cond_overlap = ~(pfs["user_id"] != pfs["user_id"].shift(1)) & cond_not_tpl
 
     # temporal overlap: overlap tripleg end with start of next staypoint
-    cond_overlap_start = cond_overlap & ~cond_gap & pd.isna(pfs["tripleg_id"])
+    cond_overlap_start = cond_overlap & ~cond_temporal_gap & pd.isna(pfs["tripleg_id"])
     pfs.loc[cond_overlap_start, "tripleg_id"] = between_tpls_ids.shift(1)[cond_overlap_start]
+    # time: tpl's end pfs overlaps with sp, but tpl's start time is set as the time of the first pf after sp (see doctrting of generate_triplegs())
     tpls = pfs.groupby("tripleg_id").agg(
         user_id=("user_id", "first"), started_at=("tracked_at", "min"), finished_at=("tracked_at", "max")
     )
 
     # spatial overlap: overlap tripleg with the location of previous and next staypoint
-    cond_overlap_end = cond_overlap & ~cond_gap.shift(-1).fillna(False) & pd.isna(pfs["tripleg_id"])
+    # geometry: tpl's share common start and end pfs with sp
+    cond_overlap_end = cond_overlap & ~cond_temporal_gap.shift(-1).fillna(False) & pd.isna(pfs["tripleg_id"])
     pfs.loc[cond_overlap_end, "tripleg_id"] = between_tpls_ids.shift(-1)[cond_overlap_end]
     cond_empty = pd.isna(pfs["tripleg_id"])
     pfs.loc[cond_empty, "tripleg_id"] = between_tpls_ids[cond_empty]
@@ -448,7 +448,7 @@ def _generate_triplegs_overlap_staypoints(cond_gap, pfs, staypoints):
     tpls = tpls.set_geometry("geom")
     tpls.crs = pfs.crs
 
-    return tpls
+    return tpls, pfs
 
 
 def _generate_staypoints_sliding_user(

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -247,6 +247,11 @@ def generate_triplegs(
     # - step 2: Find first positionfix after a staypoint
     # (relevant if the pfs of sp are not provided, and we can only infer the pfs after sp through time)
     if not staypoints_exist:
+        warnings.warn(
+            "Providing positionfixes without a 'staypoint_id' column will no longer be supported in future releases, consider call generate_staypoints() first.",
+            DeprecationWarning,
+        )
+
         # initialize the index list of pfs where a tpl will begin
         insert_index_ls = []
         pfs["staypoint_id"] = pd.NA

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -192,9 +192,6 @@ def generate_triplegs(
         Maximum allowed temporal gap size in minutes. If tracking data is missing for more than
         `gap_threshold` minutes, a new tripleg will be generated.
 
-    print_progress: boolean, default False
-        Show the progress bar for assigning staypoints to positionfixes if set to True.
-
     Returns
     -------
     pfs: Positionfixes

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -188,8 +188,7 @@ def generate_triplegs(
     method: {'between_staypoints', 'overlap_staypoints'}
         Method to create triplegs. 'between_staypoints' method defines a tripleg as all positionfixes
         between two staypoints (no overlap). 'overlap_staypoints' method defines a tripleg as all positionfixes
-        between two staypoints and includes the coordinates of the staypoints. The methods require either a
-        column 'staypoint_id' on the positionfixes or passing staypoints as an input.
+        between two staypoints and includes the coordinates of the staypoints. The latter method require passing staypoints as an input.
 
     gap_threshold: float, default 15 (minutes)
         Maximum allowed temporal gap size in minutes. If tracking data is missing for more than
@@ -212,7 +211,7 @@ def generate_triplegs(
 
     Following the assumptions in the function generate_staypoints(), to ensure consistency, the time extend and geometry for triplegs is defined as follows:
         - 'between_staypoints': The generated tripleg will not have overlapping positionfix with the existing staypoints, thus triplegs' 'geometry' does not have common pfs as sp. 'started_at' is the timestamp of the first pf after a sp, and 'finished_at' is the time of the last pf before a sp. This means a temporal gap will occur between the first positionfix of sp and the last pf of tripleg: pfs_stp_first['tracked_at'] - pfs_tpl_last['tracked_at'] != 0. No temporal gap will occur between sp ends and tripleg starts (as per sp time definition).
-        - 'overlap_staypoints': The generated tripleg will have common start and end positionfix with the existing staypoints, thus triplegs' 'geometry' have common start and end pfs as sp. 'started_at' is the timestamp of the first pf after a sp (same as 'between_staypoints', to be consistent with generate_staypoints()), and 'finished_at' is the time of the first pf of a following sp. Temporal gaps will not occur between sp and triplegs.
+        - 'overlap_staypoints': The generated tripleg will have common start and end point geometries with the existing staypoints. 'started_at' is the timestamp of the first pf after a sp (same as 'between_staypoints', to be consistent with generate_staypoints()), and 'finished_at' is the time of the first pf of a following sp. Temporal gaps will not occur between sp and triplegs.
 
     Examples
     --------

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -231,10 +231,10 @@ def generate_triplegs(
     if staypoints is not None:
         Staypoints.validate(staypoints)
     if (staypoints is None) and (not staypoints_exist):
-        raise TypeError("staypoints input must be provide for pfs without staypoint_id column.")
+        raise TypeError("staypoints input must be provided for pfs without staypoint_id column.")
     if method == "overlap_staypoints":
         if staypoints is None:
-            raise TypeError("staypoints input must be provide for overlap_staypoints method.")
+            raise TypeError("staypoints input must be provided for overlap_staypoints method.")
         if not staypoints_exist:
             raise TypeError("positionfixes must contain a staypoint_id column for overlap_staypoints method.")
     if method not in ["between_staypoints", "overlap_staypoints"]:

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -436,15 +436,8 @@ def _generate_triplegs_overlap_staypoints(cond_temporal_gap, pfs, staypoints):
     cond_empty = pd.isna(pfs["tripleg_id"])
     pfs.loc[cond_empty, "tripleg_id"] = between_tpls_ids[cond_empty]
 
-    # replace geometry of staypoint positionfixes with staypoint geometry
-    pfs_copy = pfs[["tripleg_id", "staypoint_id", pfs.geometry.name]].copy()
-    if staypoints is not None:
-        pfs_copy.loc[cond_not_tpl, pfs_copy.geometry.name] = staypoints.loc[
-            pfs_copy.loc[cond_not_tpl, "staypoint_id"]
-        ].geometry.values
-
     # create and set tripleg geometries
-    tpls["geom"] = pfs_copy.groupby("tripleg_id")[pfs_copy.geometry.name].apply(lambda x: LineString(x))
+    tpls["geom"] = pfs.groupby("tripleg_id")[pfs.geometry.name].apply(lambda x: LineString(x))
     tpls = tpls.set_geometry("geom")
     tpls.crs = pfs.crs
 

--- a/trackintel/preprocessing/positionfixes.py
+++ b/trackintel/preprocessing/positionfixes.py
@@ -365,7 +365,7 @@ def generate_triplegs(
         tpls = tpls.set_geometry("geom")
         tpls.crs = pfs.crs
     elif method == "overlap_staypoints":
-        tpls, pfs = _generate_triplegs_overlap_staypoints(cond_temporal_gap, pfs, staypoints)
+        tpls, pfs = _generate_triplegs_overlap_staypoints(cond_temporal_gap, pfs)
     else:
         raise ValueError(
             f"Method unknown. We only support 'between_staypoints' and 'overlap_staypoints'. You passed {method}"
@@ -391,14 +391,13 @@ def generate_triplegs(
     return pfs, Triplegs(tpls)
 
 
-def _generate_triplegs_overlap_staypoints(cond_temporal_gap, pfs, staypoints):
+def _generate_triplegs_overlap_staypoints(cond_temporal_gap, pfs):
     """Connect staypoints with overlapping triplegs
 
     Parameters
     ----------
     cond_temporal_gap : A boolean mask indicating gaps in the pfs data frame.
     pfs : Positionfixes
-    staypoints : Staypoints
 
     Returns
     -------


### PR DESCRIPTION
Following #607, this PR does the following:

- Clean up tests for positionfix generation
- Adding docstring to explain triplegs' time and geometry generation
- Adding more tests, in particular `test_stability()`, to ensure consistency between two cases