### PR TITLE
Fix `ravel` deprecation warning for `Series`

### DIFF
--- a/tests/geogr/test_distances.py
+++ b/tests/geogr/test_distances.py
@@ -435,7 +435,7 @@ class TestSpeedPositionfixes:
             time_diff = (pfs.loc[ind, "tracked_at"] - pfs.loc[ind_prev, "tracked_at"]).total_seconds()
             point1 = pfs.loc[ind_prev, "geom"]
             point2 = pfs.loc[ind, "geom"]
-            dist = point_haversine_dist(point1.x, point1.y, point2.x, point2.y)[0]
+            dist = point_haversine_dist(point1.x, point1.y, point2.x, point2.y)
             assert np.isclose(dist / time_diff, computed_speeds[ind], rtol=1e-06)
             assert np.isclose(dist / time_diff, correct_speeds[ind], rtol=1e-06)
 

--- a/trackintel/geogr/distances.py
+++ b/trackintel/geogr/distances.py
@@ -67,10 +67,16 @@ def point_haversine_dist(lon_1, lat_1, lon_2, lat_2, r=6371000, float_flag=False
 
         return r * math.acos(cos_lat_d - cos_lat1 * cos_lat2 * (1 - cos_lon_d))
 
-    lon_1 = np.deg2rad(lon_1).ravel()
-    lat_1 = np.deg2rad(lat_1).ravel()
-    lon_2 = np.deg2rad(lon_2).ravel()
-    lat_2 = np.deg2rad(lat_2).ravel()
+    if all(isinstance(x, pd.Series) for x in [lon_1, lat_1, lon_2, lat_2]):
+        lon_1 = lon_1.to_numpy()
+        lat_1 = lat_1.to_numpy()
+        lon_2 = lon_2.to_numpy()
+        lat_2 = lat_2.to_numpy()
+
+    lon_1 = np.deg2rad(lon_1)
+    lat_1 = np.deg2rad(lat_1)
+    lon_2 = np.deg2rad(lon_2)
+    lat_2 = np.deg2rad(lat_2)
 
     cos_lat1 = np.cos(lat_1)
     cos_lat2 = np.cos(lat_2)


### PR DESCRIPTION
Fix deprecation warning by making cast to numpy array explicit.
Here pandas complained that `ravel()` is deprecated for Series.
And the only thing it does it inexplicity converting a Series to an array.