### PR TITLE
fix deprecation warning for `inplace`

### DIFF
--- a/tests/analysis/test_tracking_quality.py
+++ b/tests/analysis/test_tracking_quality.py
@@ -374,4 +374,4 @@ class TestGet_times:
         times = [time1, time2, time3, time4]
         result = (times[:-1], times[1:])
         row = pd.Series({"index": 0, "started_at": times[0], "finished_at": times[-1]})
-        assert _get_times(row, freq="H") == result
+        assert _get_times(row, freq="h") == result

--- a/trackintel/analysis/tracking_quality.py
+++ b/trackintel/analysis/tracking_quality.py
@@ -182,7 +182,7 @@ def _split_overlaps(source, granularity="day"):
     Trackintel class
         The input object after the splitting
     """
-    freq = "H" if granularity == "hour" else "D"
+    freq = "h" if granularity == "hour" else "D"
     gdf = source.copy()
     gdf[["started_at", "finished_at"]] = gdf.apply(_get_times, axis="columns", result_type="expand", freq=freq)
     # must call DataFrame.explode directly because GeoDataFrame.explode cannot be used on multiple columns

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -90,7 +90,7 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
     # temporary as empty trips are not filtered out yet.
     sp_tpls.loc[new_trip, "temp_trip_id"] = np.arange(new_trip.sum())
     # fill NA with previous entry
-    sp_tpls["temp_trip_id"]= sp_tpls["temp_trip_id"].ffill()
+    sp_tpls["temp_trip_id"] = sp_tpls["temp_trip_id"].ffill()
 
     # exclude activities to aggregate trips together.
     # activity can be thought of as the same aggregation level as trips.

--- a/trackintel/preprocessing/triplegs.py
+++ b/trackintel/preprocessing/triplegs.py
@@ -90,7 +90,7 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
     # temporary as empty trips are not filtered out yet.
     sp_tpls.loc[new_trip, "temp_trip_id"] = np.arange(new_trip.sum())
     # fill NA with previous entry
-    sp_tpls["temp_trip_id"].ffill(inplace=True)
+    sp_tpls["temp_trip_id"]= sp_tpls["temp_trip_id"].ffill()
 
     # exclude activities to aggregate trips together.
     # activity can be thought of as the same aggregation level as trips.
@@ -154,7 +154,7 @@ def generate_trips(staypoints, triplegs, gap_threshold=15, add_geometry=True):
     trips_with_act["next_trip_id"] = trips_with_act["trip_id"].shift(-1)
 
     # transform column to binary
-    trips_with_act["is_activity"].fillna(False, inplace=True)
+    trips_with_act["is_activity"] = trips_with_act["is_activity"].fillna(False)
     # delete activities
     trips = trips_with_act[~trips_with_act["is_activity"]].copy()
 
@@ -271,7 +271,7 @@ def _concat_staypoints_triplegs(staypoints, triplegs, add_geometry):
     sp_cols = ["started_at", "finished_at", "user_id", "type", "is_activity"]
     tpls_cols = ["started_at", "finished_at", "user_id", "type"]
     sp_tpls = pd.concat([sp[sp_cols], tpls[tpls_cols]])
-    sp_tpls["is_activity"].fillna(False, inplace=True)
+    sp_tpls["is_activity"] = sp_tpls["is_activity"].fillna(False)
     sp_tpls["sp_tpls_id"] = sp_tpls.index  # store id for later reassignment
     if add_geometry:
         # Check if crs is set. Warn if None


### PR DESCRIPTION
For pandas `3.0.0` they deprecate out many places where they do under the hood copying for `ìnplace` operations. One of these places is the modifying of views on dataframes. Further changed `H` to `h` in `_split_overlaps`