### PR TITLE
TST: fix inheritance class type error

### DIFF
--- a/trackintel/model/util.py
+++ b/trackintel/model/util.py
@@ -38,10 +38,9 @@ class TrackintelGeoDataFrame(GeoDataFrame):
     @property
     def _constructor(self):
         """Interface to subtype pandas properly"""
-        super_cons = super()._constructor
 
         def _constructor_with_fallback(*args, **kwargs):
-            result = super_cons(*args, **kwargs)
+            result = GeoDataFrame._geodataframe_constructor_with_fallback(*args, **kwargs)
             if isinstance(result, GeoDataFrame):
                 return self.__class__(result, validate=False)
             # uses DataFrame constructor -> must be DataFrame
@@ -53,7 +52,7 @@ class TrackintelGeoDataFrame(GeoDataFrame):
 
     def _constructor_from_mgr(self, mgr, axes):
         """Mirror GeoPandas _constructor_from_mgr method."""
-        return self._constructor(GeoDataFrame._constructor_from_mgr(self, mgr, axes))
+        return self._constructor(GeoDataFrame._constructor_from_mgr(GeoDataFrame, mgr, axes))
 
     # Following methods manually set self.__class__ fix to GeoDataFrame.
     # Thus to properly subtype, we need to downcast them with the _wrapped_gdf_method decorator.

--- a/trackintel/preprocessing/staypoints.py
+++ b/trackintel/preprocessing/staypoints.py
@@ -81,7 +81,7 @@ def generate_locations(
         raise ValueError(f"method '{method}' is unknown. Supported value is ['dbscan'].")
 
     # initialize the return GeoDataFrames
-    sp = staypoints.copy()
+    sp = gpd.GeoDataFrame(staypoints.copy())
     non_activities = None
     if activities_only:
         if "activity" not in sp.columns:


### PR DESCRIPTION
closes #644

The issue is raised due to a recent update in the GeoDataFrame function `_geodataframe_constructor_with_fallback()` (see [here](https://github.com/geopandas/geopandas/commit/dc66966bbdd24b20ba8b60bb4ca8dad3a1e7c84b#diff-2bf1533512765e9a8c8ca4992b8bc2828c4f5567d9a853f160f1dbd0ea473c20L54)), where instead of the hardcoded `GeoDataFrame` (line 54), a class instance `cls` is passed to the function and implicitly initialized (line 2026). This means we cannot pass `self`, but instead need to explicitly pass and call `GeoDataFrame` to prevent initializing a trackintel class. The latter will raise an error because the geometry link is only assigned at the very end of the `GeoDataFrame._constructor_from_mgr()` function (see [here](https://github.com/geopandas/geopandas/blob/c36eba059f6170715b63a9aa065817c64025d263/geopandas/geodataframe.py#L2056)). 

The PR also contains a minor fix to explicitly convert sp into GeoDataFrame before processing, otherwise the `validate` function will be called multiple times. 